### PR TITLE
fix: project card on credit class page

### DIFF
--- a/web-registry/src/components/organisms/ProjectCards.tsx
+++ b/web-registry/src/components/organisms/ProjectCards.tsx
@@ -87,16 +87,10 @@ const ProjectCards: React.FC<React.PropsWithChildren<Props>> = props => {
       imageStorageBaseUrl={imageStorageBaseUrl}
       apiServerUrl={apiServerUrl}
       place={project.metadata?.['schema:location']?.place_name}
-      area={
-        project.metadata?.['regen:projectSize']?.['qudt:numericValue']?.[
-          '@value'
-        ]
-      }
+      area={project.metadata?.['regen:projectSize']?.['qudt:numericValue']}
       areaUnit={
         QUDT_UNIT_MAP[
-          project.metadata?.['regen:projectSize']?.['qudt:unit']?.[
-            '@value'
-          ] as qudtUnit
+          project.metadata?.['regen:projectSize']?.['qudt:unit'] as qudtUnit
         ]
       }
       track={track}

--- a/web-registry/src/lib/queries/react-query/registry-server/graphql/getMoreProjectsQuery/getMoreProjectsQuery.ts
+++ b/web-registry/src/lib/queries/react-query/registry-server/graphql/getMoreProjectsQuery/getMoreProjectsQuery.ts
@@ -1,0 +1,30 @@
+import { MoreProjectsDocument, MoreProjectsQuery } from 'generated/graphql';
+import { jsonLdCompact } from 'lib/rdf';
+
+import {
+  ReactQueryGetMoreProjectsParams,
+  ReactQueryGetMoreProjectsResponse,
+} from './getMoreProjectsQuery.types';
+
+export const getMoreProjectsQuery = ({
+  client,
+  ...params
+}: ReactQueryGetMoreProjectsParams): ReactQueryGetMoreProjectsResponse => ({
+  queryKey: ['MoreProjectsQuery'],
+  queryFn: async () => {
+    const { data } = await client.query<MoreProjectsQuery>({
+      query: MoreProjectsDocument,
+    });
+
+    await Promise.all(
+      data?.allProjects?.nodes?.map(async project => {
+        if (project?.metadata) {
+          project.metadata = await jsonLdCompact(project.metadata);
+        }
+        return project;
+      }) || [],
+    );
+    return data;
+  },
+  ...params,
+});

--- a/web-registry/src/lib/queries/react-query/registry-server/graphql/getMoreProjectsQuery/getMoreProjectsQuery.types.ts
+++ b/web-registry/src/lib/queries/react-query/registry-server/graphql/getMoreProjectsQuery/getMoreProjectsQuery.types.ts
@@ -1,0 +1,13 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { QueryObserverOptions } from '@tanstack/react-query';
+
+import { MoreProjectsQuery } from 'generated/graphql';
+
+import { ReactQueryBuilderResponse } from '../../../types/react-query.types';
+
+export type ReactQueryGetMoreProjectsResponse =
+  QueryObserverOptions<MoreProjectsQuery>;
+
+export type ReactQueryGetMoreProjectsParams = {
+  client: ApolloClient<NormalizedCacheObject>;
+} & ReactQueryBuilderResponse<ReactQueryGetMoreProjectsResponse>;

--- a/web-registry/src/lib/rdf/rdf.constants.ts
+++ b/web-registry/src/lib/rdf/rdf.constants.ts
@@ -21,6 +21,9 @@ export const UNANCHORED_PROJECT_CONTEXT = {
   'regen:videoURL': {
     '@type': 'schema:URL',
   },
+  'schema:url': {
+    '@type': 'schema:URL',
+  },
 };
 
 export const ANCHORED_PROJECT_CONTEXT = {

--- a/web-registry/src/pages/CreditClassDetails/CreditClassDetailsWithContent/CreditClassDetailsWithContent.tsx
+++ b/web-registry/src/pages/CreditClassDetails/CreditClassDetailsWithContent/CreditClassDetailsWithContent.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  useApolloClient,
+} from '@apollo/client';
+import { useQuery } from '@tanstack/react-query';
 import { makeStyles } from 'tss-react/mui';
 
 import Banner from 'web-components/lib/components/banner';
@@ -11,10 +17,11 @@ import Section from 'web-components/lib/components/section';
 import { Body } from 'web-components/lib/components/typography';
 import { Theme } from 'web-components/lib/theme/muiTheme';
 
-import { CreditClassByUriQuery, useMoreProjectsQuery } from 'generated/graphql';
+import { CreditClassByUriQuery } from 'generated/graphql';
 import { CreditClass } from 'generated/sanity-graphql';
 import { apiUri } from 'lib/apiUri';
 import { onBtnClick } from 'lib/button';
+import { getMoreProjectsQuery } from 'lib/queries/react-query/registry-server/graphql/getMoreProjectsQuery/getMoreProjectsQuery';
 
 import { HeroTitle } from 'components/molecules';
 import {
@@ -98,9 +105,15 @@ const CreditClassDetailsWithContent: React.FC<
   const [submitted, setSubmitted] = useState(false);
   const { classes: styles, cx } = useStyles();
   const navigate = useNavigate();
+  const graphqlClient =
+    useApolloClient() as ApolloClient<NormalizedCacheObject>;
 
   const { creditClassId } = useParams();
-  const { data: projectsData } = useMoreProjectsQuery();
+  const { data: projectsData } = useQuery(
+    getMoreProjectsQuery({
+      client: graphqlClient,
+    }),
+  );
 
   const getFeaturedProjects = (): JSX.Element => {
     const featuredProjects = projectsData?.allProjects?.nodes?.filter(project =>
@@ -123,17 +136,17 @@ const CreditClassDetailsWithContent: React.FC<
   };
 
   const getAllProjects = (): JSX.Element => {
-    const projects = projectsData?.allProjects?.nodes?.filter(
+    const allProjects = projectsData?.allProjects?.nodes?.filter(
       project =>
         project?.creditClassByCreditClassId?.uri === content.iri?.current,
     );
 
-    return projects && projects.length > 0 ? (
+    return allProjects && allProjects.length > 0 ? (
       <div className="topo-background-alternate">
         <MoreProjectsSection
           classes={{ root: styles.sectionPadding, title: styles.title }}
           title={content.buyer?.projectsTitle || 'More Projects'}
-          projects={projects}
+          projects={allProjects}
         />
       </div>
     ) : (


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1699

A quicker fix would have been just to add `@value` to `project.metadata?.['regen:previewPhoto']?.['schema:url']` in https://github.com/regen-network/regen-web/blob/1956f70d788c79718992caeb048f199f64295ae3/web-registry/src/components/organisms/ProjectCards.tsx#L84 (since the incoming project metadata wasn't compacted which was causing the error) but decided to migrate the `MoreProjects` query to use react-query and compact the project metadata from there so it's more efficient and more consistent with our way to deal with jsonld metadata.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
