### PR TITLE
feat: set sideEffects for package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "regen-web",
   "private": true,
   "description": "Regen Website",
+  "sideEffects": false,
   "homepage": "https://github.com/regen-network/regen-web",
   "bugs": {
     "url": "https://github.com/regen-network/regen-web/issues"

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "main": "build/index.js",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "scripts": {
     "remove-previous-files": "shx rm -rf ./lib/* ./tsconfig.tsbuildinfo",
     "copy-assets": "cp ./src/theme/fonts.css ./lib/theme/fonts.css && cp -R ./src/theme/assets ./lib/theme/",

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "main": "build/index.js",
-  "sideEffects": [
-    "**/*.css"
-  ],
+  "sideEffects": false,
   "scripts": {
     "remove-previous-files": "shx rm -rf ./lib/* ./tsconfig.tsbuildinfo",
     "copy-assets": "cp ./src/theme/fonts.css ./lib/theme/fonts.css && cp -R ./src/theme/assets ./lib/theme/",

--- a/web-registry/package.json
+++ b/web-registry/package.json
@@ -2,6 +2,9 @@
   "name": "web-registry",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "dependencies": {
     "@apollo/client": "^3.4.17",
     "@auth0/auth0-react": "^1.8.0",

--- a/web-registry/package.json
+++ b/web-registry/package.json
@@ -2,9 +2,7 @@
   "name": "web-registry",
   "version": "0.0.0",
   "private": true,
-  "sideEffects": [
-    "**/*.css"
-  ],
+  "sideEffects": false,
   "dependencies": {
     "@apollo/client": "^3.4.17",
     "@auth0/auth0-react": "^1.8.0",

--- a/web-registry/src/index.tsx
+++ b/web-registry/src/index.tsx
@@ -44,7 +44,7 @@ ReactDOM.render(
     cacheLocation="localstorage"
   >
     <AuthApolloProvider>
-      <IntercomProvider appId={intercomId} autoBoot>
+      <IntercomProvider appId={intercomId} initializeDelay={500}>
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <WalletProvider>
             <LedgerProvider>

--- a/web-www/gatsby-browser.js
+++ b/web-www/gatsby-browser.js
@@ -14,7 +14,7 @@ exports.onClientEntry = () => {
 // Wraps every page in a component
 exports.wrapPageElement = ({ element }) => {
   return (
-    <IntercomProvider appId={intercomAppId} autoBoot>
+    <IntercomProvider appId={intercomAppId} initializeDelay={500}>
       {element}
     </IntercomProvider>
   );

--- a/web-www/gatsby-ssr.js
+++ b/web-www/gatsby-ssr.js
@@ -7,7 +7,7 @@ const intercomAppId = process.env.GATSBY_INTERCOM_APP_ID || '';
 // // Wraps every page in a component
 export const wrapPageElement = ({ element }) => {
   return (
-    <IntercomProvider appId={intercomAppId} autoBoot>
+    <IntercomProvider appId={intercomAppId} initializeDelay={500}>
       {element}
     </IntercomProvider>
   );

--- a/web-www/package.json
+++ b/web-www/package.json
@@ -2,6 +2,9 @@
   "name": "web-www",
   "private": true,
   "version": "0.0.1",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "dependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",

--- a/web-www/package.json
+++ b/web-www/package.json
@@ -2,9 +2,7 @@
   "name": "web-www",
   "private": true,
   "version": "0.0.1",
-  "sideEffects": [
-    "**/*.css"
-  ],
+  "sideEffects": false,
   "dependencies": {
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
## Description

Apparently part of why barrel files don't function well in webpack4 is because of `sideEffects`. Manually configuring them produces a smaller bundle:

Registry before:
![image](https://user-images.githubusercontent.com/9052511/181414907-755f2d32-6e98-43ff-ac74-405d9371135d.png)

Registry now:
<img width="690" alt="CleanShot 2022-07-28 at 00 18 43@2x" src="https://user-images.githubusercontent.com/9052511/181434397-53be41e8-3d84-4a79-baa3-856e96b84bef.png">

Only about -200K, but didn't take much effort and every bit counts

Also, a big portion of the largest file seems to be coming from [libsodium](https://doc.libsodium.org) - a dependency of cosmjs. So if we could somehow lazy-load our cosmjs functions, it might help perf: 

<img width="1733" alt="CleanShot 2022-07-27 at 21 37 23@2x" src="https://user-images.githubusercontent.com/9052511/181415231-a3ce271e-9be0-48b8-9e66-402344636be7.png">

Registry deploy preview before:

<img width="614" alt="CleanShot 2022-07-27 at 23 07 44@2x" src="https://user-images.githubusercontent.com/9052511/181425139-5d5469aa-ec0d-4fa4-9752-988a149a3548.png">


After:
<img width="610" alt="CleanShot 2022-07-28 at 00 08 39@2x" src="https://user-images.githubusercontent.com/9052511/181432812-536e7870-88c1-4907-b1f8-b87395077b7a.png">

Marketing before:
<img width="602" alt="CleanShot 2022-07-28 at 00 14 49@2x" src="https://user-images.githubusercontent.com/9052511/181433771-dfc8bc87-08fb-4fcf-8fda-413271f1f818.png">

after:

<img width="599" alt="CleanShot 2022-07-28 at 00 14 14@2x" src="https://user-images.githubusercontent.com/9052511/181433702-88da0a31-513a-48d8-998f-f659b45ea1e2.png">


Not a great improvement, but better than nothing

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
