### PR TITLE
fix: only display classes that the user is an issuer for on ChooseCreditClass

### DIFF
--- a/web-registry/src/pages/ChooseCreditClass/ChooseCreditClass.Item.tsx
+++ b/web-registry/src/pages/ChooseCreditClass/ChooseCreditClass.Item.tsx
@@ -10,7 +10,6 @@ interface ClassOptionProps {
   title: string;
   imgSrc?: string;
   description?: string;
-  disabled?: boolean;
   onClick: () => void;
 }
 
@@ -19,7 +18,7 @@ interface ClassOptionProps {
 */
 const ChooseCreditClassItem: React.FC<
   React.PropsWithChildren<ClassOptionProps>
-> = ({ title, imgSrc, description, disabled, onClick }) => (
+> = ({ title, imgSrc, description, onClick }) => (
   <Grid item xs={12} sm={6}>
     <ImageActionCard
       btnText="Choose credit class"
@@ -27,7 +26,6 @@ const ChooseCreditClassItem: React.FC<
       imgSrc={imgSrc || DefaultCreditClassImage}
       description={description || ''}
       onClick={onClick}
-      disabled={disabled}
       startIcon={<CreditClassIcon sx={{ mt: '-2px' }} />}
     />
   </Grid>

--- a/web-registry/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
+++ b/web-registry/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
@@ -85,7 +85,6 @@ const ChooseCreditClass: React.FC<React.PropsWithChildren<unknown>> = () => {
               title={creditClassOption.title}
               imgSrc={creditClassOption.imageSrc}
               description={creditClassOption.description}
-              disabled={creditClassOption?.disabled}
               onClick={() =>
                 handleSelection(
                   creditClassOption.id,

--- a/web-registry/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
+++ b/web-registry/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
@@ -60,13 +60,15 @@ function useGetCreditClassOptions(): {
         const title = name
           ? `${name} (${creditClassOnChainId})`
           : creditClassOnChainId;
-
         const { issuers } = await queryClassIssuers(onChainClass.id);
         if (issuers?.includes(wallet.address)) {
           ccOptions.push({
             id: offChainMatch?.id || '',
             onChainId: creditClassOnChainId || '',
-            imageSrc: contentMatch?.image?.image?.asset?.url || '',
+            imageSrc:
+              contentMatch?.image?.image?.asset?.url ||
+              metadata?.['schema:image'] ||
+              '',
             title: title || '',
             description: metadata?.['schema:description'],
           });

--- a/web-registry/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
+++ b/web-registry/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
@@ -46,33 +46,32 @@ function useGetCreditClassOptions(): {
 
       const creditClassesContent = creditClassContentData?.allCreditClass;
 
-      const ccOptions = await Promise.all(
-        onChainClasses?.map(async onChainClass => {
-          const creditClassOnChainId = onChainClass?.id;
-          const contentMatch = creditClassesContent?.find(
-            content => content.path === creditClassOnChainId,
-          );
-          const offChainMatch = offChainClasses.find(
-            offChainClass => offChainClass?.onChainId === creditClassOnChainId,
-          );
-          const metadata = onChainClass?.metadataJson || {};
-          const name = metadata?.['schema:name'];
-          const title = name
-            ? `${name} (${creditClassOnChainId})`
-            : creditClassOnChainId;
-          const { issuers } = await queryClassIssuers(onChainClass.id);
-          const isIssuer = issuers?.includes(wallet.address);
+      let ccOptions: CreditClassOption[] = [];
+      for (const onChainClass of onChainClasses) {
+        const creditClassOnChainId = onChainClass?.id;
+        const contentMatch = creditClassesContent?.find(
+          content => content.path === creditClassOnChainId,
+        );
+        const offChainMatch = offChainClasses.find(
+          offChainClass => offChainClass?.onChainId === creditClassOnChainId,
+        );
+        const metadata = onChainClass?.metadataJson || {};
+        const name = metadata?.['schema:name'];
+        const title = name
+          ? `${name} (${creditClassOnChainId})`
+          : creditClassOnChainId;
 
-          return {
+        const { issuers } = await queryClassIssuers(onChainClass.id);
+        if (issuers?.includes(wallet.address)) {
+          ccOptions.push({
             id: offChainMatch?.id || '',
             onChainId: creditClassOnChainId || '',
             imageSrc: contentMatch?.image?.image?.asset?.url || '',
             title: title || '',
             description: metadata?.['schema:description'],
-            disabled: !isIssuer,
-          };
-        }) || [],
-      );
+          });
+        }
+      }
 
       setCreditClassOptions(ccOptions);
       setLoading(false);


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1758

Also now uses the image from the credit class metadata too as in other places.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. Go to https://deploy-preview-1987--regen-registry.netlify.app/ecocredits/projects and login with an address that is an issuer of at least one credit class
2. Click "Create project"
3. On "Choose credit class" page, you should see the credit classes you're an issuer for (the query is a bit long since it queries for all credit classes and then the issuers for all the credit classes in separate queries and we have quite a lot of credit classes on redwood...)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
