### PR TITLE
feat: provisionally display RND as project admin

### DIFF
--- a/web-components/src/components/cards/ProjectTopCard.tsx
+++ b/web-components/src/components/cards/ProjectTopCard.tsx
@@ -18,6 +18,7 @@ interface ProjectTopCardProps {
     root?: string;
     userInfo?: string;
   };
+  projectAdmin?: User;
   projectDeveloper?: User;
   landSteward?: User;
   landOwner?: User;
@@ -110,6 +111,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function ProjectTopCard({
   classes,
+  projectAdmin,
   projectDeveloper,
   landSteward,
   landOwner,
@@ -145,6 +147,17 @@ export default function ProjectTopCard({
               // </Grid>
             ))}
           </Grid>
+        </div>
+      )}
+      {projectAdmin && (
+        <div
+          className={cx(
+            styles.issuer,
+            styles.userInfo,
+            classes && classes.userInfo,
+          )}
+        >
+          <UserInfoWithTitle size="xl" user={projectAdmin} title="admin" />
         </div>
       )}
       {projectDeveloper && (

--- a/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
+++ b/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
@@ -36,6 +36,7 @@ import {
   ProjectTopSectionQuoteMark,
   useProjectTopSectionStyles,
 } from './ProjectTopSection.styles';
+import { getDisplayAdmin } from './ProjectTopSection.utils';
 
 function ProjectTopSection({
   data,
@@ -268,6 +269,7 @@ function ProjectTopSection({
         </Grid>
         <Grid item xs={12} md={4} sx={{ pt: { xs: 10, sm: 'inherit' } }}>
           <ProjectTopCard
+            projectAdmin={data.admin && getDisplayAdmin(data.admin)}
             projectDeveloper={getDisplayParty(
               'regen:projectDeveloper',
               metadata,

--- a/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.utils.ts
+++ b/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.utils.ts
@@ -1,0 +1,23 @@
+import { User } from 'web-components/lib/components/user/UserInfo';
+
+// TODO
+// This is a temporary hack to show Regen as a Project Admin when applicable
+
+const addressesMap = [
+  'regen123a7e9gvgm53zvswc6daq7c85xtzt8263lgasm', // Mainnet - Credit classes
+  'regen1v2ncquer9r2ytlkxh2djmmsq3e8we6rjc9snfn', // Mainnet - Projects
+  'regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46', // Redwood - Shared dev account
+];
+
+export const getDisplayAdmin = (address: string): User | undefined => {
+  if (addressesMap.includes(address)) {
+    return {
+      name: 'Regen Network Development, Inc',
+      type: 'ORGANIZATION',
+      image: 'https://regen-registry.s3.amazonaws.com/regen-logo-green.svg',
+      description:
+        'Regen Network realigns the agricultural economy with ecological health by creating the global marketplace for planetary stewardship.',
+    };
+  }
+  return;
+};

--- a/web-registry/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-registry/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -109,7 +109,9 @@ function ProjectDetails(): JSX.Element {
   const onChainProject = projectResponse?.project;
 
   // TODO: when all projects are on-chain, just use dataByOnChainId
-  const data = isOnChainId ? dataByOnChainId : dataByHandle;
+  const data = isOnChainId
+    ? { ...dataByOnChainId, admin: onChainProject?.admin }
+    : dataByHandle;
   const project = isOnChainId
     ? dataByOnChainId?.projectByOnChainId
     : dataByHandle?.projectByHandle;


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1062

(*) At the moment it just checks some harcoded addresses to see if it is RND and show as Project Admin 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Go to: https://deploy-preview-1309--regen-registry.netlify.app/projects/C01-001

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
