### PR TITLE
feat: remove expiration column and sort by id

### DIFF
--- a/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.Row.tsx
+++ b/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.Row.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactHtmlParser from 'react-html-parser';
 import { Box } from '@mui/material';
-import dayjs from 'dayjs';
 
 import { RegenTokenIcon } from 'web-components/lib/components/icons/RegenTokenIcon';
 import { formatDate, formatNumber } from 'web-components/lib/utils/format';
@@ -27,14 +26,12 @@ const getSellOrdersTableRow = ({
     id,
     amountAvailable,
     seller,
-    expiration,
     batchStartDate,
     batchEndDate,
     project,
   },
 }: Props): React.ReactNode[] => [
   <Link href={`/marketplace/sell-order/${id}`}>{id}</Link>,
-  <Box sx={{ color: 'info.main' }}>{dayjs(expiration).fromNow()}</Box>,
   <WithLoader isLoading={project?.name === undefined} variant="skeleton">
     <Link href={`/projects/${project?.id}}`}>{project?.name}</Link>
   </WithLoader>,

--- a/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.config.tsx
+++ b/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.config.tsx
@@ -1,17 +1,15 @@
-import React from 'react';
 import { Box } from '@mui/material';
 
 export const SELL_ORDERS_ROW = [
-  <Box sx={{ width: '64px', whiteSpace: 'normal' }}>{'SELL ORDER ID'}</Box>, // ok
-  <Box sx={{ width: '70px', whiteSpace: 'normal' }}>{'EXPIRY DATE'}</Box>, // ok
-  'PROJECT', // fatch batch + metadata batch + useProjectsByMetadataQuery
+  <Box sx={{ width: '64px', whiteSpace: 'normal' }}>{'SELL ORDER ID'}</Box>,
+  'PROJECT',
   <Box sx={{ width: '86px', whiteSpace: 'normal' }}>
     {'ASK PRICE PER CREDIT'}
   </Box>,
-  <Box sx={{ width: '70px', whiteSpace: 'normal' }}>{'AMOUNT AVAILABLE'}</Box>, // ok
-  <Box sx={{ width: '70px', whiteSpace: 'normal' }}>{'CREDIT CLASS'}</Box>, // fetch batch
-  <Box sx={{ width: '74px', whiteSpace: 'normal' }}>{'BATCH DENOM'}</Box>, // ok
-  <Box sx={{ width: '84px', whiteSpace: 'normal' }}>{'BATCH START DATE'}</Box>, // fetch batch
-  <Box sx={{ width: '72px', whiteSpace: 'normal' }}>{'BATCH END DATE'}</Box>, // fetch batch
-  'SELLER', // ok
+  <Box sx={{ width: '70px', whiteSpace: 'normal' }}>{'AMOUNT AVAILABLE'}</Box>,
+  <Box sx={{ width: '70px', whiteSpace: 'normal' }}>{'CREDIT CLASS'}</Box>,
+  <Box sx={{ width: '74px', whiteSpace: 'normal' }}>{'BATCH DENOM'}</Box>,
+  <Box sx={{ width: '84px', whiteSpace: 'normal' }}>{'BATCH START DATE'}</Box>,
+  <Box sx={{ width: '72px', whiteSpace: 'normal' }}>{'BATCH END DATE'}</Box>,
+  'SELLER',
 ];

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
@@ -49,7 +49,7 @@ import {
 import { SellOrderActions } from './Storefront.types';
 import {
   getCancelCardItems,
-  sortByExpirationDate,
+  sortBySellOrderId,
   updateBatchInfosMap,
 } from './Storefront.utils';
 
@@ -119,7 +119,7 @@ export const Storefront = (): JSX.Element => {
         batchInfos,
         sellOrders,
         projectsInfosByHandleMap,
-      }).sort(sortByExpirationDate),
+      }).sort(sortBySellOrderId),
     [batchInfos, sellOrders, projectsInfosByHandleMap],
   );
 

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
@@ -7,12 +7,12 @@ import { Item } from 'web-components/lib/components/modal/ConfirmModal';
 
 import { NormalizedSellOrder } from './Storefront.types';
 
-export const sortByExpirationDate = (
+export const sortBySellOrderId = (
   sellOrderA: NormalizedSellOrder,
   sellOrderB: NormalizedSellOrder,
 ): number => {
-  if (sellOrderA.expiration && sellOrderB.expiration) {
-    return sellOrderA.expiration > sellOrderB.expiration ? -1 : 1;
+  if (sellOrderA.id && sellOrderB.id) {
+    return Number(sellOrderA.id) > Number(sellOrderB.id) ? 1 : -1;
   }
 
   return 0;


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1167

- remove the expiration column (our sell orders don't have any currently)
- sort sell orders by id

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Go to https://deploy-preview-1187--regen-registry.netlify.app/storefront

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
