### PR TITLE
Credit Class Metadata fix: Sectoral Scope and Offset Generation Methods

### DIFF
--- a/web-registry/src/generated/json-ld/credit-class-metadata.ts
+++ b/web-registry/src/generated/json-ld/credit-class-metadata.ts
@@ -1,0 +1,48 @@
+import { URL, TypeValue } from '../../types/rdf';
+
+// type generated from https://github.com/regen-network/regen-registry-standards/blob/main/jsonld/credit-classes/C01-verified-carbon-standard-class.json
+
+export interface CreditClassMetadataLD {
+  '@type': string;
+  '@context': Context;
+  'schema:url': URL;
+  'schema:name': string;
+  'schema:description': string;
+  'regen:sectoralScope': string[];
+  'regen:sourceRegistry': NameURL;
+  'regen:verificationMethod': string;
+  'regen:approvedMethodologies': ApprovedMethodologies;
+  'regen:offsetGenerationMethod': string[];
+}
+
+export interface ApprovedMethodologies {
+  '@type': 'schema:BreadcrumbList';
+  'schema:url': URL;
+  'schema:itemListElement': ItemListElement[];
+}
+
+interface ItemListElement {
+  '@type': string;
+  'schema:url': URL;
+  'schema:name': string;
+  'schema:version': TypeValue;
+  'schema:identifier': TypeValue;
+}
+
+interface NameURL {
+  'schema:url': URL;
+  'schema:name': string;
+}
+
+interface Context {
+  xsd: string;
+  regen: string;
+  schema: string;
+  'regen:sectoralScope': ContainerList;
+  'schema:itemListElement': ContainerList;
+  'regen:offsetGenerationMethod': ContainerList;
+}
+
+interface ContainerList {
+  '@container': '@list';
+}

--- a/web-registry/src/generated/json-ld/index.ts
+++ b/web-registry/src/generated/json-ld/index.ts
@@ -6,5 +6,6 @@
 // made for this purpose.
 
 export * from './batch-metadata';
+export * from './credit-class-metadata';
 export * from './project-metadata';
 export * from './vcs-project-metadata';

--- a/web-registry/src/pages/CreditClassDetailsSimple.tsx
+++ b/web-registry/src/pages/CreditClassDetailsSimple.tsx
@@ -13,13 +13,17 @@ import { EcocreditsSection, LineItemLabelAbove } from '../components/molecules';
 import { CreditBatches, MoreProjectsSection } from '../components/organisms';
 import { toTitleCase } from '../lib/titleCase';
 import { getAccountUrl } from '../lib/block-explorer';
-import { ClassInfo, ApprovedMethodologyList } from '../types/ledger/ecocredit';
+import { ClassInfo } from '../types/ledger/ecocredit';
 import { CreditClassByOnChainIdQuery } from '../generated/graphql';
