### PR TITLE
Add missing TableRow component to the header of the credit batch table

### DIFF
--- a/web-registry/src/components/organisms/CreditBatches.tsx
+++ b/web-registry/src/components/organisms/CreditBatches.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableHead from '@material-ui/core/TableHead';
+import { Table, TableBody, TableHead, TableRow } from '@material-ui/core';
 import moment from 'moment';
 import cx from 'clsx';
 
@@ -142,23 +140,25 @@ const CreditBatches: React.FC = () => {
       <StyledTableContainer className={styles.tableBorder}>
         <Table aria-label="credit batch table" stickyHeader>
           <TableHead>
-            {headCells.map(headCell => (
-              <StyledTableCell
-                className={cx(headCell.wrap && styles.wrap)}
-                key={headCell.id}
-                align="left"
-                padding="default"
-                sortDirection={orderBy === headCell.id ? order : false}
-              >
-                <StyledTableSortLabel
-                  active={orderBy === headCell.id}
-                  direction={orderBy === headCell.id ? order : 'asc'}
-                  onClick={createSortHandler(headCell.id)}
+            <TableRow>
+              {headCells.map(headCell => (
+                <StyledTableCell
+                  className={cx(headCell.wrap && styles.wrap)}
+                  key={headCell.id}
+                  align="left"
+                  padding="default"
+                  sortDirection={orderBy === headCell.id ? order : false}
                 >
-                  {headCell.label}
-                </StyledTableSortLabel>
-              </StyledTableCell>
-            ))}
+                  <StyledTableSortLabel
+                    active={orderBy === headCell.id}
+                    direction={orderBy === headCell.id ? order : 'asc'}
+                    onClick={createSortHandler(headCell.id)}
+                  >
+                    {headCell.label}
+                  </StyledTableSortLabel>
+                </StyledTableCell>
+              ))}
+            </TableRow>
           </TableHead>
           <TableBody>
             {stableSort(batches, getComparator(order, orderBy)).map((batch: any) => {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#794

The header of the credit batch table is missing a row element (tr or TableRow) that wraps the cells (thead > tr > th)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles 
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)