### PR TITLE
feat: disable OTC flow for community credits

### DIFF
--- a/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.tsx
+++ b/web-registry/src/components/organisms/BuyCreditsModal/BuyCreditsModal.tsx
@@ -83,6 +83,7 @@ interface BuyCreditsModalProps extends RegenModalProps {
   setSelectedProjectById?: (projectId: string) => void;
   apiServerUrl?: string;
   imageStorageBaseUrl?: string;
+  isCommunityCredit?: boolean;
 }
 
 export interface BuyCreditsProject {
@@ -119,6 +120,7 @@ const BuyCreditsModal: React.FC<React.PropsWithChildren<BuyCreditsModalProps>> =
     setSelectedProjectById, // if several projects involved, handler to select the project when sell order is selected
     apiServerUrl,
     imageStorageBaseUrl,
+    isCommunityCredit = false,
   }) => {
     const { classes, cx } = useBuyCreditsModalStyles();
     const theme = useTheme();
@@ -184,7 +186,7 @@ const BuyCreditsModal: React.FC<React.PropsWithChildren<BuyCreditsModalProps>> =
           >
             {'Buy Ecocredits'}
           </Title>
-          {buyModalContent && (
+          {buyModalContent && !isCommunityCredit && (
             <BuyCreditsModalInfoCard
               content={buyModalContent.allBuyModal[0]}
               sx={{ mb: 12.5 }}

--- a/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
+++ b/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
@@ -30,7 +30,6 @@ import {
   IMAGE_STORAGE_BASE_URL,
   MAPBOX_TOKEN,
 } from 'components/templates/ProjectDetails/ProjectDetails.config';
-import { findSanityCreditClass } from 'components/templates/ProjectDetails/ProjectDetails.utils';
 
 import { getSanityImgSrc } from '../../../lib/imgSrc';
 import { ProjectTopLink } from '../../atoms';
@@ -55,7 +54,7 @@ function ProjectTopSection({
   onChainProject,
   projectMetadata,
   projectPageMetadata,
-  sanityCreditClassData,
+  creditClassSanity,
   geojson,
   isGISFile,
   onChainProjectId,
@@ -84,7 +83,7 @@ function ProjectTopSection({
   );
   const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
 
-  const { creditClass, creditClassVersion, offsetGenerationMethod } =
+  const { creditClass, offsetGenerationMethod } =
     parseOffChainProject(offChainProject);
 
   const { projectName, area, areaUnit, placeName, projectMethodology } =
@@ -123,14 +122,6 @@ function ProjectTopSection({
         !!ecocreditClient && !!creditClassOnChain?.class?.creditTypeAbbrev,
     }),
   );
-
-  const creditClassSanity = findSanityCreditClass({
-    sanityCreditClassData,
-    creditClassIdOrUrl:
-      creditClass?.onChainId ??
-      creditClassVersion?.metadata?.['schema:url'] ??
-      onChainProjectId?.split('-')?.[0], // if no offChain credit class
-  });
 
   const displayName =
     projectName ?? (onChainProjectId && `Project ${onChainProjectId}`) ?? '';

--- a/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.types.ts
+++ b/web-registry/src/components/organisms/ProjectTopSection/ProjectTopSection.types.ts
@@ -21,7 +21,7 @@ export type ProjectTopSectionProps = {
   onChainProject?: ProjectInfo;
   projectMetadata?: AnchoredProjectMetadataLD | LegacyProjectMetadataLD;
   projectPageMetadata?: ProjectPageMetadataLD;
-  sanityCreditClassData?: AllCreditClassQuery;
+  creditClassSanity?: AllCreditClassQuery['allCreditClass'][0];
   geojson?: any;
   isGISFile?: boolean;
   onChainProjectId?: string;

--- a/web-registry/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-registry/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -49,6 +49,7 @@ import { ManagementActions } from './ProjectDetails.ManagementActions';
 import { MemoizedMoreProjects as MoreProjects } from './ProjectDetails.MoreProjects';
 import { getMediaBoxStyles } from './ProjectDetails.styles';
 import {
+  findSanityCreditClass,
   getDisplayParty,
   getIsOnChainId,
   getProjectGalleryPhotos,
@@ -160,7 +161,9 @@ function ProjectDetails(): JSX.Element {
     offChainProjectMetadata,
     managementActions,
     projectDocs,
+    creditClass,
     creditClassName,
+    creditClassVersion,
     coBenefitsIris,
     primaryImpactIRI,
   } = parseOffChainProject(offChainProject as Maybe<Project>);
@@ -211,6 +214,15 @@ function ProjectDetails(): JSX.Element {
   const { credits, isSellFlowDisabled } = useCreateSellOrderData({
     projectId: projectsWithOrderData[0]?.id,
   });
+
+  const creditClassSanity = findSanityCreditClass({
+    sanityCreditClassData,
+    creditClassIdOrUrl:
+      creditClass?.onChainId ??
+      creditClassVersion?.metadata?.['schema:url'] ??
+      onChainProjectId?.split('-')?.[0], // if no offChain credit class
+  });
+  const isCommunityCredit = !creditClassSanity;
 
   const creditsWithProjectName = useMemo(() => {
     if (!credits || credits.length === 0 || !projectsWithOrderData[0]) return;
@@ -280,7 +292,7 @@ function ProjectDetails(): JSX.Element {
         onChainProject={onChainProject}
         projectMetadata={projectMetadata}
         projectPageMetadata={offChainProjectMetadata}
-        sanityCreditClassData={sanityCreditClassData}
+        creditClassSanity={creditClassSanity}
         geojson={geojson}
         isGISFile={isGISFile}
         onChainProjectId={onChainProjectId}
@@ -350,6 +362,7 @@ function ProjectDetails(): JSX.Element {
 
       <BuySellOrderFlow
         isFlowStarted={isBuyFlowStarted}
+        isCommunityCredit={isCommunityCredit}
         setIsFlowStarted={setIsBuyFlowStarted}
         projects={
           projectsWithOrderData?.length > 0

--- a/web-registry/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
+++ b/web-registry/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
@@ -4,6 +4,7 @@ import { Asset } from 'web-components/lib/components/sliders/ProjectMedia';
 import { Party } from 'web-components/lib/components/user/UserInfo';
 
 import {
+  CreditClass,
   Document,
   Maybe,
   PartyFieldsFragment,
@@ -54,6 +55,7 @@ type ParseOffChainProjectReturn = {
   offChainProjectMetadata?: ProjectPageMetadataLD & LegacyProjectMetadataLD;
   managementActions?: NameImageDescription[];
   projectDocs?: Maybe<Document>[];
+  creditClass?: Maybe<CreditClass>;
   creditClassVersion?: any;
   creditClassName?: string;
   coBenefitsIris?: string[];
@@ -69,6 +71,7 @@ export const parseOffChainProject = (
 
   const projectDocs = project?.documentsByProjectId?.nodes;
 
+  const creditClass = project?.creditClassByCreditClassId;
   const creditClassVersion =
     project?.creditClassByCreditClassId?.creditClassVersionsById?.nodes?.[0];
 
@@ -83,6 +86,7 @@ export const parseOffChainProject = (
     offChainProjectMetadata,
     managementActions,
     projectDocs,
+    creditClass,
     creditClassVersion,
     creditClassName,
     coBenefitsIris,

--- a/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
+++ b/web-registry/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
@@ -34,6 +34,7 @@ import { useSelectedProject } from './hooks/useSelectedProject';
 
 type Props = {
   isFlowStarted: boolean;
+  isCommunityCredit?: boolean;
   setIsFlowStarted: UseStateSetter<boolean>;
   projects?: ProjectWithOrderData[] | null | undefined;
   track?: Track;
@@ -43,6 +44,7 @@ type Props = {
 export const BuySellOrderFlow = ({
   projects,
   isFlowStarted,
+  isCommunityCredit = false,
   setIsFlowStarted,
   track,
   location,
@@ -68,6 +70,13 @@ export const BuySellOrderFlow = ({
   const { data: buyModalOptionsContent } = useQuery(
     getBuyModalOptionsQuery({ sanityClient: client }),
   );
+  const buyModalOptions = buyModalOptionsContent?.allBuyModalOptions[0];
+  const buyModalOptionsFiltered = isCommunityCredit
+    ? {
+        ...buyModalOptions,
+        cards: buyModalOptions?.cards?.slice(1, buyModalOptions?.cards?.length),
+      }
+    : buyModalOptions;
 
   const closeBuyModal = (): void => {
     setIsBuyModalOpen(false);
@@ -227,9 +236,10 @@ export const BuySellOrderFlow = ({
         setSelectedProjectById={
           projects && projects?.length > 1 ? setSelectedProjectById : undefined
         }
+        isCommunityCredit={isCommunityCredit}
       />
       <BuyModalOptions
-        content={buyModalOptionsContent?.allBuyModalOptions[0]}
+        content={buyModalOptionsFiltered}
         open={isBuyModalOptionsOpen}
         onClose={() => {
           setIsFlowStarted(false);

--- a/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
+++ b/web-registry/src/pages/CreditClassDetails/CreditClassDetails.tsx
@@ -51,6 +51,7 @@ function CreditClassDetails({
   const content = contentData?.allCreditClass?.find(
     creditClass => creditClass.path === creditClassId,
   );
+  const isCommunityCredit = !content;
 
   const isOnChainClassId =
     creditClassId && onChainClassRegExp.test(creditClassId);
@@ -158,6 +159,7 @@ function CreditClassDetails({
       />
       <BuySellOrderFlow
         isFlowStarted={isBuyFlowStarted}
+        isCommunityCredit={isCommunityCredit}
         setIsFlowStarted={setIsBuyFlowStarted}
         projects={projectsWithOrderData}
       />

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
@@ -186,6 +186,9 @@ export const Storefront = (): JSX.Element => {
     disableAutoRetire,
   } = normalizedSellOrders[selectedSellOrder ?? 0] ?? {};
 
+  // Community credits are identified by the presence of a credit class in sanity.
+  // If the field classIdOrName is the same as the on chain classId then it means that there is no associated credit class in sanity.
+  // In that case we assume that the credit is a community credit.
   const isCommunityCredit = project?.classId === project?.classIdOrName;
 
   const initialValues = useMemo(

--- a/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
+++ b/web-registry/src/pages/Marketplace/Storefront/Storefront.tsx
@@ -186,6 +186,8 @@ export const Storefront = (): JSX.Element => {
     disableAutoRetire,
   } = normalizedSellOrders[selectedSellOrder ?? 0] ?? {};
 
+  const isCommunityCredit = project?.classId === project?.classIdOrName;
+
   const initialValues = useMemo(
     () => ({
       creditCount: 1,
@@ -316,6 +318,7 @@ export const Storefront = (): JSX.Element => {
           id: project?.id ?? '',
         }}
         initialValues={initialValues}
+        isCommunityCredit={isCommunityCredit}
       />
       <ProcessingModal
         open={isProcessingModalOpen}


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1732

Disable OTC flow for community credit for the following pages:
- project details
- credit class

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. Project details: https://deploy-preview-1932--regen-registry.netlify.app/credit-classes/C46
2. Credit class details: https://deploy-preview-1932--regen-registry.netlify.app/project/C46-001 

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
