### PR TITLE
Cavan longDescription typo fix

### DIFF
--- a/web-registry/src/mock.json
+++ b/web-registry/src/mock.json
@@ -465,7 +465,7 @@
         }
       },
       "shortDescription": "Cavan Station is a 9,900 hectare aggregation of properties divided by the Murrunbidgee River at Yass, on the southern tablelands of NSW. Cavan comprises a diverse range of landscapes including limestone rocky outcrops, undulating slopes and steep native vegetated hills.",
-      "longDescription": "The need to build adaptability and resilience into an iconic Merino enterprise has taken a traditional, large scale business on a successful change management journey, building economic, social, and ecological capital through 'enlightened stewardship' and a major rethink on how the business manages its land.Cavan Station is focused on the production of the highest-quality, humanely certified merino wool along with lamb and beef. Cavan is also home to the Bogo Merino Stud, producing premium Merino genetics.",
+      "longDescription": "The need to build adaptability and resilience into an iconic Merino enterprise has taken a traditional, large scale business on a successful change management journey, building economic, social, and ecological capital through 'enlightened stewardship' and a major rethink on how the business manages its land. Cavan Station is focused on the production of the highest-quality, humanely certified merino wool along with lamb and beef. Cavan is also home to the Bogo Merino Stud, producing premium Merino genetics.",
       "media": [
         {
           "src": "https://regen-registry.s3.amazonaws.com/projects/cavan-station/image1.png",


### PR DESCRIPTION
space after period - typo fix to make ReadMore work correctly in Cavan longDescription