### PR TITLE
fix: add v1alpha1 ecocredit messages to Activity tx query

### DIFF
--- a/web-registry/src/lib/ecocredit/api.ts
+++ b/web-registry/src/lib/ecocredit/api.ts
@@ -165,10 +165,17 @@ export const getEcocreditTxs = async (): Promise<TxResponse[]> => {
   // we must send separate requests for each message action type:
   return Promise.all(
     Object.values(ECOCREDIT_MESSAGE_TYPES).map(async msgType => {
-      const response = await getTxsByEvent({
-        events: [`${messageActionEquals}'${msgType.message}'`],
-      });
-      allTxs = [...allTxs, ...response.txResponses];
+      try {
+        const response = await getTxsByEvent({
+          events: [`${messageActionEquals}'${msgType.message}'`],
+        });
+        if (response?.txResponses) {
+          allTxs = [...allTxs, ...response.txResponses];
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      }
     }),
   ).then(() => {
     return allTxs;

--- a/web-registry/src/lib/ecocredit/constants.ts
+++ b/web-registry/src/lib/ecocredit/constants.ts
@@ -20,14 +20,24 @@ import {
   MsgUpdateClassIssuers,
   MsgUpdateClassMetadata,
 } from '@regen-network/api/lib/generated/regen/ecocredit/v1/tx';
+import {
+  MsgCancel as MsgCancelAlpha,
+  MsgCreateBatch as MsgCreateBatchAlpha,
+  MsgCreateClass as MsgCreateClassAlpha,
+  MsgRetire as MsgRetireAlpha,
+  MsgSend as MsgSendAlpha,
+  MsgUpdateClassAdmin as MsgUpdateClassAdminAlpha,
+  MsgUpdateClassIssuers as MsgUpdateClassIssuersAlpha,
+  MsgUpdateClassMetadata as MsgUpdateClassMetadataAlpha,
+} from '@regen-network/api/lib/generated/regen/ecocredit/v1alpha1/tx';
 
 export const messageActionEquals = 'message.action=';
 
 /* An allowlist of event and/or message types we query for in Activity table */
 export const ECOCREDIT_MESSAGE_TYPES = {
-  SEND: {
-    message: `/${MsgSend.$type}`,
-    readable: 'send',
+  CANCEL: {
+    message: `/${MsgCancel.$type}`,
+    readable: 'cancel',
   },
   CREATE_BATCH: {
     message: `/${MsgCreateBatch.$type}`,
@@ -41,9 +51,9 @@ export const ECOCREDIT_MESSAGE_TYPES = {
     message: `/${MsgRetire.$type}`,
     readable: 'retire',
   },
-  CANCEL: {
-    message: `/${MsgCancel.$type}`,
-    readable: 'cancel',
+  SEND: {
+    message: `/${MsgSend.$type}`,
+    readable: 'send',
   },
   UPDATE_CLASS_ADMIN: {
     message: `/${MsgUpdateClassAdmin.$type}`,
@@ -55,6 +65,38 @@ export const ECOCREDIT_MESSAGE_TYPES = {
   },
   UPDATE_CLASS_META: {
     message: `/${MsgUpdateClassMetadata.$type}`,
+    readable: 'update class metadata',
+  },
+  CANCEL_ALPHA: {
+    message: `/${MsgCancelAlpha.$type}`,
+    readable: 'cancel',
+  },
+  CREATE_BATCH_ALPHA: {
+    message: `/${MsgCreateBatchAlpha.$type}`,
+    readable: 'create batch',
+  },
+  CREATE_CLASS_ALPHA: {
+    message: `/${MsgCreateClassAlpha.$type}`,
+    readable: 'create class',
+  },
+  RETIRE_ALPHA: {
+    message: `/${MsgRetireAlpha.$type}`,
+    readable: 'retire',
+  },
+  SEND_ALPHA: {
+    message: `/${MsgSendAlpha.$type}`,
+    readable: 'send',
+  },
+  UPDATE_CLASS_ADMIN_ALPHA: {
+    message: `/${MsgUpdateClassAdminAlpha.$type}`,
+    readable: 'update class admin',
+  },
+  UPDATE_CLASS_ISSUERS_ALPHA: {
+    message: `/${MsgUpdateClassIssuersAlpha.$type}`,
+    readable: 'update class issuers',
+  },
+  UPDATE_CLASS_META_ALPHA: {
+    message: `/${MsgUpdateClassMetadataAlpha.$type}`,
     readable: 'update class metadata',
   },
   CREATE_BASKET: {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1123

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

- Adds `v1alpha1` ecocredit message types to TX query for Activity table
- This restores historical activity in PROD
    - the associated ledger patch is not in Redwood yet, so the deploy preview will not show the pre-upgrade activity
    - This screenshot is of my localhost, pointed at mainnet. You can see the activity from 3 months ago in addition to the recent "CREATE CLASS"

<img width="1331" alt="Screen Shot 2022-09-01 at 11 04 37 AM" src="https://user-images.githubusercontent.com/9438198/187972332-5ffb50b8-85c6-4136-a329-1020d4891198.png">


---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
