### PR TITLE
Fix 1083 allow zero tradable amount when retirement

### DIFF
--- a/web-components/src/components/form/CreditSendForm.tsx
+++ b/web-components/src/components/form/CreditSendForm.tsx
@@ -92,14 +92,25 @@ const CreditSendForm: React.FC<FormProps> = ({
       errors.recipient = requiredMessage;
     }
 
-    const errAmount = validateAmount(
-      availableTradableAmount,
-      values.tradableAmount,
-    );
-    if (errAmount) errors.tradableAmount = errAmount;
+    if (!values.withRetire) {
+      const errAmount = validateAmount(
+        availableTradableAmount,
+        values.tradableAmount,
+      );
+      if (errAmount) errors.tradableAmount = errAmount;
+    }
 
     // Retire form validation (optional subform)
     if (values.withRetire) {
+      // also check tradable amount because with retirement is allowed to be zero
+      const errAmount = validateAmount(
+        availableTradableAmount,
+        values.tradableAmount,
+        undefined,
+        true, //zero allowed
+      );
+      if (errAmount) errors.tradableAmount = errAmount;
+
       errors = validateCreditRetire(availableTradableAmount, values, errors);
 
       // combo validation: send + retire

--- a/web-components/src/components/form/RecipientsForm.tsx
+++ b/web-components/src/components/form/RecipientsForm.tsx
@@ -63,15 +63,23 @@ export function getValidationSchemaFields(addressPrefix: string): ReturnType {
                 : false,
             ),
           tradableAmount: Yup.number()
-            .required(invalidAmount)
+            .required(requiredMessage)
             .positive()
             .integer()
-            .min(1, invalidAmount),
+            .min(1, invalidAmount)
+            .when('withRetire', {
+              is: true,
+              then: Yup.number()
+                .required(requiredMessage)
+                .positive()
+                .integer()
+                .min(0, invalidAmount),
+            }),
           withRetire: Yup.boolean().required(),
           retiredAmount: Yup.number().when('withRetire', {
             is: true,
             then: Yup.number()
-              .required()
+              .required(requiredMessage)
               .positive()
               .integer()
               .min(1, invalidAmount),

--- a/web-components/src/components/inputs/validation.ts
+++ b/web-components/src/components/inputs/validation.ts
@@ -46,7 +46,10 @@ export function validateAmount(
   availableTradableAmount: number,
   amount?: number,
   customInsufficientCredits?: string,
+  zeroAllowed?: boolean,
 ): string | undefined {
+  if (zeroAllowed && (amount === 0 || (amount && Math.sign(amount) === 0)))
+    return;
   if (!amount) {
     return requiredMessage;
   } else if (Math.sign(amount) !== 1) {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1083

The validation for `amountTradable` is updated to allow it to be zero when doing a retirement in the `send` and `create batch` cases.

Each of these cases has a different implementation. 
* In one case (`send form`) a `validateAmount` util function has been updated (to optionally allow the value zero as valid)
* in the other case (`create batch form`) the validation rules of the corresponding `YUP` object have been updated.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
