### PR TITLE
add objectFit: cover to team photos

### DIFF
--- a/web-components/src/components/team-item/index.tsx
+++ b/web-components/src/components/team-item/index.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   img: {
+    objectFit: 'cover',
     position: 'absolute',
     width: theme.spacing(38.5),
     height: theme.spacing(37.75),


### PR DESCRIPTION
This will help non squared photos still look somewhat decent if they get uploaded, but I did go ahead and let Sara J know she should probably still stick to squared photos if she wants them to look best.