### PR TITLE
fix: show error banner on buy action when not connected

### DIFF
--- a/web-registry/src/features/marketplace/BuySellOrderFlow.tsx
+++ b/web-registry/src/features/marketplace/BuySellOrderFlow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 
+import ErrorBanner from 'web-components/lib/components/banner/ErrorBanner';
 import { CelebrateIcon } from 'web-components/lib/components/icons/CelebrateIcon';
 import { ProcessingModal } from 'web-components/lib/components/modal/ProcessingModal';
 import { TxErrorModal } from 'web-components/lib/components/modal/TxErrorModal';
@@ -28,6 +29,7 @@ export const BuySellOrderFlow = ({ selectedProject }: Props): JSX.Element => {
   const [txButtonTitle, setTxButtonTitle] = useState<string>('');
   const [txModalHeader, setTxModalHeader] = useState<string>('');
   const [cardItems, setCardItems] = useState<Item[] | undefined>(undefined);
+  const [displayErrorBanner, setDisplayErrorBanner] = useState(false);
   const navigate = useNavigate();
 
   const closeBuyModal = (): void => setIsBuyModalOpen(false);
@@ -58,12 +60,6 @@ export const BuySellOrderFlow = ({ selectedProject }: Props): JSX.Element => {
     navigate('/ecocredits/dashboard');
   };
 
-  useEffect(() => {
-    if (selectedProject) {
-      setIsBuyModalOpen(true);
-    }
-  }, [selectedProject]);
-
   const {
     signAndBroadcast,
     setDeliverTxResponse,
@@ -85,6 +81,14 @@ export const BuySellOrderFlow = ({ selectedProject }: Props): JSX.Element => {
     setTxModalTitle,
     buttonTitle: VIEW_ECOCREDITS,
   });
+
+  useEffect(() => {
+    if (selectedProject && accountAddress) {
+      setIsBuyModalOpen(true);
+    } else if (selectedProject && !accountAddress) {
+      setDisplayErrorBanner(true);
+    }
+  }, [selectedProject, accountAddress]);
 
   return (
     <>
@@ -125,6 +129,9 @@ export const BuySellOrderFlow = ({ selectedProject }: Props): JSX.Element => {
         onButtonClick={handleTxModalClose}
         buttonTitle="close"
       />
+      {displayErrorBanner && (
+        <ErrorBanner text="Please connect to Keplr to use Regen Ledger features" />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1193

- display error banner while trying to buy a sell order and wallet is not connected

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Go to https://deploy-preview-1212--regen-registry.netlify.app/
2. Try to buy sell order on home page or projects page with keplr wallet not connected

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
