### PR TITLE
fix: empty state activity stats

### DIFF
--- a/web-registry/src/components/organisms/CreditTotals.tsx
+++ b/web-registry/src/components/organisms/CreditTotals.tsx
@@ -9,9 +9,9 @@ import { BatchInfoWithSupply } from '../../types/ledger/ecocredit';
 import { Statistic } from '../molecules';
 
 interface CreditTotalData {
-  tradeable: number;
-  retired: number;
-  created: number;
+  tradeable?: number;
+  retired?: number;
+  created?: number;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -31,9 +31,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 const CreditTotals: React.FC = () => {
   const styles = useStyles();
   const [totals, setTotals] = useState<CreditTotalData>({
-    tradeable: 0,
-    retired: 0,
-    created: 0,
+    tradeable: undefined,
+    retired: undefined,
+    created: undefined,
   });
 
   const parseNumber = (value: any): number => {
@@ -92,22 +92,19 @@ const CreditTotals: React.FC = () => {
   return (
     <Grid container spacing={6} className={styles.root}>
       <Grid item xs={12} sm={3} className={styles.item}>
-        <Statistic
-          label="ecocredits tradeable"
-          count={totals.tradeable ? totals.tradeable : undefined}
-        />
+        <Statistic label="ecocredits tradeable" count={totals.tradeable} />
       </Grid>
       <Grid item xs={12} sm={3} className={styles.item}>
         <Statistic
           label="ecocredits retired"
-          count={totals.retired ? totals.retired : undefined}
+          count={totals.retired}
           arrow="downLeft"
         />
       </Grid>
       <Grid item xs={12} sm={3} className={styles.item}>
         <Statistic
           label="ecocredits created"
-          count={totals.created ? totals.created : undefined}
+          count={totals.created}
           arrow="upRight"
         />
       </Grid>


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1273

- fix empty state for activity stats

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
