### PR TITLE
feat: new homepage header

### DIFF
--- a/web-registry/src/components/atoms/RegistryIconLink.tsx
+++ b/web-registry/src/components/atoms/RegistryIconLink.tsx
@@ -9,8 +9,8 @@ export const RegistryIconLink: React.FC<{ color: string }> = ({ color }) => {
     <Link to="/">
       <Box
         sx={{
-          width: { xs: 100, sm: 117 },
-          height: { xs: 'auto', sm: 77 },
+          width: { xs: 62, md: 117 },
+          height: { xs: 'auto', md: 77 },
         }}
       >
         <RegenMarketIcon sx={{ color }} />

--- a/web-registry/src/components/molecules/BackgroundImgSection.tsx
+++ b/web-registry/src/components/molecules/BackgroundImgSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SxProps } from '@mui/material';
 import CardMedia from '@mui/material/CardMedia';
 import { makeStyles } from '@mui/styles';
 import cx from 'clsx';
@@ -11,6 +12,7 @@ type Props = {
   /** sets larger `minHeight` on mobile to match gatsby `BackgroundSection` */
   isBanner?: boolean;
   linearGradient?: string;
+  sx?: SxProps<Theme>;
   classes?: {
     section?: string;
     root?: string;
@@ -54,14 +56,17 @@ const useStyles = makeStyles<Theme, StyleProps>(theme => ({
   }),
 }));
 
