### PR TITLE
chore: add terms of service to cookie banner

### DIFF
--- a/web-components/src/components/banner/CookiesBanner.tsx
+++ b/web-components/src/components/banner/CookiesBanner.tsx
@@ -11,6 +11,7 @@ import { Body } from '../typography';
 
 interface CookiesBannerProps {
   privacyUrl: string;
+  TOSUrl: string;
 }
 
 const rejectCookieName: string = 'cookies-rejected';
@@ -45,6 +46,7 @@ function setCookie(name: string, cookieValue: string): void {
 
 export default function CookiesBanner({
   privacyUrl,
+  TOSUrl,
 }: CookiesBannerProps): JSX.Element | null {
   const [visible, setVisible] = useState(false);
 
@@ -106,6 +108,10 @@ export default function CookiesBanner({
               using this site, you accept our use of{' '}
               <Link href={privacyUrl} color="secondary.main">
                 cookies policy
+              </Link>
+              {' '}and agree to our{' '}
+              <Link href={TOSUrl} color="secondary.main">
+                platform terms of service
               </Link>
               .
             </Body>

--- a/web-registry/src/App.tsx
+++ b/web-registry/src/App.tsx
@@ -282,7 +282,10 @@ const App: React.FC = (): JSX.Element => {
             <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </Suspense>
-        <CookiesBanner privacyUrl="https://www.regen.network/privacy-policy/" />
+        <CookiesBanner
+          privacyUrl="https://www.regen.network/privacy-policy/"
+          TOSUrl="https://www.regen.network/terms-service/"
+        />
         <footer>
           <AppFooter />
         </footer>


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/regen-registry/issues/1146

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
