### PR TITLE
Remove excess padding in Overview section

### DIFF
--- a/web-registry/src/components/organisms/CreditClassOverviewSection.tsx
+++ b/web-registry/src/components/organisms/CreditClassOverviewSection.tsx
@@ -43,7 +43,6 @@ const useStyles = makeStyles(theme => ({
   },
   overview: {
     display: 'flex',
-    paddingTop: theme.spacing(8),
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
     },
@@ -58,6 +57,9 @@ const useStyles = makeStyles(theme => ({
       flexWrap: 'nowrap',
       overflow: 'scroll',
       marginLeft: theme.spacing(-4),
+      '&::-webkit-scrollbar': {
+        display: 'none',
+      },
     },
   },
   cardItem: {


### PR DESCRIPTION
related to: #689 

remove excess padding, hide scrollbar (credit class details page)