### PR TITLE
fix: prevent user from buying its own orders

### DIFF
--- a/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
@@ -230,7 +230,9 @@ export function ProjectCard({
                     startIcon={
                       <CurrentCreditsIcon height="18px" width="18px" />
                     }
-                    disabled={purchaseInfo.sellInfo.userCreditsAvailable === 0}
+                    disabled={
+                      purchaseInfo.sellInfo.creditsAvailableForUser === 0
+                    }
                     sx={{ width: '100%' }}
                   >
                     {'BUY ECOCREDITS'}

--- a/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
@@ -230,7 +230,7 @@ export function ProjectCard({
                     startIcon={
                       <CurrentCreditsIcon height="18px" width="18px" />
                     }
-                    disabled={purchaseInfo.sellInfo.creditsAvailable === 0}
+                    disabled={purchaseInfo.sellInfo.userCreditsAvailable === 0}
                     sx={{ width: '100%' }}
                   >
                     {'BUY ECOCREDITS'}

--- a/web-components/src/components/cards/ProjectCard/ProjectCard.types.ts
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.types.ts
@@ -19,7 +19,7 @@ export interface PurchaseInfo {
   sellInfo?: {
     pricePerTon: string;
     creditsAvailable: number;
-    userCreditsAvailable: number;
+    creditsAvailableForUser: number;
     denomLogo?: JSX.Element;
   };
 }

--- a/web-components/src/components/cards/ProjectCard/ProjectCard.types.ts
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.types.ts
@@ -19,6 +19,7 @@ export interface PurchaseInfo {
   sellInfo?: {
     pricePerTon: string;
     creditsAvailable: number;
+    userCreditsAvailable: number;
     denomLogo?: JSX.Element;
   };
 }

--- a/web-components/src/components/cards/card.stories.tsx
+++ b/web-components/src/components/cards/card.stories.tsx
@@ -99,7 +99,11 @@ export const projectCard = (): JSX.Element => (
       imgSrc="/coorong.png"
       onClick={onClick}
       purchaseInfo={{
-        sellInfo: { creditsAvailable: 1200, pricePerTon: '17.20-24.20 ' },
+        sellInfo: {
+          creditsAvailable: 1200,
+          userCreditsAvailable: 1190,
+          pricePerTon: '17.20-24.20',
+        },
       }}
       sx={{ maxWidth: 338, mr: 10, mb: 10 }}
     />

--- a/web-components/src/components/cards/card.stories.tsx
+++ b/web-components/src/components/cards/card.stories.tsx
@@ -101,7 +101,7 @@ export const projectCard = (): JSX.Element => (
       purchaseInfo={{
         sellInfo: {
           creditsAvailable: 1200,
-          userCreditsAvailable: 1190,
+          creditsAvailableForUser: 1190,
           pricePerTon: '17.20-24.20',
         },
       }}

--- a/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
+++ b/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
@@ -126,9 +126,11 @@ export const BuySellOrderFlow = ({
   const project = useMemo(
     () => ({
       id: selectedProject?.id.toString() ?? '',
-      sellOrders: projectUiSellOrdersInfo,
+      sellOrders: projectUiSellOrdersInfo?.filter(
+        sellOrder => sellOrder.seller !== accountAddress,
+      ),
     }),
-    [selectedProject, projectUiSellOrdersInfo],
+    [selectedProject, projectUiSellOrdersInfo, accountAddress],
   );
 
   useEffect(() => {

--- a/web-registry/src/features/marketplace/BuySellOrderFlow/hooks/useBuySellOrderData.tsx
+++ b/web-registry/src/features/marketplace/BuySellOrderFlow/hooks/useBuySellOrderData.tsx
@@ -25,9 +25,11 @@ export const useBuySellOrderData = ({ projects }: Props): ReponseType => {
       projects,
       sellOrders,
     });
-
+  const sellOrdersAvailable = projectsWithOrderData[0]?.sellOrders.filter(
+    sellOrder => sellOrder.seller !== wallet?.address,
+  );
   const isBuyFlowDisabled =
-    (loadingProjects || projectsWithOrderData[0]?.sellOrders.length === 0) &&
+    (loadingProjects || sellOrdersAvailable.length === 0) &&
     Boolean(wallet?.address);
 
   return {

--- a/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.tsx
+++ b/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.tsx
@@ -20,7 +20,6 @@ type Props = {
   sellOrders?: SellOrderInfoExtented[];
   regenPrice?: number;
   limit?: number;
-  userAddress?: string;
 };
 
 export interface ProjectsSellOrders {
@@ -33,7 +32,6 @@ export const useProjectsSellOrders = ({
   sellOrders,
   regenPrice,
   limit,
-  userAddress,
 }: Props): ProjectsSellOrders => {
   const [projectsWithOrderData, setProjectsWithOrderData] = useState<
     ProjectWithOrderData[]

--- a/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.tsx
+++ b/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ProjectInfo } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 
 import { getMetadata } from 'lib/metadata-graph';
+import { useWallet } from 'lib/wallet';
 
 import { SellOrderInfoExtented } from 'hooks/useQuerySellOrders';
 
@@ -19,6 +20,7 @@ type Props = {
   sellOrders?: SellOrderInfoExtented[];
   regenPrice?: number;
   limit?: number;
+  userAddress?: string;
 };
 
 export interface ProjectsSellOrders {
@@ -31,11 +33,13 @@ export const useProjectsSellOrders = ({
   sellOrders,
   regenPrice,
   limit,
+  userAddress,
 }: Props): ProjectsSellOrders => {
   const [projectsWithOrderData, setProjectsWithOrderData] = useState<
     ProjectWithOrderData[]
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const { wallet } = useWallet();
 
   useEffect(() => {
     if (projectsWithOrderData.length > 0) return;
@@ -47,13 +51,21 @@ export const useProjectsSellOrders = ({
           sellOrders,
           limit ?? projects.length,
           regenPrice,
+          wallet?.address,
         );
         setProjectsWithOrderData(_projectsWithOrders);
         setLoading(false);
       }
     };
     normalize();
-  }, [projectsWithOrderData, projects, sellOrders, regenPrice, limit]);
+  }, [
+    projectsWithOrderData,
+    projects,
+    sellOrders,
+    regenPrice,
+    limit,
+    wallet?.address,
+  ]);
 
   return { projectsWithOrderData, loading };
 };
@@ -63,6 +75,7 @@ const getProjectDisplayData = async (
   sellOrders: SellOrderInfoExtented[],
   limit: number,
   regenPrice?: number,
+  userAddress?: string,
 ): Promise<ProjectWithOrderData[]> => {
   const projectsWithOrderData = await Promise.all(
     projects
@@ -76,6 +89,7 @@ const getProjectDisplayData = async (
           projectId: project.id,
           sellOrders,
           regenPrice,
+          userAddress,
         });
         let metadata;
         if (project.metadata.length) {

--- a/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.utils.tsx
+++ b/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.utils.tsx
@@ -15,6 +15,7 @@ type GetPurchaseInfoParams = {
   projectId: string;
   sellOrders: SellOrderInfo[];
   regenPrice?: number;
+  userAddress?: string;
 };
 
 const REGEN_DENOM = 'uregen';
@@ -23,6 +24,7 @@ export const getPurchaseInfo = ({
   projectId,
   sellOrders,
   regenPrice,
+  userAddress,
 }: GetPurchaseInfoParams): PurchaseInfo => {
   const ordersForThisProject = sellOrders.filter(order =>
     order.batchDenom.startsWith(projectId),
@@ -32,11 +34,17 @@ export const getPurchaseInfo = ({
       sellInfo: {
         pricePerTon: `-`,
         creditsAvailable: 0,
+        userCreditsAvailable: 0,
       },
     };
   }
 
   const creditsAvailable = ordersForThisProject
+    .map(order => parseFloat(order.quantity))
+    .reduce((total, quantity) => total + quantity, 0);
+
+  const userCreditsAvailable = ordersForThisProject
+    .filter(order => order.seller !== userAddress)
     .map(order => parseFloat(order.quantity))
     .reduce((total, quantity) => total + quantity, 0);
 
@@ -72,6 +80,9 @@ export const getPurchaseInfo = ({
     sellInfo: {
       pricePerTon: hasPrice ? `$${priceMinDisplayed}-${priceMaxDisplayed}` : '',
       creditsAvailable: roundFloatNumber(creditsAvailable, {
+        decimals: 0,
+      }),
+      userCreditsAvailable: roundFloatNumber(userCreditsAvailable, {
         decimals: 0,
       }),
     },

--- a/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.utils.tsx
+++ b/web-registry/src/pages/Projects/hooks/useProjectsSellOrders.utils.tsx
@@ -34,7 +34,7 @@ export const getPurchaseInfo = ({
       sellInfo: {
         pricePerTon: `-`,
         creditsAvailable: 0,
-        userCreditsAvailable: 0,
+        creditsAvailableForUser: 0,
       },
     };
   }
@@ -43,7 +43,7 @@ export const getPurchaseInfo = ({
     .map(order => parseFloat(order.quantity))
     .reduce((total, quantity) => total + quantity, 0);
 
-  const userCreditsAvailable = ordersForThisProject
+  const creditsAvailableForUser = ordersForThisProject
     .filter(order => order.seller !== userAddress)
     .map(order => parseFloat(order.quantity))
     .reduce((total, quantity) => total + quantity, 0);
@@ -82,7 +82,7 @@ export const getPurchaseInfo = ({
       creditsAvailable: roundFloatNumber(creditsAvailable, {
         decimals: 0,
       }),
-      userCreditsAvailable: roundFloatNumber(userCreditsAvailable, {
+      creditsAvailableForUser: roundFloatNumber(creditsAvailableForUser, {
         decimals: 0,
       }),
     },


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1261

- remove own sell orders from `BuyCreditsModal`
- disabled button if a projects has only user own sell orders

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
