### PR TITLE
feat: refresh portfolio data

### DIFF
--- a/web-registry/src/hooks/useQueryBalances.ts
+++ b/web-registry/src/hooks/useQueryBalances.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  DeepPartial,
+  QueryBalancesRequest,
+  QueryBalancesResponse,
+  QueryClientImpl,
+} from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
+
+import { useLedger } from '../ledger';
+
+type FetchBalances = (
+  request: DeepPartial<QueryBalancesRequest>,
+) => Promise<QueryBalancesResponse | undefined>;
+
+type Params = {
+  address?: string;
+};
+
+export default function useQueryBalances({ address }: Params): {
+  balancesResponse: QueryBalancesResponse | undefined;
+  fetchBalances: FetchBalances;
+} {
+  const { api } = useLedger();
+  const [balancesResponse, setBalancesResponse] = useState<
+    QueryBalancesResponse | undefined
+  >();
+  const [queryClient, setQueryClient] = useState<QueryClientImpl | undefined>();
+
+  const fetchBalances = useCallback(async () => {
+    if (!queryClient) return;
+
+    try {
+      const balances = await queryClient.Balances({ address });
+      return balances;
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+    }
+
+    return;
+  }, [queryClient, address]);
+
+  useEffect(() => {
+    if (!api?.queryClient) return;
+
+    const queryClient: QueryClientImpl = new QueryClientImpl(api.queryClient);
+    setQueryClient(queryClient);
+
+    if (address) {
+      fetchBalances()
+        .then(setBalancesResponse)
+        /* eslint-disable */
+        .catch(console.error);
+    }
+  }, [api?.queryClient, address]);
+
+  return { balancesResponse, fetchBalances };
+}

--- a/web-registry/src/hooks/useQueryBalances.ts
+++ b/web-registry/src/hooks/useQueryBalances.ts
@@ -41,9 +41,12 @@ export default function useQueryBalances({ address }: Params): {
 
   useEffect(() => {
     if (!api?.queryClient) return;
+    if (queryClient) return;
+    setQueryClient(new QueryClientImpl(api.queryClient));
+  }, [api?.queryClient, queryClient]);
 
-    const queryClient: QueryClientImpl = new QueryClientImpl(api.queryClient);
-    setQueryClient(queryClient);
+  useEffect(() => {
+    if (!queryClient) return;
 
     if (address) {
       fetchBalances()
@@ -51,7 +54,7 @@ export default function useQueryBalances({ address }: Params): {
         /* eslint-disable */
         .catch(console.error);
     }
-  }, [api?.queryClient, address]);
+  }, [queryClient, address]);
 
   return { balancesResponse, fetchBalances };
 }

--- a/web-registry/src/pages/Dashboard/MyEcocredits/MyEcocredits.tsx
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/MyEcocredits.tsx
@@ -126,7 +126,7 @@ export const MyEcocredits = (): JSX.Element => {
     setIsProcessingModalOpen(false);
     // Refetch basket/ecocredits data so it shows latest values
     fetchBasketTokens();
-    fetchCredits();
+    reloadBalances();
   };
 
   const {
@@ -143,7 +143,7 @@ export const MyEcocredits = (): JSX.Element => {
   const txHash = deliverTxResponse?.transactionHash;
   const txHashUrl = getHashUrl(txHash);
   const accountAddress = wallet?.address;
-  const { credits, fetchCredits, isLoadingCredits } = useEcocredits({
+  const { credits, reloadBalances, isLoadingCredits } = useEcocredits({
     address: accountAddress,
     paginationParams,
   });

--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useUpdateCreditBaskets.tsx
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useUpdateCreditBaskets.tsx
@@ -19,7 +19,7 @@ const useUpdateCreditBaskets = ({
 }: Props): ReturnType => {
   useEffect(() => {
     // Get available baskets to put credits into
-    if (basketsWithClasses && basketsWithClasses.length > 0) {
+    if (credits && basketsWithClasses && basketsWithClasses.length > 0) {
       setCreditBaskets(
         credits.map(credit =>
           basketsWithClasses.filter(

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
@@ -67,15 +67,18 @@ export const Storefront = (): JSX.Element => {
   const batchDenoms = useMemo(
     () =>
       sellOrders
-        ?.slice(offset, offset + rowsPerPage)
+        ?.sort(sortBySellOrderId)
+        .slice(offset, offset + rowsPerPage)
         .map(sellOrder => sellOrder.batchDenom),
     [sellOrders, offset, rowsPerPage],
   );
+
   const [batchInfosMap] = useState(new Map<string, BatchInfo>());
   const newBatchDenoms = useMemo(
     () => batchDenoms?.filter(batchDenom => !batchInfosMap.has(batchDenom)),
     [batchDenoms, batchInfosMap],
   );
+
   const batchInfoResponses = useQueryListBatchInfo(newBatchDenoms);
   const batchInfos = updateBatchInfosMap({ batchInfosMap, batchInfoResponses });
 
@@ -119,7 +122,7 @@ export const Storefront = (): JSX.Element => {
         batchInfos,
         sellOrders,
         projectsInfosByHandleMap,
-      }).sort(sortBySellOrderId),
+      }),
     [batchInfos, sellOrders, projectsInfosByHandleMap],
   );
 

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
@@ -1,3 +1,4 @@
+import { SellOrderInfo } from '@regen-network/api/lib/generated/regen/ecocredit/marketplace/v1/query';
 import {
   BatchInfo,
   QueryBatchResponse,
@@ -8,8 +9,8 @@ import { Item } from 'web-components/lib/components/modal/ConfirmModal';
 import { NormalizedSellOrder } from './Storefront.types';
 
 export const sortBySellOrderId = (
-  sellOrderA: NormalizedSellOrder,
-  sellOrderB: NormalizedSellOrder,
+  sellOrderA: SellOrderInfo,
+  sellOrderB: SellOrderInfo,
 ): number => {
   if (sellOrderA.id && sellOrderB.id) {
     return Number(sellOrderA.id) < Number(sellOrderB.id) ? 1 : -1;

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.utils.ts
@@ -12,7 +12,7 @@ export const sortBySellOrderId = (
   sellOrderB: NormalizedSellOrder,
 ): number => {
   if (sellOrderA.id && sellOrderB.id) {
-    return Number(sellOrderA.id) > Number(sellOrderB.id) ? 1 : -1;
+    return Number(sellOrderA.id) < Number(sellOrderB.id) ? 1 : -1;
   }
 
   return 0;


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1186

- reload user portfolio balance after doing an action
- fix racing condition while loading portfolio page
- reverse sort order on sell order table to have new sell order fist
- perform sort before doing batch info fetch
---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [x] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
