### PR TITLE
fix: use _redirects file syntax for registry to app redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -61,9 +61,3 @@
 
 [build.environment]
   NODE_OPTIONS = "--max_old_space_size=4096"
-
-[[redirects]]
-  from = "https://registry.regen.network"
-  to = "https://app.regen.network"
-  status = 301
-  force = true

--- a/web-registry/public/_redirects
+++ b/web-registry/public/_redirects
@@ -1,7 +1,2 @@
-/*    /index.html   200
-
-/projects  /projects/wilmot  200
-/projects/impactag  /projects/wilmot  200
-/projects/impactag/admin /projects/wilmot/admin 200
-
 https://registry.regen.network/*  https://app.regen.network/:splat 301!
+/*    /index.html   200

--- a/web-registry/public/_redirects
+++ b/web-registry/public/_redirects
@@ -3,3 +3,5 @@
 /projects  /projects/wilmot  200
 /projects/impactag  /projects/wilmot  200
 /projects/impactag/admin /projects/wilmot/admin 200
+
+https://registry.regen.network/*  https://app.regen.network/:splat 301!


### PR DESCRIPTION
## Description

Fixes: https://github.com/regen-network/regen-web/pull/1176

I can't figure out a way to test this without merging to master, if someone knows a way that would be great. But I'm pretty sure I've got it right now, please review my comments.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