+import {
+  CreditClassMetadataLD,
+  ApprovedMethodologies,
+} from '../generated/json-ld';
 
 interface CreditDetailsProps {
   dbClass: CreditClassByOnChainIdQuery['creditClassByOnChainId'];
   onChainClass: ClassInfo;
-  metadata?: any;
+  metadata?: CreditClassMetadataLD;
 }
 
 const useStyles = makeStyles<Theme>((theme: Theme) => ({
@@ -106,6 +110,10 @@ const CreditClassDetailsSimple: React.FC<CreditDetailsProps> = ({
   metadata,
 }) => {
   const styles = useStyles();
+  const offsetGenerationMethods = metadata?.['regen:offsetGenerationMethod'];
+  const sectoralScopes = metadata?.['regen:sectoralScope'];
+  const verificationMethod = metadata?.['regen:verificationMethod'];
+  const sourceRegistry = metadata?.['regen:sourceRegistry'];
 
   const Projects: React.FC = () => {
     const projects = dbClass?.projectsByCreditClassId?.nodes;
@@ -122,8 +130,10 @@ const CreditClassDetailsSimple: React.FC<CreditDetailsProps> = ({
   };
 
   const ApprovedMethodologies: React.FC<{
-    methodologyList: ApprovedMethodologyList;
+    methodologyList?: ApprovedMethodologies;
   }> = ({ methodologyList }) => {
+    if (!methodologyList) return null;
+
     const methodologies = methodologyList?.['schema:itemListElement'];
     const count = methodologies?.length;
     const firstMethodology = methodologies?.[0];
@@ -208,21 +218,17 @@ const CreditClassDetailsSimple: React.FC<CreditDetailsProps> = ({
                   </Body>
                 }
               />
-              {metadata?.['regen:sourceRegistry']?.['schema:name'] && (
+              {sourceRegistry?.['schema:name'] && (
                 <LineItemLabelAbove
                   label="registry"
                   data={
                     <Link
-                      href={
-                        metadata?.['regen:sourceRegistry']?.['schema:url']?.[
-                          '@value'
-                        ]
-                      }
+                      href={sourceRegistry?.['schema:url']?.['@value']}
                       target="_blank"
                     >
                       <Box sx={{ display: 'flex', alignItems: 'center' }}>
                         <Body size="xl" sx={{ mr: 1 }}>
-                          {metadata?.['regen:sourceRegistry']?.['schema:name']}
+                          {sourceRegistry?.['schema:name']}
                         </Body>
                         <SmallArrowIcon
                           sx={{ mt: '-2px' }}
@@ -236,34 +242,42 @@ const CreditClassDetailsSimple: React.FC<CreditDetailsProps> = ({
               <ApprovedMethodologies
                 methodologyList={metadata?.['regen:approvedMethodologies']}
               />
-              <LineItemLabelAbove
-                label="offset generation method"
-                data={metadata?.['regen:offsetGenerationMethod']?.[
-                  'schema:itemListElement'
-                ]?.map((method: string) => (
-                  <Body size="xl" key={method}>
-                    {toTitleCase(method)}
-                  </Body>
-                ))}
-              />
-              <LineItemLabelAbove
-                label="verification method"
-                data={
-                  <Body size="xl" sx={{ mr: 1 }}>
-                    {toTitleCase(metadata?.['regen:verificationMethod'])}
-                  </Body>
-                }
-              />
-              <LineItemLabelAbove
-                label="sectoral scope"
-                data={metadata?.['regen:sectoralScope']?.[
-                  'schema:itemListElement'
-                ]?.map((sector: string) => (
-                  <Body size="xl" key={sector}>
-                    {sector}
-                  </Body>
-                ))}
-              />
+              {offsetGenerationMethods && offsetGenerationMethods?.length > 0 && (
+                <LineItemLabelAbove
+                  label={`offset generation method${
+                    offsetGenerationMethods.length > 1 ? 's' : ''
+                  }`}
+                  data={
+                    <>
+                      {offsetGenerationMethods.map((method: string) => (
+                        <Body size="xl">{toTitleCase(method)}</Body>
+                      ))}
+                    </>
+                  }
+                />
+              )}
+              {verificationMethod && (
+                <LineItemLabelAbove
+                  label="verification method"
+                  data={
+                    <Body size="xl">{toTitleCase(verificationMethod)}</Body>
+                  }
+                />
+              )}
+              {sectoralScopes && sectoralScopes?.length > 0 && (
+                <LineItemLabelAbove
+                  label={`sectoral scope${
+                    sectoralScopes.length > 1 ? 's' : ''
+                  }`}
+                  data={
+                    <>
+                      {sectoralScopes.map((sector: string) => (
+                        <Body size="xl">{sector}</Body>
+                      ))}
+                    </>
+                  }
+                />
+              )}
             </Box>
           </Box>
           <Box

--- a/web-registry/src/types/ledger/ecocredit.ts
+++ b/web-registry/src/types/ledger/ecocredit.ts
@@ -92,22 +92,3 @@ export interface QueryClassesResponse {
   classes: ClassInfo[];
   pagination?: PageResponse;
 }
-
-// TODO: pull these types from credit-class shacl schema
-export interface ApprovedMethodologyList {
-  '@type': 'schema:BreadcrumbList';
-  'schema:itemListElement': ApprovedMethodology[];
-  'schema:url': {
-    '@type': string;
-    '@value': string;
-  };
-}
-
-interface ApprovedMethodology {
-  '@type': 'regen:Methodology';
-  'schema:name': string;
-  'schema:url': {
-    '@type': string;
-    '@value': string;
-  };
-}


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#878

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

- Fixes missing metadata fields _Sectoral Scope_ and _Offset Generation Methods_
- Adds TS support for credit-class-metadata, derived from https://github.com/regen-network/regen-registry-standards/blob/main/jsonld/credit-classes/C01-verified-carbon-standard-class.json


https://deploy-preview-917--regen-registry.netlify.app/credit-classes/C01

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles 
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)