### PR TITLE
Fix auth0 redirectUri

### DIFF
--- a/web-registry/src/components/Signup.tsx
+++ b/web-registry/src/components/Signup.tsx
@@ -76,7 +76,7 @@ export default function Signup(): JSX.Element {
       <LoginForm
         submit={submit}
         termsLink="/terms-service/"
-        loginFromSignup={() => loginWithRedirect({ redirectUri: '/user-profile' })}
+        loginFromSignup={() => loginWithRedirect({ redirectUri: `${window.location.origin}/user-profile` })}
         privacyLink="/privacy-policy/"
       />
     </OnBoardingSection>


### PR DESCRIPTION
Small fix to provide full url as auth0 redirectUri instead of only subpath (issue introduced by https://github.com/regen-network/regen-web/pull/611)