### PR TITLE
fix: prevent card items to shrink on tx modal

### DIFF
--- a/web-components/src/components/modal/TxModal.tsx
+++ b/web-components/src/components/modal/TxModal.tsx
@@ -121,6 +121,9 @@ const TxModal: React.FC<TxModalProps> = ({
       </Title>
       <Card
         sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          flexShrink: 0,
           width: '100%',
           px: { sm: 7.75, xs: 5.5 },
           py: { sm: 9, xs: 7.5 },


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1305

- Prevent card items to shrink on tx modal

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood` and `hambach` (see below)

#### Setting up backport PRs

After merging your PR to `master`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR, `@Mergifyio backport redwood hambach`.

2. If your branch does have merge commits:

    a. Pull latest `master`, `hambach` and `redwood` branches

    b. Create new branches for backports and merge `master` (replace `<PR#>` with your PR #)
    ```
    git checkout -b hambach-backport-<PR#> hambach
    git merge master
    git push origin hambach-backport-<PR#>
    git checkout -b redwood-backport-<PR#> redwood
    git merge master
    git push origin redwood-backport-<PR#>`
    ```

    c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.
  

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
