### PR TITLE
Updates usage of metadata-graph API

### DIFF
--- a/web-registry/src/lib/metadata-graph.ts
+++ b/web-registry/src/lib/metadata-graph.ts
@@ -1,12 +1,14 @@
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import getApiUri from './apiUri';
 
-export const getMetadata = async (hash: Uint8Array): Promise<AxiosResponse> => {
+export const getMetadata = async (hash: Uint8Array): Promise<any> => {
   if (hash) {
     // The on-chain metadata fields being stored as bytes for now, we need to decode it using base64 to get the corresponding IRI value as a string.
     // This won't be needed once the on-chain metadata fields are converted to string: https://github.com/regen-network/regen-ledger/issues/829
     const iri = atob(hash.toString());
-    return axios.get(`${getApiUri()}/metadata-graph/${iri}`);
+    const { data } = await axios.get(`${getApiUri()}/metadata-graph/${iri}`);
+
+    return data;
   }
-  return Promise.reject('No metadata hash provided');
+  throw new Error('No metadata hash provided');
 };

--- a/web-registry/src/pages/BatchDetails.tsx
+++ b/web-registry/src/pages/BatchDetails.tsx
@@ -41,8 +41,8 @@ export const BatchDetails: React.FC = () => {
           const batch = await getBatchWithSupplyForDenom(batchDenom);
           setBatch(batch);
           if (batch.metadata) {
-            const metadata = await getMetadata(batch.metadata);
-            setMetadata(metadata);
+            const data = await getMetadata(batch.metadata);
+            setMetadata(data);
           }
         } catch (err) {
           console.error(err); // eslint-disable-line no-console

--- a/web-registry/src/pages/BatchDetails.tsx
+++ b/web-registry/src/pages/BatchDetails.tsx
@@ -41,8 +41,8 @@ export const BatchDetails: React.FC = () => {
           const batch = await getBatchWithSupplyForDenom(batchDenom);
           setBatch(batch);
           if (batch.metadata) {
-            const { data } = await getMetadata(batch.metadata);
-            setMetadata(data.metadata);
+            const metadata = await getMetadata(batch.metadata);
+            setMetadata(metadata);
           }
         } catch (err) {
           console.error(err); // eslint-disable-line no-console

--- a/web-registry/src/pages/CreditClassDetails.tsx
+++ b/web-registry/src/pages/CreditClassDetails.tsx
@@ -48,21 +48,23 @@ function CreditClassDetail({ isLandSteward }: CreditDetailsProps): JSX.Element {
   });
 
   useEffect(() => {
-    if (creditClassId) {
-      queryEcoClassInfo(creditClassId)
-        .then(res => {
+    const fetch = async (): Promise<void> => {
+      if (creditClassId) {
+        try {
+          const res = await queryEcoClassInfo(creditClassId);
           const classInfo = res?.info;
           if (classInfo) {
             setLedgerClass(classInfo);
-            getMetadata(classInfo.metadata).then(res => {
-              if (res?.data?.metadata) {
-                setMetadata(res.data.metadata);
-              }
-            });
+            const metadata = await getMetadata(classInfo.metadata);
+            setMetadata(metadata);
           }
+        } catch (err) {
           // eslint-disable-next-line
-        }).catch(console.error);;
-    }
+          console.error(err);
+        }
+      }
+    };
+    fetch();
   }, [creditClassId]);
 
   const dbCreditClass = dbData?.creditClassByOnChainId;

--- a/web-registry/src/pages/CreditClassDetails.tsx
+++ b/web-registry/src/pages/CreditClassDetails.tsx
@@ -55,8 +55,8 @@ function CreditClassDetail({ isLandSteward }: CreditDetailsProps): JSX.Element {
           const classInfo = res?.info;
           if (classInfo) {
             setLedgerClass(classInfo);
-            const metadata = await getMetadata(classInfo.metadata);
-            setMetadata(metadata);
+            const data = await getMetadata(classInfo.metadata);
+            setMetadata(data);
           }
         } catch (err) {
           // eslint-disable-next-line


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/900

- The /metadata-graph API from the registry-server was previously
  returning the metadata in a wrapped JSON object. It was decided
  that we actually wanted a flat response. In other words, the API
  just returns the metadata now, rather than { metadata: metadata}

- This PR also modified CreditClassDetails to use the same type of
  async/await approach that BatchDetails was using. This improves
  the consistency of how we are interacting with getMetadata. It
  converted Promise.reject to a throw (again for async/await
  consistency)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles 
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)