### PR TITLE
fix: use new regen IRI for compacting credit class metadata

### DIFF
--- a/web-registry/src/lib/db/api/metadata-graph.ts
+++ b/web-registry/src/lib/db/api/metadata-graph.ts
@@ -3,11 +3,14 @@ import axios from 'axios';
 import getApiUri from 'lib/apiUri';
 import { jsonLdCompact } from 'lib/rdf';
 
-export const getMetadata = async (iri?: string): Promise<any> => {
+export const getMetadata = async (
+  iri?: string,
+  context?: object,
+): Promise<any> => {
   if (!iri) return null;
   try {
     const { data } = await axios.get(`${getApiUri()}/metadata-graph/${iri}`);
-    return await jsonLdCompact(data);
+    return await jsonLdCompact(data, context);
   } catch (err) {
     return null;
   }

--- a/web-registry/src/lib/rdf/rdf.compact.ts
+++ b/web-registry/src/lib/rdf/rdf.compact.ts
@@ -5,9 +5,10 @@ import { COMPACTED_CONTEXT } from './rdf.constants';
 
 export const jsonLdCompact = async (
   data: JsonLdDocument,
+  context?: object,
 ): Promise<NodeObject> => {
   return await jsonld.compact(
     data,
-    JSON.parse(JSON.stringify(COMPACTED_CONTEXT)),
+    JSON.parse(JSON.stringify({ ...COMPACTED_CONTEXT, ...context })),
   );
 };

--- a/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
+++ b/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
@@ -94,7 +94,9 @@ function CreditClassDetails({
           const classInfo = res?.class;
           if (classInfo) {
             setOnChainClass(classInfo);
-            const data = await getMetadata(classInfo.metadata);
+            const data = await getMetadata(classInfo.metadata, {
+              regen: 'https://schema.regen.network',
+            });
             setMetadata(data);
           }
         } catch (err) {

--- a/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
+++ b/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
@@ -95,7 +95,7 @@ function CreditClassDetails({
           if (classInfo) {
             setOnChainClass(classInfo);
             const data = await getMetadata(classInfo.metadata, {
-              regen: 'https://schema.regen.network',
+              regen: 'https://schema.regen.network#',
             });
             setMetadata(data);
           }


### PR DESCRIPTION
## Description

Ref: https://regen-network.slack.com/archives/C01LX9E8QN8/p1679596011497989

**HOTFIX**
**IMPORTANT NOTE: per our [Release process document](https://www.notion.so/regennetwork/Release-process-for-regen-web-3dce8a42813b466fa46d44e8723a3b62?pvs=4#3406c219896c4d3eaba9f1a14e1b5fc8), this shouldn't be merged here via Github UI but manually once approved.**

The new credit class metadata updates related to the regen IRI prefix change have been broadcasted but the front-end code is not yet ready to support it (in prod) since it's still expecting `regen` to be `http://regen.network/` instead of the new `https://schema.regen.network#` (see related PR: https://github.com/regen-network/regen-web/pull/1820 that will be included as part of the next release).
This is a hotfix to set the JSON-LD compaction to use `https://schema.regen.network#` for `regen` on the credit class page only.


cc/ @clevinson @S4mmyb @erikalogie 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

Metadata has been updated on redwood for C02:
https://deploy-preview-1831--regen-registry.netlify.app/credit-classes/C02

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
