### PR TITLE
fix: projects page responsive issue

### DIFF
--- a/web-components/src/components/cards/ProjectCard/ProjectCard.styles.ts
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.styles.ts
@@ -16,9 +16,9 @@ export const useProjectCardStyles = makeStyles((theme: Theme) => ({
     },
   },
   placeInfo: {
-    flex: '1 0 auto',
     [theme.breakpoints.up('sm')]: {
       padding: theme.spacing(1.75, 5.25, 5.25),
+      flex: '1 0 auto',
     },
     [theme.breakpoints.down('sm')]: {
       padding: theme.spacing(1.75, 4.5, 5),

--- a/web-registry/src/pages/Projects/Projects.tsx
+++ b/web-registry/src/pages/Projects/Projects.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box, SelectChangeEvent } from '@mui/material';
+import { spacing } from 'styles/spacing';
 
 import { Flex } from 'web-components/lib/components/box';
 import { ProjectCard } from 'web-components/lib/components/cards/ProjectCard';
@@ -39,7 +40,7 @@ export const Projects: React.FC = () => {
         bgcolor: 'grey.50',
         borderTop: 1,
         borderColor: 'grey.100',
-        px: [6, 8.75],
+        py: [6, 8.75],
         pt: 8.75,
         pb: 25,
         justifyContent: 'center',
@@ -51,8 +52,11 @@ export const Projects: React.FC = () => {
           gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 400px))',
           gridGap: '1.125rem',
           flex: 1,
-          justifyContent: 'center',
-          maxWidth: '1700px',
+          maxWidth: theme => ({
+            xs: '100%',
+            lg: theme.typography.pxToRem(1400),
+          }),
+          ...spacing.header,
         }}
       >
         <Flex flex={1} sx={{ gridColumn: '1 / -1' }}>
@@ -66,8 +70,13 @@ export const Projects: React.FC = () => {
               <Subtitle size="lg">Projects</Subtitle>
               <Body size="lg"> ({projects.length})</Body>
             </Flex>
-            <Flex alignItems="center" sx={{ width: ['60%', 'auto'] }}>
-              <Box sx={{ width: [0, 63], visibility: ['hidden', 'visible'] }}>
+            <Flex alignItems="center" sx={{ width: { xs: '60%', md: 'auto' } }}>
+              <Box
+                sx={{
+                  width: [0, 0, 63],
+                  visibility: { xs: 'hidden', md: 'visible' },
+                }}
+              >
                 <Body size="xs">Sort by:</Body>
               </Box>
               <SelectTextFieldBase

--- a/web-registry/src/pages/Projects/Projects.tsx
+++ b/web-registry/src/pages/Projects/Projects.tsx
@@ -52,6 +52,7 @@ export const Projects: React.FC = () => {
           gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 400px))',
           gridGap: '1.125rem',
           flex: 1,
+          justifyContent: { xs: 'flex-start', md: 'flex-start' },
           maxWidth: theme => ({
             xs: '100%',
             lg: theme.typography.pxToRem(1400),

--- a/web-registry/src/styles/spacing.ts
+++ b/web-registry/src/styles/spacing.ts
@@ -1,0 +1,9 @@
+import { SxProps } from '@mui/material';
+
+import { Theme } from 'web-components/lib/theme/muiTheme';
+
+export const spacing = {
+  header: {
+    px: (theme: Theme) => ({ xs: theme.spacing(3.75), md: theme.spacing(6) }),
+  } as SxProps,
+};


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1281

- fix projects page responsive
- extract header padding to make it reusable wherever we want to align content with the header logo

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
