### PR TITLE
fix: use uppercase for avg pricel label

### DIFF
--- a/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
+++ b/web-components/src/components/cards/ProjectCard/ProjectCard.tsx
@@ -213,7 +213,11 @@ export function ProjectCard({
                           size="xs"
                           mobileSize="xxs"
                           color="info.main"
-                          sx={{ mr: 1, fontWeight: 800 }}
+                          sx={{
+                            mr: 1,
+                            fontWeight: 800,
+                            textTransform: 'uppercase',
+                          }}
                         >
                           {AVG_PRICE_LABEL}
                         </Subtitle>


### PR DESCRIPTION
## Description

regen-network/rnd-dev-team#1771

- use uppercase for avg price label

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2030--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
