### PR TITLE
Figured out a stop-gap hack for the safari bug

### DIFF
--- a/web-components/src/components/header/HeaderLogoLink.tsx
+++ b/web-components/src/components/header/HeaderLogoLink.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import React, { useEffect, useState } from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import RegenIcon from '../icons/RegenIcon';
 
-const useStyles = makeStyles(theme => {
+const useStyles = makeStyles<Theme, { isLoaded: boolean }>(theme => {
   const { pxToRem } = theme.typography;
+
   return {
-    icon: {
+    icon: props => ({
+      display: props.isLoaded ? 'block' : 'inline-block',
       height: 'auto',
       width: pxToRem(186),
       [theme.breakpoints.down('sm')]: {
@@ -14,12 +16,23 @@ const useStyles = makeStyles(theme => {
       [theme.breakpoints.down('xs')]: {
         width: pxToRem(104),
       },
-    },
+    }),
   };
 });
 
 export const HeaderLogoLink: React.FC<{ color: string }> = ({ color }) => {
-  const styles = useStyles();
+  const [isLoaded, setIsLoaded] = useState(false);
+  const styles = useStyles({ isLoaded });
+  const location = window.location.href;
+
+  // TODO: this is a hack to make the SVG render properly in safari - it's not a
+  // perfect solution but should work until we can dedicate time to find
+  // something more long-term. You can see the bug by visiting the /community
+  // page in safari
+  useEffect(() => {
+    setIsLoaded(!isLoaded);
+  }, [location]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <a href="/">
       <RegenIcon className={styles.icon} color={color} />


### PR DESCRIPTION
This isn't a long-term fix, but seems to fix the bug in the immediate.

I noticed that by toggling the `display` property on the parent svg, the icon would render, so I made a hook that will toggle between `block` and `inline-block` on route change (both should render correctly).

Might be worth creating a ticket to look into this further, but it's really hard to figure out what's actually going on