### PR TITLE
fix: incorrect availability modal trigger

### DIFF
--- a/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
+++ b/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
@@ -74,6 +74,7 @@ export const BuySellOrderFlow = ({
     setDeliverTxResponse(undefined);
     setError(undefined);
     setIsFlowStarted(false);
+    selectedSellOrderIdRef.current = undefined;
   };
   const handleError = (): void => {
     closeProcessingModal();
@@ -84,6 +85,7 @@ export const BuySellOrderFlow = ({
   ): Promise<void> => {
     closeProcessingModal();
     closeBuyModal();
+    selectedSellOrderIdRef.current = undefined;
   };
   const onTxSuccessButtonClick = (): void => {
     handleTxModalClose();

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
@@ -157,7 +157,9 @@ export const Storefront = (): JSX.Element => {
     selectedSellOrderIdRef.current = undefined;
     refetchSellOrders();
   };
-  const handleError = (): void => setIsProcessingModalOpen(false);
+  const handleError = (): void => {
+    setIsProcessingModalOpen(false);
+  };
   const handleTxModalClose = (): void => {
     setCardItems(undefined);
     setTxModalTitle('');
@@ -165,6 +167,7 @@ export const Storefront = (): JSX.Element => {
     setDeliverTxResponse(undefined);
     setError(undefined);
     setSelectedAction(undefined);
+    selectedSellOrderIdRef.current = undefined;
   };
 
   const handleCancelModalClose = (): void => {


### PR DESCRIPTION
## Description

- fix incorrect availability modal trigger

Video of issue: https://www.loom.com/share/5a5cf4519d6c4e8a9212eb18782613df 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
