### PR TITLE
fix: batch balances which didn't always correspond to batches on portfolio ecocredits table

### DIFF
--- a/web-registry/src/components/organisms/BasketOverview/hooks/useBasketPutData.tsx
+++ b/web-registry/src/components/organisms/BasketOverview/hooks/useBasketPutData.tsx
@@ -55,7 +55,7 @@ export const useBasketPutData = (): BasketPutData => {
         balance.batchDenom.startsWith(projectClass),
       ),
     )
-    .filter(credit => credit.tradableAmount !== '0');
+    .filter(credit => Number(credit.tradableAmount) !== 0);
 
   const creditBatchDenoms = creditsPutable?.map(credit => credit.batchDenom);
   const isLoadingPutData = isLoadingBalances || isLoadingBasket;

--- a/web-registry/src/hooks/useBasketTokens.ts
+++ b/web-registry/src/hooks/useBasketTokens.ts
@@ -45,7 +45,7 @@ export default function useBasketTokens(
     );
 
     const withPositiveBalance = (basket: BasketTokens): boolean =>
-      basket.balance?.balance?.amount !== '0';
+      Number(basket.balance?.balance?.amount) !== 0;
 
     setBasketTokens(_basketTokens.filter(withPositiveBalance));
     isFetchingRef.current = false;

--- a/web-registry/src/hooks/useEcocredits.ts
+++ b/web-registry/src/hooks/useEcocredits.ts
@@ -19,9 +19,9 @@ import useQueryBalances from './useQueryBalances';
 
 const hasBatchBalance = (batchWithBalance: BatchInfoWithBalance): boolean => {
   return (
-    batchWithBalance?.balance?.tradableAmount !== '0' ||
-    batchWithBalance.balance.retiredAmount !== '0' ||
-    batchWithBalance.balance.escrowedAmount !== '0'
+    Number(batchWithBalance?.balance?.tradableAmount) !== 0 ||
+    Number(batchWithBalance?.balance?.retiredAmount) !== 0 ||
+    Number(batchWithBalance?.balance?.escrowedAmount) !== 0
   );
 };
 

--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useCreditSendSubmit.tsx
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useCreditSendSubmit.tsx
@@ -132,7 +132,7 @@ const useCreditSendSubmit = ({
               label: 'recipient',
               value: { name: recipient, url: getAccountUrl(recipient) },
             },
-          ].filter(item => item.value.name !== '0'),
+          ].filter(item => Number(item.value.name) !== 0),
         );
         setTxModalHeader(SEND_HEADER);
         setTxModalTitle(creditSendTitle);

--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchBaskets.tsx
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchBaskets.tsx
@@ -92,7 +92,8 @@ export const useFetchBaskets = ({ credits, address }: Params): Response => {
     }))
     .filter(
       basketToken =>
-        basketToken.balance && basketToken.balance?.balance?.amount !== '0',
+        basketToken.balance &&
+        Number(basketToken.balance.balance?.amount) !== 0,
     );
 
   const creditBaskets = normalizeCreditBaskets({

--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
@@ -79,6 +79,12 @@ export const useFetchEcocredits = ({
   const balancesPagination = balancesData?.pagination;
   const allBalancesCount = Number(balancesPagination?.total ?? 0);
 
+  const filteredBalances = balances.filter(
+    balance =>
+      balance.escrowedAmount !== '0' ||
+      balance.retiredAmount !== '0' ||
+      balance.tradableAmount !== '0',
+  );
   const {
     batches,
     isBatchesLoading,
@@ -88,7 +94,7 @@ export const useFetchEcocredits = ({
     isProjectsMetadataLoading,
     classesMetadata,
     isClassesMetadataLoading,
-  } = useBatchesWithMetadata(balances);
+  } = useBatchesWithMetadata(filteredBalances);
 
   // AllCreditClasses
   const { data: creditClassData } = useQuery(
@@ -98,27 +104,20 @@ export const useFetchEcocredits = ({
   // Normalization
   // isLoading -> undefined: return empty strings in normalizer to trigger skeleton
   // !isLoading -> null/result: return results with field value different from empty strings and stop displaying the skeletons
-  const credits = balances
-    .filter(
-      balance =>
-        balance.escrowedAmount !== '0' ||
-        balance.retiredAmount !== '0' ||
-        balance.tradableAmount !== '0',
-    )
-    .map((balance, index) =>
-      normalizeEcocredits({
-        balance,
-        batch: isBatchesLoading ? undefined : batches[index]?.batch,
-        projectMetadata: isProjectsMetadataLoading
-          ? undefined
-          : projectsMetadata[index],
-        project: isProjectsLoading ? undefined : projects[index]?.project,
-        sanityCreditClassData: creditClassData,
-        creditClassMetadata: isClassesMetadataLoading
-          ? undefined
-          : classesMetadata[index],
-      }),
-    );
+  const credits = filteredBalances.map((balance, index) =>
+    normalizeEcocredits({
+      balance,
+      batch: isBatchesLoading ? undefined : batches[index]?.batch,
+      projectMetadata: isProjectsMetadataLoading
+        ? undefined
+        : projectsMetadata[index],
+      project: isProjectsLoading ? undefined : projects[index]?.project,
+      sanityCreditClassData: creditClassData,
+      creditClassMetadata: isClassesMetadataLoading
+        ? undefined
+        : classesMetadata[index],
+    }),
+  );
 
   const paginationParamsWithCount = useMemo(
     () => ({ ...paginationParams, count: allBalancesCount }),

--- a/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
+++ b/web-registry/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
@@ -81,9 +81,9 @@ export const useFetchEcocredits = ({
 
   const filteredBalances = balances.filter(
     balance =>
-      balance.escrowedAmount !== '0' ||
-      balance.retiredAmount !== '0' ||
-      balance.tradableAmount !== '0',
+      Number(balance.escrowedAmount) !== 0 ||
+      Number(balance.retiredAmount) !== 0 ||
+      Number(balance.tradableAmount) !== 0,
   );
   const {
     batches,


### PR DESCRIPTION
## Description

Closes: #1950

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

Use our testing account regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46
Go to https://dev.app.regen.network/ecocredits/portfolio, on the ecocredits table last page (), you should see you have some tradable credits for C01-001-20170607-20220622-022, while your tradable balance for this batch is 0: http://redwood.regen.network:1317/regen/ecocredit/v1/balances/regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46
Go to https://deploy-preview-1979--regen-registry.netlify.app/ecocredits/portfolio, you shouldn't see any row for C01-001-20170607-20220622-022 anymore.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
