### PR TITLE
fix: unable to load project with initial metadata

### DIFF
--- a/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery.ts
+++ b/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery.ts
@@ -29,13 +29,22 @@ export const getProjectByIdQuery = ({
       });
 
       if (projectById.data?.projectById?.metadata) {
-        projectById.data.projectById.metadata = await jsonLdCompact(
-          projectById.data.projectById.metadata,
-        );
+        projectById.data.projectById.metadata = await jsonLdCompact({
+          // NOTE: We set the context here with "schema" and "regen" to prevent
+          // a prefix confusion error when no context is provided and field values
+          // with either prefix are present within the project metadata.
+          '@context': {
+            schema: 'http://schema.org/',
+            regen: 'https://schema.regen.network#',
+          },
+          ...projectById.data.projectById.metadata,
+        });
       }
 
       return projectById;
     } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
       return null;
     }
   },


### PR DESCRIPTION
## Description

Closes: #2039

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The issue with the project creation workflow was the result of an error when compacting project metadata without a context that included the proper references to `schema` and `regen`. This was producing the following error:

![Screenshot from 2023-08-23 17-53-51](https://github.com/regen-network/regen-web/assets/12519942/874238b6-da21-421e-bb2a-c179239fe886)

This is resolved by add `schema` and `regen` to the context before compacting in the event no context is provided.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
