### PR TITLE
feat: add new website GA4 tag

### DIFF
--- a/web-www/.prettierignore
+++ b/web-www/.prettierignore
@@ -1,0 +1,2 @@
+generated/
+sanity-graphql.schema.json

--- a/web-www/pages/index.tsx
+++ b/web-www/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { InferGetStaticPropsType } from 'next';
+import Script from 'next/script';
 
 import BlogSection from '../components/templates/home/Blog/Home.blog';
 import CarbonplusSection from '../components/templates/home/CarbonPlus/Home.CarbonPlus';
@@ -37,9 +38,26 @@ export default function Home({
   const statsData = allHomePageWeb.homeWebStatsSection;
   const valuesData = allHomePageWeb.valuesSection;
   const ledgerDescription = allHomePageWeb.ledgerDescription;
+  const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
   return (
     <>
+      {GA_MEASUREMENT_ID && (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          />
+          <Script id="google-analytics">
+            {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+          </Script>
+        </>
+      )}
       <Box sx={{ overflow: 'hidden' }}>
         <HomeFoldSection homeFoldData={homeFoldData} />
         <CarbonplusSection carbonPlusData={carbonPlusData} />

--- a/web-www/pages/index.tsx
+++ b/web-www/pages/index.tsx
@@ -49,12 +49,11 @@ export default function Home({
           />
           <Script id="google-analytics">
             {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-
-          gtag('config', '${GA_MEASUREMENT_ID}');
-        `}
+             window.dataLayer = window.dataLayer || [];
+             function gtag(){dataLayer.push(arguments);}
+             gtag('js', new Date());
+             gtag('config', '${GA_MEASUREMENT_ID}');
+           `}
           </Script>
         </>
       )}


### PR DESCRIPTION
## Description

Closes: https://github.com/regen-network/rnd-dev-team/issues/1671

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Adds GA4 tag to web-www via `NEXT_PUBLIC_GA_MEASUREMENT_ID` which will need to be set to `G-N7DHYF5D4J` in production.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. Check out the branch and set the env var
2. Navigate to the Regen Network Website GA4 tag in Google Analytics, go to "realtime"
3. Click around in the local website, and observe your data being collected.

Our tag reported that data collection works with this set up:
![Screen Shot 2023-08-02 at 11 15 17 PM](https://github.com/regen-network/regen-web/assets/10120306/ee369696-35d3-48ca-ad88-0ce3706df575)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
