### PR TITLE
Change all launchInfoSection links to use same url format

### DIFF
--- a/web-www/content/mainnet/index.yaml
+++ b/web-www/content/mainnet/index.yaml
@@ -22,20 +22,18 @@ launchInfoSection:
           spending
     actionItems:
       - title: Validators
-        linkURL: ""
         linkText: Submit Gentx
         description: Participating in our validator set at genesis? Make sure you submit
           your GenTx by following this link!
         icon: ../../static/media/mainnet-validators.svg
         linkUrl: https://github.com/regen-network/mainnet/blob/main/regen-1/README.md
       - title: Community
-        linkURL: https://discord.com/invite/BDcBJu3
+        linkUrl: https://discord.com/invite/BDcBJu3
         linkText: Join Discord
         description: Find us on Discord! Join in the discussion as we launch the first
           Cosmos SDK blockchain for ecological regeneration.
         icon: ../../static/media/mainnet-magnifying-glass.svg
       - title: Token Holders
-        linkURL: ""
         linkText: View Block Explorer
         description: Are you a genesis token holder? Verify that your balance is correct
           by searching for your address into our prelaunch chain’s block

--- a/web-www/src/sections/mainnet/LaunchInfoSection.tsx
+++ b/web-www/src/sections/mainnet/LaunchInfoSection.tsx
@@ -128,7 +128,7 @@ type ActionItem = {
   title: string;
   description: string;
   linkText: string;
-  linkURL: string;
+  linkUrl: string;
   icon: {
     publicURL: string;
   };
@@ -187,7 +187,7 @@ const LaunchInfoSection: React.FC = () => {
             }
             actionItems {
               title
-              linkURL
+              linkUrl
               linkText
               description
               icon {
@@ -288,12 +288,12 @@ const ActionItem: React.FC<ActionItem> = p => {
       <div className={classes.btnWrap}>
         <ContainedButton
           className={classes.btn}
-          href={p.linkURL}
-          disabled={!p.linkURL}
+          href={p.linkUrl}
+          disabled={!p.linkUrl}
           target="_blank"
           rel="noopener noreferrer"
         >
-          {p.linkURL ? p.linkText : 'Coming Soon'}
+          {p.linkUrl ? p.linkText : 'Coming Soon'}
         </ContainedButton>
       </div>
     </div>


### PR DESCRIPTION
Fixes display of recently added URLs on the mainnet launch info page