-const BackgroundImgSection: React.FC<Props> = ({ classes, ...props }) => {
+const BackgroundImgSection: React.FC<Props> = ({
+  classes,
+  sx = [],
+  ...props
+}) => {
   const styles = useStyles({
     isBanner: !!props.isBanner,
     linearGradient: props?.linearGradient,
   });
 
   return (
-    // <div className={props?.linearGradient ? styles.backgroundGradient : ''}>
     <CardMedia
       image={props.img}
       classes={{
@@ -69,6 +74,7 @@ const BackgroundImgSection: React.FC<Props> = ({ classes, ...props }) => {
           [styles.backgroundGradient]: props?.linearGradient,
         }),
       }}
+      sx={Array.isArray(sx) ? sx : [sx]}
     >
       <Section classes={{ root: cx(styles.section, classes?.section) }}>
         <div className={cx(styles.main, classes && classes.main)}>
@@ -76,7 +82,6 @@ const BackgroundImgSection: React.FC<Props> = ({ classes, ...props }) => {
         </div>
       </Section>
     </CardMedia>
-    // </div>
   );
 };
 

--- a/web-registry/src/pages/Home/Home.styles.tsx
+++ b/web-registry/src/pages/Home/Home.styles.tsx
@@ -3,6 +3,12 @@ import { makeStyles } from '@mui/styles';
 export const useHomeStyles = makeStyles(theme => ({
   section: {
     paddingBottom: theme.spacing(16.25),
+    maxWidth: '1240px',
+    width: '100%',
+    [theme.breakpoints.up('lg')]: {
+      paddingLeft: 0,
+      paddingRight: 0,
+    },
   },
   title: {
     marginBottom: theme.spacing(8.75),

--- a/web-registry/src/pages/Home/Home.tsx
+++ b/web-registry/src/pages/Home/Home.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, CardMedia, useMediaQuery } from '@mui/material';
-import { useTheme } from '@mui/styles';
+import { Box, CardMedia } from '@mui/material';
 import { gradients } from 'styles/gradients';
 
 import { BlockContent } from 'web-components/lib/components/block-content';
@@ -29,7 +28,6 @@ const Home: React.FC = () => {
   const [modalLink, setModalLink] = useState<string>('');
 
   const styles = useHomeStyles();
-  const theme = useTheme();
 
   // Featured projects fetching
 
@@ -42,8 +40,6 @@ const Home: React.FC = () => {
   const creditClassesContent = creditClassData?.allCreditClass;
 
   const { batchesWithSupply, setPaginationParams } = usePaginatedBatches();
-
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   useEffect(() => {
     const anchor = window.location.hash.slice(1);
@@ -146,7 +142,7 @@ const Home: React.FC = () => {
         >
           <CreditClassCards
             btnText="Learn More"
-            justifyContent={isMobile ? 'center' : 'flex-start'}
+            justifyContent={['center', 'center', 'flex-start']}
             creditClassesContent={creditClassesContent} // CMS data
           />
         </Section>

--- a/web-registry/src/pages/Home/Home.tsx
+++ b/web-registry/src/pages/Home/Home.tsx
@@ -63,7 +63,11 @@ const Home: React.FC = () => {
         }
         linearGradient="linear-gradient(203.09deg, #000000 45.49%, #5E9078 92.1%);"
         classes={{ section: styles.section }}
-        sx={{ display: 'flex', alignItems: 'center', height: [600, 600, 760] }}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: [600, 600, 760],
+        }}
       >
         <Box
           sx={{

--- a/web-registry/src/pages/Home/Home.tsx
+++ b/web-registry/src/pages/Home/Home.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, CardMedia, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/styles';
+import { gradients } from 'styles/gradients';
 
 import { BlockContent } from 'web-components/lib/components/block-content';
 import { Loading } from 'web-components/lib/components/loading';
@@ -59,9 +60,14 @@ const Home: React.FC = () => {
   return (
     <Box sx={{ backgroundColor: 'primary.main' }}>
       <BackgroundImgSection
-        img={heroSection?.background?.image?.asset?.url || ''}
-        linearGradient="linear-gradient(180deg, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 100%);"
+        img={
+          'https://cdn.sanity.io/images/jm12rn9t/production/ae7630b9aa71e3d701b692ed576ba0fbd4c0433a-1440x760.jpg?w=2000&fit=max&auto=format' ||
+          heroSection?.background?.image?.asset?.url ||
+          ''
+        }
+        linearGradient="linear-gradient(203.09deg, #000000 45.49%, #5E9078 92.1%);"
         classes={{ section: styles.section }}
+        sx={{ display: 'flex', alignItems: 'center', height: [600, 600, 760] }}
       >
         <Box
           sx={{
@@ -72,7 +78,7 @@ const Home: React.FC = () => {
             pt: { xs: 8, sm: 15 },
           }}
         >
-          <Box sx={{ pr: 4, maxWidth: '585px' }}>
+          <Box sx={{ pr: 4, alignSelf: 'center', maxWidth: '585px' }}>
             <Title
               variant="h1"
               sx={{
@@ -80,7 +86,14 @@ const Home: React.FC = () => {
                 lineHeight: { xs: '140%', sm: '130%' },
               }}
             >
-              {heroSection?.title}
+              Discover{' '}
+              <Box sx={{ display: 'inline-block', ...gradients.blueGreen }}>
+                Ecocredits
+              </Box>{' '}
+              and NCT{' '}
+              <Box sx={{ display: 'inline-block', ...gradients.blueGreen }}>
+                basket tokens
+              </Box>
             </Title>
             <Body
               as="div"
@@ -99,13 +112,17 @@ const Home: React.FC = () => {
           <Box
             sx={{
               alignSelf: 'center',
-              maxWidth: { xs: '187px', sm: '100%' },
+              maxWidth: ['252px', '560px'],
             }}
           >
             <img
               loading="lazy"
               style={{ width: '100%' }}
-              src={heroSection?.icon?.image?.asset?.url || ''}
+              src={
+                'https://cdn.sanity.io/images/jm12rn9t/production/5402a5e5868601a1920b270178dfbe0b60da6683-590x503.png?w=2000&fit=max&auto=format' ||
+                heroSection?.icon?.image?.asset?.url ||
+                ''
+              }
               alt={heroSection?.icon?.imageAlt || 'icon'}
             />
           </Box>

--- a/web-registry/src/pages/Home/Home.tsx
+++ b/web-registry/src/pages/Home/Home.tsx
@@ -56,11 +56,7 @@ const Home: React.FC = () => {
   return (
     <Box sx={{ backgroundColor: 'primary.main' }}>
       <BackgroundImgSection
-        img={
-          'https://cdn.sanity.io/images/jm12rn9t/production/ae7630b9aa71e3d701b692ed576ba0fbd4c0433a-1440x760.jpg?w=2000&fit=max&auto=format' ||
-          heroSection?.background?.image?.asset?.url ||
-          ''
-        }
+        img={heroSection?.background?.image?.asset?.url || ''}
         linearGradient="linear-gradient(203.09deg, #000000 45.49%, #5E9078 92.1%);"
         classes={{ section: styles.section }}
         sx={{
@@ -118,11 +114,7 @@ const Home: React.FC = () => {
             <img
               loading="lazy"
               style={{ width: '100%' }}
-              src={
-                'https://cdn.sanity.io/images/jm12rn9t/production/5402a5e5868601a1920b270178dfbe0b60da6683-590x503.png?w=2000&fit=max&auto=format' ||
-                heroSection?.icon?.image?.asset?.url ||
-                ''
-              }
+              src={heroSection?.icon?.image?.asset?.url || ''}
               alt={heroSection?.icon?.imageAlt || 'icon'}
             />
           </Box>

--- a/web-registry/src/styles/gradients.ts
+++ b/web-registry/src/styles/gradients.ts
@@ -1,0 +1,10 @@
+import { SxProps } from '@mui/material';
+
+export const gradients = {
+  blueGreen: {
+    background:
+      'linear-gradient(204.4deg, #527984 5.94%, #79C6AA 51.92%, #C4DAB5 97.89%)',
+    backgroundClip: 'text',
+    textFillColor: 'transparent',
+  } as SxProps,
+};


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1196

![image](https://user-images.githubusercontent.com/530644/192287866-23e38a1c-6173-408c-95e3-27fdae25cee6.png)

- update home page header
- fix issue with header logo on md breakpoint

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
