### PR TITLE
Fix pagination component upgrade

### DIFF
--- a/web-components/src/components/table/TablePagination.tsx
+++ b/web-components/src/components/table/TablePagination.tsx
@@ -16,18 +16,18 @@ const useStylesAction = makeStyles(theme => ({
 
 const TablePaginationActions = (props: any): any => {
   const classes = useStylesAction();
-  const { count, page, rowsPerPage, onChangePage } = props;
+  const { count, page, rowsPerPage, onPageChange } = props;
 
   const handleBackButtonClick = (
     event: React.MouseEvent<HTMLDivElement>,
   ): void => {
-    onChangePage(event, page - 1);
+    onPageChange(event, page - 1);
   };
 
   const handleNextButtonClick = (
     event: React.MouseEvent<HTMLDivElement>,
   ): void => {
-    onChangePage(event, page + 1);
+    onPageChange(event, page + 1);
   };
 
   return (
@@ -102,7 +102,7 @@ export interface TablePaginationProps {
   count: number;
   rowsPerPage: number;
   page: number;
-  onChangePage: (event: unknown, newPage: number) => void;
+  onPageChange: (event: unknown, newPage: number) => void;
   onChangeRowsPerPage: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -113,7 +113,7 @@ export const TablePagination: React.FC<TablePaginationProps> = props => {
       count={props.count}
       rowsPerPage={props.rowsPerPage}
       page={props.page}
-      onPageChange={props.onChangePage}
+      onPageChange={props.onPageChange}
       onRowsPerPageChange={props.onChangeRowsPerPage}
       ActionsComponent={TablePaginationActions}
     />

--- a/web-components/src/components/table/table.stories.tsx
+++ b/web-components/src/components/table/table.stories.tsx
@@ -48,8 +48,8 @@ export const tablePagination = (): JSX.Element => (
           count={6}
           rowsPerPage={5}
           page={0}
-          onChangePage={(e, newPage) => {}}
-          onChangeRowsPerPage={e => {}}
+          onPageChange={(e, newPage) => { }}
+          onChangeRowsPerPage={e => { }}
         />
       </TableRow>
     </TableFooter>

--- a/web-components/src/components/table/useTablePagination.ts
+++ b/web-components/src/components/table/useTablePagination.ts
@@ -14,12 +14,15 @@ import { TablePagination, TablePaginationProps } from './TablePagination';
  * correspond when the page is changed, and a setter method to set the total
  * data in the source.
  */
-export function useTablePagination(rowsPerPageOptions: number[] = [5]): UseTablePaginationResult {
+export function useTablePagination(
+  rowsPerPageOptions: number[] = [5],
+): UseTablePaginationResult {
   const [page, setPage] = useState<number>(0);
   const [rowsPerPage, setRowsPerPage] = useState<number>(rowsPerPageOptions[0]);
   const [offset, setOffset] = useState<number>(0);
   const [countTotal, setCountTotal] = useState<number>(0);
-  const [paginationParams, setPaginationParams] = useState<URLSearchParams | null>(null);
+  const [paginationParams, setPaginationParams] =
+    useState<URLSearchParams | null>(null);
 
   const prepareParams = (rowsPerPage: number, offset: number): void => {
     const params = new URLSearchParams();
@@ -42,7 +45,9 @@ export function useTablePagination(rowsPerPageOptions: number[] = [5]): UseTable
     setPage(newPage);
   };
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
     setRowsPerPage(parseInt(event.target.value as string, 10));
     setOffset(0);
     setPage(0);
@@ -53,7 +58,7 @@ export function useTablePagination(rowsPerPageOptions: number[] = [5]): UseTable
     count: countTotal,
     rowsPerPage: rowsPerPage,
     page: page,
-    onChangePage: handleChangePage,
+    onPageChange: handleChangePage,
     onChangeRowsPerPage: handleChangeRowsPerPage,
   };
 


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#807

Upgrading to MUI v5 has broken the page change function in the component. Simply rename the method/prop to `onPageChange` in a couple of locations.

https://mui.com/guides/migration-v4/#tablepagination

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles 
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)