### PR TITLE
Fix item key warning on project cards, both desktop and mobile

### DIFF
--- a/web-registry/src/components/organisms/ProjectCards.tsx
+++ b/web-registry/src/components/organisms/ProjectCards.tsx
@@ -94,29 +94,29 @@ const ProjectCards: React.FC<Props> = props => {
 
   return isMobile ? (
     <div className={styles.swipe}>
-      {props.projects.map((project, i) => (
-        <>
-          {project && (
+      {props.projects.map((project, i) => {
+        return (
+          project && (
             <Link className={styles.swipeItem} key={project.handle || i} href={`/projects/${project.handle}`}>
               <LinkedProject project={project} />
             </Link>
-          )}
-        </>
-      ))}
+          )
+        );
+      })}
     </div>
   ) : (
     <Grid container className={clsx(styles.root, props.classes && props.classes.root)} spacing={5}>
-      {props.projects.map((project, i) => (
-        <>
-          {project && (
+      {props.projects.map((project, i) => {
+        return (
+          project && (
             <Grid item sm={6} md={4} key={project.handle || i} className={styles.item}>
               <Link className={styles.projectCard} href={`/projects/${project.handle}`}>
                 <LinkedProject project={project} />
               </Link>
             </Grid>
-          )}
-        </>
-      ))}
+          )
+        );
+      })}
     </Grid>
   );
 };


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#792

Removes the React.Fragment that wraps each item in the project card list (ProjectCards.tsx), to expose the underlying item components with the key property.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles 
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)