### PR TITLE
fix: hide ecocredit batch when no balance

### DIFF
--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
@@ -133,15 +133,22 @@ export const useFetchEcocredits = ({
   // Normalization
   // isLoading -> undefined: return empty strings in normalizer to trigger skeleton
   // !isLoading -> null/result: return results with field value different from empty strings and stop displaying the skeletons
-  const credits = balances.map((balance, index) =>
-    normalizeEcocredits({
-      balance,
-      batch: isBatchesLoading ? undefined : batches[index]?.batch,
-      metadata: isMetadatasLoading ? undefined : metadatas[index],
-      project: isProjectsLoading ? undefined : projects[index]?.project,
-      sanityCreditClassData: creditClassData,
-    }),
-  );
+  const credits = balances
+    .filter(
+      balance =>
+        balance.escrowedAmount !== '0' ||
+        balance.retiredAmount !== '0' ||
+        balance.tradableAmount !== '0',
+    )
+    .map((balance, index) =>
+      normalizeEcocredits({
+        balance,
+        batch: isBatchesLoading ? undefined : batches[index]?.batch,
+        metadata: isMetadatasLoading ? undefined : metadatas[index],
+        project: isProjectsLoading ? undefined : projects[index]?.project,
+        sanityCreditClassData: creditClassData,
+      }),
+    );
 
   const paginationParamsWithCount = useMemo(
     () => ({ ...paginationParams, count: allBalancesCount }),


### PR DESCRIPTION
## Description

Closes: #1848

- hide ecocredits when the user has a balance of 0 of all 3 fields (tradable, retired, escrowed).

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. go to https://deploy-preview-1853--regen-registry.netlify.app/ecocredits/accounts/regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46/portfolio
2. Check that there's no line in the table without value on all 3 balance columns

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
