### PR TITLE
fix: remove walletConnect from params in useAddAddress

### DIFF
--- a/web-registry/src/lib/wallet/hooks/useAddAddress.tsx
+++ b/web-registry/src/lib/wallet/hooks/useAddAddress.tsx
@@ -33,7 +33,6 @@ export const useAddAddress = ({
   const addAddress = useCallback(
     async ({
       walletConfig,
-      walletConnect,
       wallet,
       accountId,
       onSuccess,
@@ -46,7 +45,6 @@ export const useAddAddress = ({
           // Get new user wallet
           const walletClient = await walletConfig?.getClient({
             chainInfo,
-            walletConnect,
           });
           const newWallet = await getWallet({ walletClient, walletConfig });
 
@@ -54,7 +52,6 @@ export const useAddAddress = ({
             // Generate the signature for the addresses request
             const signature = await signArbitrary({
               walletConfig,
-              walletConnect,
               wallet: newWallet,
               nonce,
               addAddr: true,


### PR DESCRIPTION
## Description

Removes walletConnect which isn't part of the params anymore
This was an oversight as part of https://github.com/regen-network/regen-web/pull/1976

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
