### PR TITLE
fix: credit batches location column in project page

### DIFF
--- a/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
+++ b/web-registry/src/components/organisms/CreditBatches/CreditBatches.tsx
@@ -178,10 +178,12 @@ const CreditBatches: React.FC<CreditBatchProps> = ({
           <Box className={styles.noWrap}>
             {formatDate(batch.endDate as Date, undefined, true)}
           </Box>,
-          <WithLoader isLoading={!batch.projectLocation} variant="skeleton">
-            <Box key="projectLocation" className={styles.noWrap}>
-              {batch.projectLocation}
-            </Box>
+          <WithLoader
+            key="projectLocation"
+            isLoading={!batch.projectLocation}
+            variant="skeleton"
+          >
+            <Box className={styles.noWrap}>{batch.projectLocation}</Box>
           </WithLoader>,
         ].filter(item => {
           return (


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1264

Just move the key to the outermost element of the corresponding cell

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. Go to: https://deploy-preview-1311--regen-registry.netlify.app/projects/C01-001

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
