### PR TITLE
fix issue 1097: padding should be 0 only on top of the footer item's …

### DIFF
--- a/web-components/src/components/footer/index.tsx
+++ b/web-components/src/components/footer/index.tsx
@@ -69,7 +69,7 @@ const FooterItem = ({ title, items }: FooterItemProps): JSX.Element => {
       <List sx={{ p: 0 }}>
         {items.map((item, index) => (
           <ListItem
-            sx={{ py: 0.75, px: 0, ':first-of-type': { p: 0 } }}
+            sx={{ py: 0.75, px: 0, ':first-of-type': { pt: 0 } }}
             key={index}
           >
             <Link


### PR DESCRIPTION
…first list element

## Description

Closes: #1097 

Visual glitch was caused by setting both top and bottom padding to zero on the first list item, whereas only the top one should disappear.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Open the www website in a browser, and check that the spacing between the first and second element of the lists of links in the website footer have a spacing that is consistent with all other links in the list (see original issue screenshot for comparison)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
