### PR TITLE
fix: use base denom as fallback

### DIFF
--- a/web-registry/src/components/molecules/DenomLabel/DenomLabel.tsx
+++ b/web-registry/src/components/molecules/DenomLabel/DenomLabel.tsx
@@ -14,11 +14,17 @@ import { findDisplayDenom } from './DenomLabel.utils';
 
 export interface Props {
   size: LabelSize;
-  denom: string;
+  bankDenom: string;
+  baseDenom?: string;
   sx?: SxProps<Theme>;
 }
 
-const DenomLabel = ({ denom, size, sx = [] }: Props): JSX.Element => {
+const DenomLabel = ({
+  bankDenom,
+  baseDenom,
+  size,
+  sx = [],
+}: Props): JSX.Element => {
   const { marketplaceClient } = useLedger();
   const { data: allowedDenomsData, isLoading: isLoadingAllowedDenoms } =
     useQuery(
@@ -30,7 +36,8 @@ const DenomLabel = ({ denom, size, sx = [] }: Props): JSX.Element => {
 
   const displayDenom = findDisplayDenom({
     allowedDenomsData,
-    denom,
+    bankDenom,
+    baseDenom,
   });
 
   return (

--- a/web-registry/src/components/molecules/DenomLabel/DenomLabel.utils.ts
+++ b/web-registry/src/components/molecules/DenomLabel/DenomLabel.utils.ts
@@ -2,22 +2,24 @@ import { QueryAllowedDenomsResponse } from '@regen-network/api/lib/generated/reg
 import { UPPERCASE_DENOM } from 'config/allowedBaseDenoms';
 
 type Params = {
-  denom: string;
+  bankDenom: string;
+  baseDenom?: string;
   allowedDenomsData?: QueryAllowedDenomsResponse;
 };
 
 export const findDisplayDenom = ({
   allowedDenomsData,
-  denom,
+  bankDenom,
+  baseDenom,
 }: Params): string => {
   const allowedDenom = allowedDenomsData?.allowedDenoms?.find(
-    allowedDenom => allowedDenom.bankDenom === denom,
+    allowedDenom => allowedDenom.bankDenom === bankDenom,
   );
-  const displayDenom = allowedDenom?.displayDenom;
+  const displayDenom = allowedDenom?.displayDenom ?? baseDenom;
   const result =
-    displayDenom && UPPERCASE_DENOM.includes(denom)
+    displayDenom && UPPERCASE_DENOM.includes(baseDenom ?? bankDenom)
       ? displayDenom.toUpperCase()
       : displayDenom;
 
-  return result ?? denom;
+  return result ?? bankDenom;
 };

--- a/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.tsx
+++ b/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.tsx
@@ -298,7 +298,8 @@ const BuyCreditsModal: React.FC<React.PropsWithChildren<BuyCreditsModalProps>> =
                             selectedSellOrder?.askAmount || '',
                           )} ${findDisplayDenom({
                             allowedDenomsData,
-                            denom: selectedSellOrder?.askDenom ?? '',
+                            bankDenom: selectedSellOrder?.askDenom ?? '',
+                            baseDenom: selectedSellOrder?.askBaseDenom,
                           })}/credit`}
                         </Body>
                         <Body
@@ -335,7 +336,8 @@ const BuyCreditsModal: React.FC<React.PropsWithChildren<BuyCreditsModalProps>> =
                                 askAmount: Number(selectedSellOrder?.askAmount),
                                 displayDenom: findDisplayDenom({
                                   allowedDenomsData,
-                                  denom: selectedSellOrder?.askDenom ?? '',
+                                  bankDenom: selectedSellOrder?.askDenom ?? '',
+                                  baseDenom: selectedSellOrder?.askBaseDenom,
                                 }),
                                 userBalance,
                               })}
@@ -379,12 +381,8 @@ const BuyCreditsModal: React.FC<React.PropsWithChildren<BuyCreditsModalProps>> =
                                   })}
                                 </Title>
                                 <DenomLabel
-                                  denom={
-                                    findDisplayDenom({
-                                      allowedDenomsData,
-                                      denom: selectedSellOrder?.askDenom ?? '',
-                                    }) ?? ''
-                                  }
+                                  bankDenom={selectedSellOrder?.askDenom ?? ''}
+                                  baseDenom={selectedSellOrder?.askBaseDenom}
                                   size="sm"
                                   sx={{ color: 'info.dark' }}
                                 />

--- a/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.utils.tsx
+++ b/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.utils.tsx
@@ -62,13 +62,14 @@ export const getSellOrderLabel = ({
   allowedDenomsData,
   setSelectedProjectById,
 }: GetSellOrderLabelParams): JSX.Element => {
-  const { id, askAmount, askDenom, quantity, batchDenom } = {
+  const { id, askAmount, askDenom, askBaseDenom, quantity, batchDenom } = {
     ...sellOrder,
   };
   const price = microToDenom(askAmount);
   const displayDenom = findDisplayDenom({
     allowedDenomsData,
-    denom: askDenom,
+    bankDenom: askDenom,
+    baseDenom: askBaseDenom,
   });
   const truncatedQuantity = floorFloatNumber(parseFloat(quantity));
 

--- a/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.Row.tsx
+++ b/web-registry/src/components/organisms/SellOrdersTable/SellOrdersTable.Row.tsx
@@ -60,7 +60,8 @@ const getSellOrdersTableRow = ({
       iconSx={{ fontSize: '30px' }}
     />
     <DenomLabel
-      denom={askDenom}
+      bankDenom={askDenom}
+      baseDenom={askBaseDenom}
       size="sm"
       sx={{
         fontSize: { xs: '1rem' },

--- a/web-registry/src/config/allowedBaseDenoms.ts
+++ b/web-registry/src/config/allowedBaseDenoms.ts
@@ -10,4 +10,4 @@ export const REGEN_DENOM = 'uregen';
 export const USD_DENOMS = [GRAVITY_USDC_DENOM, AXELAR_USDC_DENOM];
 export const EUR_DENOMS = [EEUR_DENOM];
 export const CAPITALIZED_DENOM = [];
-export const UPPERCASE_DENOM = [REGEN_DENOM];
+export const UPPERCASE_DENOM = [REGEN_DENOM, EEUR_DENOM];


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1705

- fix EEUR denom display
- use `baseDenom`from `denomTrace` as fallback a denom label can't be found in the allowed list

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-1910--regen-registry.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
