### PR TITLE
feat: add project ledger query

### DIFF
--- a/web-registry/src/hooks/useEcocreditQuery.ts
+++ b/web-registry/src/hooks/useEcocreditQuery.ts
@@ -18,6 +18,7 @@ import {
   queryCreditTypes,
   queryProjects,
   queryProjectsByAdmin,
+  queryProject,
 } from '../lib/ecocredit/api';
 
 // TODO - this hook is still missing batch query functionality
@@ -87,6 +88,11 @@ export default function useEcocreditQuery<T extends EcocreditQueryResponse>({
     [],
   );
 
+  const project = useCallback(
+    (client, params) => queryProject({ client, request: params }),
+    [],
+  );
+
   useEffect(() => {
     if (!client) return;
     if (!params) return;
@@ -120,6 +126,9 @@ export default function useEcocreditQuery<T extends EcocreditQueryResponse>({
       case 'projectsByAdmin':
         response = projectsByAdmin(client, params);
         break;
+      case 'project':
+        response = project(client, params);
+        break;
       default:
         setError(
           new Error(
@@ -151,6 +160,7 @@ export default function useEcocreditQuery<T extends EcocreditQueryResponse>({
     creditTypes,
     projects,
     projectsByAdmin,
+    project,
   ]);
 
   return { data, loading, error };

--- a/web-registry/src/lib/ecocredit/api.ts
+++ b/web-registry/src/lib/ecocredit/api.ts
@@ -23,6 +23,8 @@ import {
   QueryProjectsByClassResponse,
   QueryProjectsByAdminRequest,
   QueryProjectsByAdminResponse,
+  QueryProjectRequest,
+  QueryProjectResponse,
 } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 import { TxResponse } from '@regen-network/api/lib/generated/cosmos/base/abci/v1beta1/abci';
 import {
@@ -381,6 +383,11 @@ type ProjectsByAdminParams = {
   params: DeepPartial<QueryProjectsByAdminRequest>;
 };
 
+type ProjectParams = {
+  query: 'project';
+  params: DeepPartial<QueryProjectRequest>;
+};
+
 export type EcocreditQueryProps =
   | BalanceParams
   | BatchInfoParams
@@ -389,7 +396,8 @@ export type EcocreditQueryProps =
   | ClassesParams
   | CreditTypesParams
   | ProjectsParams
-  | ProjectsByAdminParams;
+  | ProjectsByAdminParams
+  | ProjectParams;
 
 // typing the response
 
@@ -401,7 +409,8 @@ export type EcocreditQueryResponse =
   | QueryClassesResponse
   | QueryCreditTypesResponse
   | QueryProjectsResponse
-  | QueryProjectsByAdminResponse;
+  | QueryProjectsByAdminResponse
+  | QueryProjectResponse;
 
 /**
  *
@@ -565,7 +574,26 @@ export const queryProjectsByAdmin = async ({
     return await client.ProjectsByAdmin(request);
   } catch (err) {
     throw new Error(
-      `Error in the Projects query of the ledger ecocredit module: ${err}`,
+      `Error in the ProjectsByAdmin query of the ledger ecocredit module: ${err}`,
+    );
+  }
+};
+
+// Project (by id)
+
+interface QueryProjectProps extends EcocreditQueryClientProps {
+  request: DeepPartial<QueryProjectRequest>;
+}
+
+export const queryProject = async ({
+  client,
+  request,
+}: QueryProjectProps): Promise<QueryProjectResponse> => {
+  try {
+    return await client.Project(request);
+  } catch (err) {
+    throw new Error(
+      `Error in the Project query of the ledger ecocredit module: ${err}`,
     );
   }
 };


### PR DESCRIPTION
## Description

Just adds the query of a project to the ledger, since it is being requested in a couple of tasks, it is advanced independently

In order to do:
```
const { data: project } = useEcocreditQuery({
    query: 'project',
    params: { projectId: 'C02-002' },
});
```
---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
