### PR TITLE
feat: add StatCard and StatsCardsSection

### DIFF
--- a/web-components/src/components/atoms/dummy/Dummy.tsx
+++ b/web-components/src/components/atoms/dummy/Dummy.tsx
@@ -1,5 +1,7 @@
 import { Box, SxProps } from '@mui/material';
 
+import { sxToArray } from 'src/utils/mui/sxToArray';
+
 import { Theme } from '../../../theme/muiTheme';
 import { DummyVariant } from './Dummy.types';
 import { DummyVariantSizeMapping } from './Dummy.utils';
@@ -14,7 +16,7 @@ export interface Props {
 To be used as a starter to create new components  */
 const Dummy = ({ label, variant, sx = [] }: Props): JSX.Element => {
   return (
-    <Box sx={[...(Array.isArray(sx) ? sx : [sx])]}>
+    <Box sx={[...sxToArray(sx)]}>
       <Box sx={{ fontSize: DummyVariantSizeMapping[variant] }}>{label}</Box>
     </Box>
   );

--- a/web-components/src/components/molecules/StatCard/StatCard.stories.tsx
+++ b/web-components/src/components/molecules/StatCard/StatCard.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { StatCard } from './StatCard';
+
+export default {
+  title: 'molecules/StatCard',
+  component: StatCard,
+} as ComponentMeta<typeof StatCard>;
+
+const Template: ComponentStory<typeof StatCard> = args => (
+  <StatCard {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {
+  label: 'Carbon credits retired',
+  stat: '588,448',
+  description: 'Our unique ecocredits are high-quality and industry-leading.',
+  image: { src: '/illustrations/carbon-credit.svg' },
+};

--- a/web-components/src/components/molecules/StatCard/StatCard.tsx
+++ b/web-components/src/components/molecules/StatCard/StatCard.tsx
@@ -1,0 +1,41 @@
+import { Box, SxProps } from '@mui/material';
+
+import { BlockContent } from 'src/components/block-content';
+import { Body, Label, Title } from 'src/components/typography';
+
+import { Theme } from '../../../theme/muiTheme';
+import { StatCardType } from './StatCard.types';
+
+type Props = {
+  sx?: SxProps<Theme>;
+} & StatCardType;
+
+const StatCard = ({ label, stat, description, image, sx = [] }: Props) => (
+  <Box
+    sx={[
+      {
+        px: { xs: 5, sm: 7.5 },
+        py: { xs: 7.5, sm: 12.5 },
+        borderRadius: '20px',
+        background: `url(${image.src}), linear-gradient(204.4deg, #EEF1F3 5.94%, #F1F9F6 51.92%, #F9FBF8 97.89%);`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'bottom 0 right 0',
+        border: theme => `1px solid ${theme.palette.info.light}`,
+      },
+      ...(Array.isArray(sx) ? sx : [sx]),
+    ]}
+  >
+    <Box>
+      <Label size="xs" sx={{ mb: 2.5, color: 'info.dark' }}>
+        {label}
+      </Label>
+      <Title variant="h2" as="div" sx={{ mb: 5.5 }}>
+        {stat}
+      </Title>
+      <Body size="lg" as="div" sx={{ maxWidth: 355 }}>
+        <BlockContent content={description} />
+      </Body>
+    </Box>
+  </Box>
+);
+export { StatCard };

--- a/web-components/src/components/molecules/StatCard/StatCard.tsx
+++ b/web-components/src/components/molecules/StatCard/StatCard.tsx
@@ -1,8 +1,7 @@
 import { Box, SxProps } from '@mui/material';
 
-import { BlockContent } from 'src/components/block-content';
-import { Body, Label, Title } from 'src/components/typography';
-
+import { BlockContent } from '../../../components/block-content';
+import { Body, Label, Title } from '../../../components/typography';
 import { Theme } from '../../../theme/muiTheme';
 import { StatCardType } from './StatCard.types';
 

--- a/web-components/src/components/molecules/StatCard/StatCard.types.ts
+++ b/web-components/src/components/molecules/StatCard/StatCard.types.ts
@@ -3,6 +3,6 @@ import { ImageType } from '../../../types/shared/imageType';
 export type StatCardType = {
   label: string;
   stat: string;
-  description: string;
+  description: string | JSX.Element;
   image: ImageType;
 };

--- a/web-components/src/components/molecules/StatCard/StatCard.types.ts
+++ b/web-components/src/components/molecules/StatCard/StatCard.types.ts
@@ -1,0 +1,8 @@
+import { ImageType } from '../../../types/shared/imageType';
+
+export type StatCardType = {
+  label: string;
+  stat: string;
+  description: string;
+  image: ImageType;
+};

--- a/web-components/src/components/molecules/StatCard/index.ts
+++ b/web-components/src/components/molecules/StatCard/index.ts
@@ -1,0 +1,1 @@
+export { StatCard as default } from './StatCard';

--- a/web-components/src/components/organisms/Section/Section.tsx
+++ b/web-components/src/components/organisms/Section/Section.tsx
@@ -5,9 +5,10 @@ import ReactHtmlParser from 'html-react-parser';
 import { Theme } from '../../../theme/muiTheme';
 import { sxToArray } from '../../../utils/mui/sxToArray';
 import { BlockContent } from '../../block-content';
-import { Body, Title } from '../../typography';
+import { Body, Label, Title } from '../../typography';
 
 export interface SectionProps {
+  label?: string;
   title?: string | JSX.Element;
   description?: string | JSX.Element;
   backgroundImage?: string;
@@ -15,10 +16,12 @@ export interface SectionProps {
   sx?: {
     container?: SxProps<Theme>;
     section?: SxProps<Theme>;
+    title?: SxProps<Theme>;
   };
 }
 
 const Section = ({
+  label,
   title,
   description,
   backgroundImage,
@@ -49,7 +52,15 @@ const Section = ({
         ]}
       >
         <Box>
-          <Title variant="h2" sx={{ textAlign: 'center' }}>
+          {label && (
+            <Label size="md" sx={{ mb: 2.5, color: 'info.main' }}>
+              {label}
+            </Label>
+          )}
+          <Title
+            variant="h2"
+            sx={[{ textAlign: 'center' }, ...sxToArray(sx?.title)]}
+          >
             {title}
           </Title>
           {description && (

--- a/web-components/src/components/organisms/Section/Section.tsx
+++ b/web-components/src/components/organisms/Section/Section.tsx
@@ -17,6 +17,7 @@ export interface SectionProps {
     container?: SxProps<Theme>;
     section?: SxProps<Theme>;
     title?: SxProps<Theme>;
+    children?: SxProps<Theme>;
   };
 }
 
@@ -84,7 +85,9 @@ const Section = ({
             </Body>
           )}
         </Box>
-        <Box sx={{ mt: { xs: 10, sm: 14 } }}>{children}</Box>
+        <Box sx={[{ mt: { xs: 10, sm: 14 } }, ...sxToArray(sx?.children)]}>
+          {children}
+        </Box>
       </Box>
     </Box>
   );

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.constants.ts
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.constants.ts
@@ -1,0 +1,2 @@
+export const STAT_CARDS_GRID_COLUMNS = 12;
+export const STAT_CARDS_GRID_CARDS_BY_ROW = 2;

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.mock.ts
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.mock.ts
@@ -1,0 +1,31 @@
+import { StatCardType } from '../../../components/molecules/StatCard/StatCard.types';
+
+export const statCardsMock: StatCardType[] = [
+  {
+    label: 'Carbon credits retired',
+    stat: '588,448',
+    description: 'Our unique ecocredits are high-quality and industry-leading.',
+    image: { src: '/illustrations/carbon-credit.svg' },
+  },
+  {
+    label: 'new credits in 2023',
+    stat: '2M+',
+    description:
+      'Regen Registry is stewarding dozens of new projects and credit standards. ',
+    image: { src: '/illustrations/carbon-credit.svg' },
+  },
+  {
+    label: 'hectares of land',
+    stat: '15M+',
+    description:
+      'We work with project developers across the globe. See what’s being Built on Regen→',
+    image: { src: '/illustrations/carbon-credit.svg' },
+  },
+  {
+    label: 'methodologies under development',
+    stat: '40+',
+    description:
+      'Our unique methodologies measure ecological change in various ecosystems.',
+    image: { src: '/illustrations/carbon-credit.svg' },
+  },
+];

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.stories.tsx
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { StatCardsSection } from './StatCardsSection';
+import { statCardsMock } from './StatCardsSection.mock';
+
+export default {
+  title: 'organisms/StatCardsSection',
+  component: StatCardsSection,
+} as ComponentMeta<typeof StatCardsSection>;
+
+const Template: ComponentStory<typeof StatCardsSection> = args => (
+  <StatCardsSection {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = {
+  label: 'Stats',
+  title: 'Our impact',
+  cards: [...statCardsMock, ...statCardsMock],
+};

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.tsx
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.tsx
@@ -1,0 +1,59 @@
+import { Box, SxProps } from '@mui/material';
+
+import StatCard from 'src/components/molecules/StatCard';
+import { StatCardType } from 'src/components/molecules/StatCard/StatCard.types';
+
+import { Theme } from '../../../theme/muiTheme';
+import Section from '../Section';
+import { STAT_CARDS_GRID_COLUMNS } from './StatCardsSection.constants';
+import { getGridAreas, getGridTemplateAreas } from './StatCardsSection.utils';
+
+export interface StatCardsSectionProps {
+  label?: string;
+  title?: string | JSX.Element;
+  cards: StatCardType[];
+  sx?: SxProps<Theme>;
+}
+
+const StatCardsSection = ({
+  label,
+  title,
+  cards,
+  sx,
+}: StatCardsSectionProps) => {
+  return (
+    <Section
+      label={label}
+      title={title}
+      sx={{ container: sx, title: { textAlign: 'left' } }}
+    >
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: 'auto',
+            md: `repeat(${STAT_CARDS_GRID_COLUMNS}, 1fr)`,
+          },
+          gridTemplateRows: 'auto',
+          gridTemplateAreas: {
+            xs: 'none',
+            md: getGridTemplateAreas({
+              itemsCount: cards.length,
+            }),
+          },
+          gap: '23px',
+        }}
+      >
+        {cards.map(card => (
+          <StatCard
+            key={card.label}
+            sx={getGridAreas({ itemsCount: STAT_CARDS_GRID_COLUMNS })}
+            {...card}
+          />
+        ))}
+      </Box>
+    </Section>
+  );
+};
+
+export { StatCardsSection };

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.tsx
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.tsx
@@ -1,8 +1,7 @@
 import { Box, SxProps } from '@mui/material';
 
-import StatCard from 'src/components/molecules/StatCard';
-import { StatCardType } from 'src/components/molecules/StatCard/StatCard.types';
-
+import StatCard from '../../../components/molecules/StatCard';
+import { StatCardType } from '../../../components/molecules/StatCard/StatCard.types';
 import { Theme } from '../../../theme/muiTheme';
 import Section from '../Section';
 import { STAT_CARDS_GRID_COLUMNS } from './StatCardsSection.constants';

--- a/web-components/src/components/organisms/StatCardsSection/StatCardsSection.utils.ts
+++ b/web-components/src/components/organisms/StatCardsSection/StatCardsSection.utils.ts
@@ -1,0 +1,39 @@
+import { SxProps } from '@mui/system';
+
+import { Theme } from '../../../theme/muiTheme';
+import { STAT_CARDS_GRID_CARDS_BY_ROW } from './StatCardsSection.constants';
+
+type GetGridTemplateAreasParams = {
+  itemsCount: number;
+};
+
+export const getGridTemplateAreas = ({
+  itemsCount,
+}: GetGridTemplateAreasParams) => {
+  const rowsCount = Math.ceil(itemsCount / STAT_CARDS_GRID_CARDS_BY_ROW);
+  return Array.from({ length: rowsCount })
+    .map((_, rowIndex) => {
+      const isEven = rowIndex % STAT_CARDS_GRID_CARDS_BY_ROW === 0;
+      const c1 = rowIndex * STAT_CARDS_GRID_CARDS_BY_ROW + 1;
+      const c2 = rowIndex * STAT_CARDS_GRID_CARDS_BY_ROW + 2;
+      return isEven
+        ? `"card${c1} card${c1} card${c1} card${c1} card${c2} card${c2} card${c2} card${c2} card${c2} card${c2} card${c2} card${c2}"`
+        : `"card${c1} card${c1} card${c1} card${c1} card${c1} card${c1} card${c1} card${c1} card${c2} card${c2} card${c2} card${c2}"`;
+    })
+    .join(' ');
+};
+
+type GetGridAreasParams = {
+  itemsCount: number;
+};
+export const getGridAreas = ({ itemsCount }: GetGridAreasParams) => {
+  return Array.from({ length: itemsCount }).reduce<
+    Record<string, SxProps<Theme>>
+  >((previousValue, _, currentIndex) => {
+    previousValue[`:nth-child(n+${currentIndex + 1})`] = {
+      gridArea: { xs: '', md: `card${currentIndex + 1}` },
+    };
+
+    return previousValue;
+  }, {});
+};

--- a/web-components/src/components/organisms/StatCardsSection/index.ts
+++ b/web-components/src/components/organisms/StatCardsSection/index.ts
@@ -1,0 +1,1 @@
+export { StatCardsSection as default } from './StatCardsSection';

--- a/web-components/src/components/sliders/ResponsiveSlider.tsx
+++ b/web-components/src/components/sliders/ResponsiveSlider.tsx
@@ -28,6 +28,7 @@ export interface ResponsiveSliderProps {
   dots?: boolean;
   onChange?: (i: number) => void;
   visibleOverflow?: boolean;
+  adaptiveHeight?: boolean;
 }
 
 interface StyleProps {
@@ -153,6 +154,7 @@ export default function ResponsiveSlider({
   dots = false,
   onChange,
   visibleOverflow = false,
+  adaptiveHeight = false,
 }: ResponsiveSliderProps): JSX.Element {
   const theme = useTheme();
   const [currSlide, setCurrSlide] = useState(0);
@@ -266,6 +268,7 @@ export default function ResponsiveSlider({
         afterChange={i => {
           if (onChange) onChange(i);
         }}
+        adaptiveHeight={adaptiveHeight}
       >
         {items.map((item, index) => (
           <div className={styles.item} key={index}>

--- a/web-components/src/components/sliders/ResponsiveSlider.tsx
+++ b/web-components/src/components/sliders/ResponsiveSlider.tsx
@@ -21,6 +21,7 @@ export interface ResponsiveSliderProps {
     root?: string;
     title?: string;
     headerWrap?: string;
+    slider?: string;
   };
   padding?: string | number;
   itemWidth?: string;
@@ -261,7 +262,7 @@ export default function ResponsiveSlider({
       <Slider
         {...settings}
         ref={slider}
-        className={styles.slider}
+        className={cx(styles.slider, classes?.slider)}
         beforeChange={(_, newIdx) => {
           setCurrSlide(newIdx);
         }}

--- a/web-components/src/components/sliders/ResponsiveSlider.tsx
+++ b/web-components/src/components/sliders/ResponsiveSlider.tsx
@@ -168,10 +168,10 @@ export default function ResponsiveSlider({
   const slides: number = gridView
     ? 2
     : desktop
-    ? slidesToShow || items.length
+    ? slidesToShow ?? items.length
     : mobile
     ? 1
-    : Math.min(items.length, 2);
+    : Math.min(slidesToShow ?? items.length, 2);
 
   const { classes: styles, cx } = useStyles({
     gridView,

--- a/web-storybook/public/illustrations/carbon-credit.svg
+++ b/web-storybook/public/illustrations/carbon-credit.svg
@@ -1,0 +1,41 @@
+<svg width="300" height="180" viewBox="0 0 300 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_792_15484)">
+<g clip-path="url(#clip1_792_15484)">
+<path d="M237.385 39.1554C274.245 61.3497 288.206 19.2627 288.206 19.2627C264.526 3.76135 240.812 13.0648 237.385 39.1554Z" fill="url(#paint0_linear_792_15484)"/>
+<path d="M218.302 68.3792C176.49 78.4947 175.777 34.1542 175.777 34.1542C203.011 26.47 222.848 42.4603 218.302 68.3792Z" fill="url(#paint1_linear_792_15484)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M214.551 7.91704C213.969 7.32771 213.02 7.32195 212.43 7.90417C211.841 8.48639 211.835 9.43612 212.417 10.0255C219.579 17.275 224.942 26.7047 226.252 39.7381C227.164 48.8122 226.116 59.6875 222.277 72.8466C217.191 58.4859 206.164 51.828 193.397 44.1189L193.088 43.9325C192.379 43.5041 191.457 43.7316 191.029 44.4405C190.601 45.1495 190.829 46.0715 191.538 46.4999C205.785 55.1032 216.708 61.7113 220.675 77.9789C219.243 82.2926 217.527 86.837 215.499 91.6273C215.176 92.3902 215.533 93.2704 216.296 93.5934C217.059 93.9163 217.939 93.5596 218.262 92.7967C225.205 76.3928 228.622 62.6686 229.39 51.0863C229.491 50.9828 229.578 50.863 229.647 50.7283C238.479 33.5704 257.034 26.8357 271.828 24.9212C272.65 24.8149 273.23 24.0627 273.124 23.2413C273.018 22.4198 272.265 21.8401 271.444 21.9464C257.532 23.7467 239.739 29.7684 229.552 44.9885C229.523 43.0755 229.417 41.2264 229.237 39.4382C227.852 25.6553 222.146 15.6042 214.551 7.91704Z" fill="url(#paint2_linear_792_15484)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M196.893 89.8926L221.368 153.897C212.768 157.178 217.924 155.211 209.324 158.492C197.015 163.189 181.558 152.668 174.799 134.994C168.041 117.319 172.54 99.1842 184.85 94.4877C193.441 91.2099 188.295 93.1731 196.893 89.8926Z" fill="url(#paint3_linear_792_15484)"/>
+<ellipse cx="34.2911" cy="23.7085" rx="34.2911" ry="23.7085" transform="matrix(0.357196 0.934125 -0.934221 0.356444 219.765 81.1315)" fill="url(#paint4_linear_792_15484)"/>
+</g>
+</g>
+<defs>
+<linearGradient id="paint0_linear_792_15484" x1="273.853" y1="9.23169" x2="246.552" y2="34.1787" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A8BCC1"/>
+<stop offset="0.5" stop-color="#BCE1D4"/>
+<stop offset="1" stop-color="#DFECDA"/>
+</linearGradient>
+<linearGradient id="paint1_linear_792_15484" x1="192.475" y1="28.8907" x2="211.044" y2="60.8827" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A8BCC1"/>
+<stop offset="0.5" stop-color="#BCE1D4"/>
+<stop offset="1" stop-color="#DFECDA"/>
+</linearGradient>
+<linearGradient id="paint2_linear_792_15484" x1="236.043" y1="11.462" x2="186.313" y2="86.0906" gradientUnits="userSpaceOnUse">
+<stop offset="0.00458717" stop-color="#7BC796"/>
+<stop offset="1" stop-color="#C5E6D1"/>
+</linearGradient>
+<linearGradient id="paint3_linear_792_15484" x1="202.934" y1="104.41" x2="176.281" y2="148.286" gradientUnits="userSpaceOnUse">
+<stop offset="0.447472" stop-color="#FFF6DE"/>
+<stop offset="1" stop-color="#F5E9CE"/>
+</linearGradient>
+<linearGradient id="paint4_linear_792_15484" x1="15.7305" y1="-0.589977" x2="57.6722" y2="41.3288" gradientUnits="userSpaceOnUse">
+<stop offset="0.447472" stop-color="#FFECBC"/>
+<stop offset="1" stop-color="#ECD59F"/>
+</linearGradient>
+<clipPath id="clip0_792_15484">
+<path d="M0 0H300V161C300 171.493 291.493 180 281 180H0V0Z" fill="white"/>
+</clipPath>
+<clipPath id="clip1_792_15484">
+<rect width="168.127" height="168.127" fill="white" transform="translate(150.456 -15) rotate(10.0904)"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## Description

Part of: regen-network/regen-web#1793

Add 2 new components needed for the home page revamp:
- StatCard
- StatsCardsSection (infinite grid of StatCard)

The content of this PR will also be added to `react-17` branch.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-1811--regen-storybook.netlify.app/?path=/story/organisms-statcardssection--default

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
