### PR TITLE
fix: missing cfc project dates

### DIFF
--- a/web-registry/src/components/molecules/ProjectMetadata/ProjectMetadata.CFC.tsx
+++ b/web-registry/src/components/molecules/ProjectMetadata/ProjectMetadata.CFC.tsx
@@ -26,8 +26,8 @@ const ProjectMetadataCFC: React.FC<CFCMetadataProps> = ({
     return null;
   }
 
-  const startDate = metadata?.['regen:projectStartDate']?.['@value'];
-  const endDate = metadata?.['regen:projectEndDate']?.['@value'];
+  const startDate = metadata?.['regen:projectStartDate'];
+  const endDate = metadata?.['regen:projectEndDate'];
   const offsetProtocol = metadata?.['regen:offsetProtocol'];
   const projectDesignDocument = metadata?.['regen:projectDesignDocument'];
   const projectActivity = metadata?.['regen:projectActivity'];

--- a/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.utils.ts
+++ b/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.utils.ts
@@ -29,7 +29,7 @@ export const getDisplayAdmin = (address?: string): User | undefined => {
 };
 
 export const getDisplayDeveloper = (
-  metadata?: ProjectMetadataLD,
+  metadata?: ProjectMetadataLD | CFCProjectMetadataLD,
   party?: Maybe<PartyFieldsFragment>,
 ): User | undefined => {
   if (!metadata) return;

--- a/web-registry/src/generated/json-ld/cfc-project-metadata.ts
+++ b/web-registry/src/generated/json-ld/cfc-project-metadata.ts
@@ -1,15 +1,19 @@
-import { URL } from 'web-components/lib/types/rdf';
-
 import { ProjectMetadataLD } from './project-metadata';
 
 // type generated from https://github.com/regen-network/regen-registry-standards/blob/main/jsonld/projects/C02-project.jsonld
 
-export interface CFCProjectMetadataLD extends ProjectMetadataLD {
+export interface CFCProjectMetadataLD
+  extends Omit<
+    ProjectMetadataLD,
+    'regen:projectStartDate' | 'regen:projectEndDate'
+  > {
   'regen:cfcProjectId'?: string;
   'regen:cfcProjectPage'?: string;
   'regen:projectDesignDocument'?: string;
   'regen:projectOperator'?: RegenProjectOperator;
   'regen:offsetProtocol'?: RegenOffsetProtocol;
+  'regen:projectStartDate': string;
+  'regen:projectEndDate': string;
 }
 
 interface RegenOffsetProtocol {

--- a/web-registry/src/lib/transform.ts
+++ b/web-registry/src/lib/transform.ts
@@ -9,6 +9,7 @@ import {
   ProjectByOnChainIdQuery,
 } from '../generated/graphql';
 import {
+  CFCProjectMetadataLD,
   ProjectMetadataLD,
   ProjectStakeholder,
 } from '../generated/json-ld/index';
@@ -188,7 +189,7 @@ type StakeholderType =
   | 'regen:projectOriginator';
 
 const getPartyFromMetadata = (
-  metadata: ProjectMetadataLD,
+  metadata: ProjectMetadataLD | CFCProjectMetadataLD,
   role: StakeholderType,
 ): Party | undefined => {
   const metadataRole: ProjectStakeholder = metadata[role];
@@ -209,7 +210,7 @@ const getPartyFromMetadata = (
 
 export function getDisplayParty(
   role: StakeholderType,
-  metadata?: ProjectMetadataLD,
+  metadata?: ProjectMetadataLD | CFCProjectMetadataLD,
   party?: Maybe<PartyFieldsFragment>,
 ): Party | undefined {
   const showOnProjectPage = metadata?.[role]?.['regen:showOnProjectPage'];

--- a/web-registry/src/pages/ProjectReview/ProjectReview.tsx
+++ b/web-registry/src/pages/ProjectReview/ProjectReview.tsx
@@ -13,6 +13,8 @@ import { ProcessingModal } from 'web-components/lib/components/modal/ProcessingM
 import { TxErrorModal } from 'web-components/lib/components/modal/TxErrorModal';
 import { UrlType } from 'web-components/lib/utils/schemaURL';
 
+import { VCSProjectMetadataLD } from 'generated/json-ld';
+
 import { Link } from '../../components/atoms';
 import { ProjectPageFooter } from '../../components/molecules';
 import { OnboardingFormTemplate } from '../../components/templates';
@@ -196,7 +198,7 @@ export const ProjectReview: React.FC = () => {
         onEditClick={() => navigate(`${editPath}/metadata`)}
       >
         {isVCS ? (
-          <VCSMetadata metadata={metadata} />
+          <VCSMetadata metadata={metadata as VCSProjectMetadataLD} />
         ) : (
           <Box
             sx={theme => ({


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#1366

- add missing start/end date for CFC projects type
- update `CFCProjectMetadataLD` type as it is slightly different for start/end date


---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1. https://deploy-preview-1387--regen-registry.netlify.app/projects/C45-010
2. Check start/end date

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
