### PR TITLE
chore: remove tsc from linting

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -8,8 +8,8 @@
     "copy-assets": "cp ./src/theme/fonts.css ./lib/theme/fonts.css && cp -R ./src/theme/assets ./lib/theme/",
     "watch": "yarn remove-previous-files && tsc --watch && yarn copy-assets",
     "build": "yarn remove-previous-files && tsc && yarn copy-assets",
-    "lint": "tsc --noEmit && eslint ./src  -c .eslintrc.js --max-warnings 0 --ext .ts,.tsx",
-    "lint-fix": "tsc --noEmit && eslint ./src --fix -c .eslintrc.js --ext .ts,.tsx",
+    "lint": "eslint ./src  -c .eslintrc.js --max-warnings 0 --ext .ts,.tsx",
+    "lint-fix": "eslint ./src --fix -c .eslintrc.js --ext .ts,.tsx",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
     "format-and-fix": "yarn format && yarn lint-fix"
   },

--- a/web-registry/package.json
+++ b/web-registry/package.json
@@ -48,8 +48,8 @@
     "web-components": "0.0.0"
   },
   "scripts": {
-    "lint": "tsc --noEmit && eslint ./src  -c .eslintrc.js --max-warnings 0 --ext .ts,.tsx",
-    "lint-fix": "tsc --noEmit && eslint ./src --fix -c .eslintrc.js --ext .ts,.tsx",
+    "lint": "eslint ./src  -c .eslintrc.js --max-warnings 0 --ext .ts,.tsx",
+    "lint-fix": "eslint ./src --fix -c .eslintrc.js --ext .ts,.tsx",
     "format": "prettier --write --loglevel warn './src/**/*.{ts,tsx,json,md,css}'",
     "format-and-fix": "yarn format && yarn lint-fix",
     "start": "react-scripts start",


### PR DESCRIPTION
## Description

Removes the `tsc` ran before linting - shouldn’t be necesary, as we’re only linting `ts` and `tsx` file types. Should speed up the time it takes to run the command

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
