### PR TITLE
fix: display profile header on public page

### DIFF
--- a/web-registry/src/apollo.tsx
+++ b/web-registry/src/apollo.tsx
@@ -29,19 +29,12 @@ export const AuthApolloProvider = ({
     credentials: 'include',
   });
   // https://www.apollographql.com/docs/react/api/link/apollo-link-context/#overview
-  const authLink = setContext(
-    (_, { headers }) =>
-      new Promise((success, fail) => {
-        if (query.isFetched && query.data) {
-          success({
-            headers: {
-              ...headers,
-              'X-CSRF-TOKEN': query.data,
-            },
-          });
-        }
-      }),
-  );
+  const authLink = setContext((_, { headers }) => ({
+    headers: {
+      ...headers,
+      'X-CSRF-TOKEN': query.data,
+    },
+  }));
 
   const defaultOptions: DefaultOptions = {
     watchQuery: {
@@ -60,6 +53,7 @@ export const AuthApolloProvider = ({
     link,
     defaultOptions,
   });
+
   return (
     <ApolloProvider client={apolloClientFactory.getClient()}>
       {children}

--- a/web-registry/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-registry/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -1,16 +1,24 @@
 import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  useApolloClient,
+} from '@apollo/client';
 import Box from '@mui/material/Box';
 import { useTheme } from '@mui/styles';
+import { useQuery } from '@tanstack/react-query';
 
 import Header from 'web-components/lib/components/header';
 import { UserMenuItem } from 'web-components/lib/components/header/components/UserMenuItem';
 import { Theme } from 'web-components/lib/theme/muiTheme';
 import { truncate } from 'web-components/lib/utils/truncate';
 
+import { getPartyByAddrQuery } from 'lib/queries/react-query/registry-server/graphql/getPartyByAddrQuery/getPartyByAddrQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
-import DefaultAvatar from '../../../assets/avatar.png';
+import { usePartyInfos } from 'pages/ProfileEdit/hooks/usePartyInfos';
+
 import { chainId } from '../../../lib/ledger';
 import { RegistryIconLink, RegistryNavLink } from '../../atoms';
 import { WalletButton } from '../WalletButton/WalletButton';
@@ -34,6 +42,18 @@ const RegistryLayoutHeader: React.FC = () => {
     [pathname, theme],
   );
 
+  const graphqlClient =
+    useApolloClient() as ApolloClient<NormalizedCacheObject>;
+
+  const { data: partyByAddr } = useQuery(
+    getPartyByAddrQuery({
+      client: graphqlClient,
+      addr: wallet?.address ?? '',
+      enabled: !!wallet?.address && !!graphqlClient,
+    }),
+  );
+  const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
+
   const color = headerColors[pathname]
     ? headerColors[pathname]
     : theme.palette.primary.light;
@@ -56,7 +76,7 @@ const RegistryLayoutHeader: React.FC = () => {
             {chainId && loaded && isConnected && disconnect && (
               <UserMenuItem
                 address={truncate(wallet?.address)}
-                avatar={DefaultAvatar}
+                avatar={party?.image ? party?.image : defaultAvatar}
                 disconnect={disconnect}
                 pathname={pathname}
                 linkComponent={RegistryNavLink}

--- a/web-registry/src/pages/Dashboard/Dashboard.tsx
+++ b/web-registry/src/pages/Dashboard/Dashboard.tsx
@@ -15,8 +15,6 @@ import { CreditBatchIcon } from 'web-components/lib/components/icons/CreditBatch
 import { CreditClassIcon } from 'web-components/lib/components/icons/CreditClassIcon';
 import CreditsIcon from 'web-components/lib/components/icons/CreditsIcon';
 import { ProjectPageIcon } from 'web-components/lib/components/icons/ProjectPageIcon';
-import TwitterIcon2 from 'web-components/lib/components/icons/social/TwitterIcon2';
-import WebsiteLinkIcon from 'web-components/lib/components/icons/social/WebsiteLinkIcon';
 import { ProfileHeader } from 'web-components/lib/components/organisms/ProfileHeader/ProfileHeader';
 import { SocialLink } from 'web-components/lib/components/organisms/ProfileHeader/ProfileHeader.types';
 import { IconTabProps } from 'web-components/lib/components/tabs/IconTab';
@@ -42,6 +40,7 @@ import { useQueryIfIssuer } from 'hooks/useQueryIfIssuer';
 import { useQueryIfProjectAdmin } from 'hooks/useQueryIfProjectAdmin';
 
 import { dashBoardStyles } from './Dashboard.styles';
+import { getSocialsLinks } from './Dashboard.utils';
 
 const Dashboard = (): JSX.Element => {
   const theme = useTheme();
@@ -64,6 +63,11 @@ const Dashboard = (): JSX.Element => {
     }),
   );
   const { party, defaultAvatar } = usePartyInfos({ accountId, partyByAddr });
+
+  const socialsLinks: SocialLink[] = useMemo(
+    () => getSocialsLinks({ partyByAddr }),
+    [partyByAddr],
+  );
 
   const tabs: IconTabProps[] = useMemo(
     () => [
@@ -114,23 +118,6 @@ const Dashboard = (): JSX.Element => {
       .filter(tab => !tab.hidden)
       .findIndex(tab => location.pathname.includes(tab.href ?? '')),
     0,
-  );
-
-  const socialsLinks: SocialLink[] = useMemo(
-    () =>
-      [
-        {
-          href: party?.twitterLink,
-          icon: <TwitterIcon2 />,
-        },
-        {
-          href: party?.websiteLink,
-          icon: <WebsiteLinkIcon />,
-        },
-      ].filter((link): link is SocialLink => {
-        return !!link.href;
-      }),
-    [party?.twitterLink, party?.websiteLink],
   );
 
   return (

--- a/web-registry/src/pages/Dashboard/Dashboard.tsx
+++ b/web-registry/src/pages/Dashboard/Dashboard.tsx
@@ -62,7 +62,7 @@ const Dashboard = (): JSX.Element => {
       enabled: !!wallet?.address && !!graphqlClient,
     }),
   );
-  const { party, defaultAvatar } = usePartyInfos({ accountId, partyByAddr });
+  const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
 
   const socialsLinks: SocialLink[] = useMemo(
     () => getSocialsLinks({ partyByAddr }),

--- a/web-registry/src/pages/Dashboard/Dashboard.utils.tsx
+++ b/web-registry/src/pages/Dashboard/Dashboard.utils.tsx
@@ -1,0 +1,28 @@
+import TwitterIcon2 from 'web-components/lib/components/icons/social/TwitterIcon2';
+import WebsiteLinkIcon from 'web-components/lib/components/icons/social/WebsiteLinkIcon';
+import { SocialLink } from 'web-components/lib/components/organisms/ProfileHeader/ProfileHeader.types';
+
+import { PartyByAddrQuery } from 'generated/graphql';
+
+type GetSocialsLinksParams = {
+  partyByAddr?: PartyByAddrQuery | null;
+};
+
+export const getSocialsLinks = ({
+  partyByAddr,
+}: GetSocialsLinksParams): SocialLink[] => {
+  const party = partyByAddr?.walletByAddr?.partyByWalletId;
+
+  return [
+    {
+      href: party?.twitterLink,
+      icon: <TwitterIcon2 />,
+    },
+    {
+      href: party?.websiteLink,
+      icon: <WebsiteLinkIcon />,
+    },
+  ].filter((link): link is SocialLink => {
+    return !!link.href;
+  });
+};

--- a/web-registry/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-registry/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -19,7 +19,6 @@ import { truncate } from 'web-components/lib/utils/truncate';
 
 import { getAccountUrl } from 'lib/block-explorer';
 import { getPartyByAddrQuery } from 'lib/queries/react-query/registry-server/graphql/getPartyByAddrQuery/getPartyByAddrQuery';
-import { useWallet } from 'lib/wallet/wallet';
 
 import { getSocialsLinks } from 'pages/Dashboard/Dashboard.utils';
 import { usePartyInfos } from 'pages/ProfileEdit/hooks/usePartyInfos';

--- a/web-registry/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-registry/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -37,7 +37,6 @@ export const EcocreditsByAccount = (): JSX.Element => {
   const { accountAddress } = useParams<{ accountAddress: string }>();
   const theme = useTheme();
   const location = useLocation();
-  const { wallet, accountId } = useWallet();
 
   const graphqlClient =
     useApolloClient() as ApolloClient<NormalizedCacheObject>;
@@ -45,11 +44,11 @@ export const EcocreditsByAccount = (): JSX.Element => {
   const { data: partyByAddr } = useQuery(
     getPartyByAddrQuery({
       client: graphqlClient,
-      addr: wallet?.address ?? '',
-      enabled: !!wallet?.address && !!graphqlClient,
+      addr: accountAddress ?? '',
+      enabled: !!accountAddress && !!graphqlClient,
     }),
   );
-  const { party, defaultAvatar } = usePartyInfos({ accountId, partyByAddr });
+  const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
 
   const socialsLinks = useMemo(
     () => getSocialsLinks({ partyByAddr }),
@@ -88,8 +87,8 @@ export const EcocreditsByAccount = (): JSX.Element => {
         avatar={party?.image ? party?.image : defaultAvatar}
         infos={{
           addressLink: {
-            href: getAccountUrl(wallet?.address, true),
-            text: truncate(wallet?.address),
+            href: getAccountUrl(accountAddress, true),
+            text: truncate(accountAddress),
           },
           description: party?.description?.trimEnd() ?? '',
           socialsLinks,

--- a/web-registry/src/pages/ProfileEdit/ProfileEdit.tsx
+++ b/web-registry/src/pages/ProfileEdit/ProfileEdit.tsx
@@ -37,7 +37,7 @@ import {
 
 export const ProfileEdit = () => {
   const setBannerTextAtom = useSetAtom(bannerTextAtom);
-  const { wallet, accountId } = useWallet();
+  const { wallet } = useWallet();
   const [updatePartyById] = useUpdatePartyByIdMutation();
   const graphqlClient =
     useApolloClient() as ApolloClient<NormalizedCacheObject>;
@@ -53,7 +53,7 @@ export const ProfileEdit = () => {
     [graphqlClient, wallet?.address],
   );
   const { data: partyByAddr, isFetching } = useQuery(partyByAddrQuery);
-  const { party, defaultAvatar } = usePartyInfos({ accountId, partyByAddr });
+  const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
 
   const initialValues: EditProfileFormSchemaType = useMemo(
     () => ({

--- a/web-registry/src/pages/ProfileEdit/hooks/usePartyInfos.tsx
+++ b/web-registry/src/pages/ProfileEdit/hooks/usePartyInfos.tsx
@@ -7,12 +7,10 @@ import {
 
 type Params = {
   partyByAddr?: PartyByAddrQuery | null;
-  accountId?: string;
 };
 
-export const usePartyInfos = ({ partyByAddr, accountId }: Params) => {
-  const partyData = partyByAddr?.walletByAddr?.partyByWalletId;
-  const party = accountId === partyData?.accountId ? partyData : undefined;
+export const usePartyInfos = ({ partyByAddr }: Params) => {
+  const party = partyByAddr?.walletByAddr?.partyByWalletId;
   const isOrganization = party?.type === PartyType.Organization;
   const defaultAvatar = isOrganization
     ? DEFAULT_PROFILE_COMPANY_AVATAR


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1645

- Display profile on the public account page
- Use avatar from profile in the header
- fix a race condition in Apollo client init

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. Default public profile: https://deploy-preview-1857--regen-registry.netlify.app/ecocredits/accounts/regen1typewgr0qksjl0m2r0cal530zl0g835wsunxna/portfolio
2. Shared account public profile: https://deploy-preview-1857--regen-registry.netlify.app/ecocredits/accounts/regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46/portfolio

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
