### PR TITLE
fix: Warning when inputing decimal price values in "Create Sell Order" form

### DIFF
--- a/web-components/src/components/form/CreateSellOrderForm.tsx
+++ b/web-components/src/components/form/CreateSellOrderForm.tsx
@@ -139,8 +139,6 @@ const CreateSellOrderForm: React.FC<React.PropsWithChildren<FormProps>> = ({
                 component={NumberTextField}
                 name="price"
                 label="Price"
-                increment={0.1}
-                min={0.0}
                 arrows={false}
                 errors={errors}
               />

--- a/web-components/src/components/inputs/validation.ts
+++ b/web-components/src/components/inputs/validation.ts
@@ -111,6 +111,9 @@ export function validatePrice(
   if (!price) {
     return requiredMessage;
   }
+  if (Math.sign(price) !== 1) {
+    return invalidAmount;
+  }
   const priceDecimalPlaces = decimalCount(price);
   maximumFractionDigits = maximumFractionDigits || MAX_FRACTION_DIGITS;
   if (!!priceDecimalPlaces && priceDecimalPlaces > maximumFractionDigits) {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1664

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. Go to https://deploy-preview-1996--regen-registry.netlify.app and login with an address that has some credits
2. Go to your /ecocredits/portfolio
3. Try to create a sell order with a decimal price

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
