### PR TITLE
fix: credit batches Tx column

### DIFF
--- a/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
+++ b/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
@@ -108,6 +108,12 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
     );
   }
 
+  const someTx = batches.some(b => b.txhash);
+
+  if (!someTx) {
+    columnsToShow = columnsToShow.filter(col => col.id !== 'txhash');
+  }
+
   const table = (
     <ActionsTable
       tableLabel="credit batch table"
@@ -126,16 +132,22 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
         </Box>
       ))}
       onTableChange={onTableChange}
-      rows={batches.map(batch =>
+      rows={batches.map(batch => {
         /* eslint-disable react/jsx-key */
-        [
-          <Link
-            href={getHashUrl(batch.txhash)}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {truncateHash(batch.txhash)}
-          </Link>,
+        let result = [];
+        if (someTx) {
+          result.push(
+            <Link
+              href={getHashUrl(batch.txhash)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {truncateHash(batch.txhash)}
+            </Link>,
+          );
+        }
+
+        result.push(
           <WithLoader isLoading={!batch.projectName} variant="skeleton">
             <Link
               href={`/projects/${batch?.projectId}`}
@@ -183,13 +195,15 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
               {batch.projectLocation}
             </Box>
           </WithLoader>,
-        ].filter(item => {
+        );
+
+        return result.filter(item => {
           return (
             !(creditClassId && item?.key === 'classId') &&
             !filteredColumns?.includes(String(item?.key))
           );
-        }),
-      )}
+        });
+      })}
       /* eslint-enable react/jsx-key */
     />
   );

--- a/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
+++ b/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
@@ -108,10 +108,10 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
     );
   }
 
-  const someTx = batches.some(b => b.txhash);
+  const someTx = batches.some(batch => batch.txhash);
 
   if (!someTx) {
-    columnsToShow = columnsToShow.filter(col => col.id !== 'txhash');
+    columnsToShow = columnsToShow.filter(column => column.id !== 'txhash');
   }
 
   const table = (
@@ -137,11 +137,7 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
         let result = [];
         if (someTx) {
           result.push(
-            <Link
-              href={getHashUrl(batch.txhash)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <Link href={getHashUrl(batch.txhash)}>
               {truncateHash(batch.txhash)}
             </Link>,
           );


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1195

(*) for the moment it checks that if there is no batch with Tx hash yet, the column is hidden

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Go to: https://deploy-preview-1310--regen-registry.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
