### PR TITLE
fix: filter user batches with current balance

### DIFF
--- a/web-registry/src/hooks/useEcocredits.ts
+++ b/web-registry/src/hooks/useEcocredits.ts
@@ -15,6 +15,14 @@ import { client as sanityClient } from '../sanity';
 import useEcocreditQuery from './useEcocreditQuery';
 import useQueryBalances from './useQueryBalances';
 
+const hasBatchBalance = (batchWithBalance: BatchInfoWithBalance): boolean => {
+  return (
+    batchWithBalance?.balance?.tradableAmount !== '0' ||
+    batchWithBalance.balance.retiredAmount !== '0' ||
+    batchWithBalance.balance.escrowedAmount !== '0'
+  );
+};
+
 type Props = {
   address?: string;
   paginationParams?: TablePaginationParams;
@@ -37,6 +45,7 @@ export default function useEcocredits({ address, paginationParams }: Props): {
   const { balancesResponse, fetchBalances } = useQueryBalances({
     address,
   });
+
   const { data: sanityCreditClassData } = useAllCreditClassQuery({
     client: sanityClient,
   });
@@ -49,20 +58,22 @@ export default function useEcocredits({ address, paginationParams }: Props): {
       sanityCreditClassData &&
       !credits
     ) {
-      const initialCredits = balancesResponse?.balances.map(balance => {
-        const batch = batchesResponse?.data?.batches.find(
-          batch => batch.denom === balance.batchDenom,
-        ) as BatchInfo;
+      const initialCredits = balancesResponse?.balances
+        .map(balance => {
+          const batch = batchesResponse?.data?.batches.find(
+            batch => batch.denom === balance.batchDenom,
+          ) as BatchInfo;
 
-        return {
-          ...batch,
-          balance,
-          className: '',
-          classId: '',
-          projectName: '',
-          projectLocation: '',
-        };
-      });
+          return {
+            ...batch,
+            balance,
+            className: '',
+            classId: '',
+            projectName: '',
+            projectLocation: '',
+          };
+        })
+        .filter(hasBatchBalance);
 
       if (initialCredits) {
         setCredits(initialCredits);


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1238

* Add predicate function `hasBatchBalance` to filter the user's batches that currently have a balance (ie some amount such as tradable, retired, or escrowed). We want to hide the cases in which the user had only tradable credits but deposited them all in a basket.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
- [ ] once the PR is closed, set up backport PRs for `redwood`, `hambach` and optionally `master` (see below)

#### Setting up backport PRs

After merging your PR to `dev`, set up backports by doing the following:

1. If your branch does not have merge commits, add the following comment to
   your PR:

- If PR is a new feature: `@Mergifyio backport redwood hambach`.
- If PR is a bug fix: `@Mergifyio backport redwood hambach master`.

2. If your branch does have merge commits:

   a. Pull latest `dev`, `hambach` and `redwood` branches

   b. Create new branches for backports and merge `dev` (replace `<PR#>` with your PR #)

   ```
   git checkout -b hambach-backport-<PR#> hambach
   git merge dev
   git push origin hambach-backport-<PR#>
   git checkout -b redwood-backport-<PR#> redwood
   git merge dev
   git push origin redwood-backport-<PR#>`
   ```

   c. Open new PRs in regen-web targeting `hambach` and `redwood`, respectively.

   d. If PR is a bug fix repeat the same process for `master` branch.

### How to test

1. https://deploy-preview-1529--regen-registry.netlify.app/ecocredits/dashboard

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
