### PR TITLE
fix: amount input on retire form

### DIFF
--- a/web-components/src/components/form/CreditRetireForm.tsx
+++ b/web-components/src/components/form/CreditRetireForm.tsx
@@ -231,11 +231,19 @@ export const CreditRetireFields = ({
   arrayIndex,
 }: CreditRetireFieldsProps): JSX.Element => {
   return (
-    <BottomCreditRetireFields
-      mapboxToken={mapboxToken}
-      arrayPrefix={arrayPrefix}
-      arrayIndex={arrayIndex}
-    />
+    <>
+      <AmountField
+        name={`${arrayPrefix}retiredAmount`}
+        label="Amount retired"
+        availableAmount={availableTradableAmount}
+        denom={batchDenom}
+      />
+      <BottomCreditRetireFields
+        mapboxToken={mapboxToken}
+        arrayPrefix={arrayPrefix}
+        arrayIndex={arrayIndex}
+      />
+    </>
   );
 };
 

--- a/web-components/src/components/form/CreditSendForm.tsx
+++ b/web-components/src/components/form/CreditSendForm.tsx
@@ -21,6 +21,7 @@ import { RegenModalProps } from '../modal';
 import InfoTooltip from '../tooltip/InfoTooltip';
 import { Subtitle } from '../typography';
 import {
+  BottomCreditRetireFields,
   BottomCreditRetireFieldsProps,
   CreditRetireFields,
   initialValues as initialValuesRetire,
@@ -181,10 +182,9 @@ const CreditSendForm: React.FC<FormProps> = ({
 
           {values.withRetire && (
             <>
-              <CreditRetireFields
-                availableTradableAmount={availableTradableAmount}
-                batchDenom={batchDenom}
+              <BottomCreditRetireFields
                 mapboxToken={mapboxToken}
+                arrayPrefix=""
               />
             </>
           )}


### PR DESCRIPTION
## Description

- fix retire amount on retire modal (was removed in regen-network/regen-web#1300)

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. https://deploy-preview-1372--regen-registry.netlify.app/ecocredits/dashboard
2. Try to retire credits

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
