### PR TITLE
feat: credit classes issuers perf

### DIFF
--- a/web-marketplace/src/components/organisms/BasketOverview/hooks/useFetchEcocredit.ts
+++ b/web-marketplace/src/components/organisms/BasketOverview/hooks/useFetchEcocredit.ts
@@ -12,7 +12,7 @@ import { getBatchQuery } from 'lib/queries/react-query/ecocredit/getBatchQuery/g
 import { getClassQuery } from 'lib/queries/react-query/ecocredit/getClassQuery/getClassQuery';
 import { getProjectQuery } from 'lib/queries/react-query/ecocredit/getProjectQuery/getProjectQuery';
 import { getMetadataQuery } from 'lib/queries/react-query/registry-server/getMetadataQuery/getMetadataQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
 interface Response {
@@ -66,7 +66,7 @@ export const useFetchEcocredit = ({ batchDenom }: Props): Response => {
 
   // AllCreditClasses
   const { data: creditClassesData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // Credit Class

--- a/web-marketplace/src/components/organisms/BridgedEcocreditsTable/hooks/useFetchBridgedEcocredits.tsx
+++ b/web-marketplace/src/components/organisms/BridgedEcocreditsTable/hooks/useFetchBridgedEcocredits.tsx
@@ -14,7 +14,7 @@ import { messageActionEquals } from 'lib/ecocredit/constants';
 import { normalizeBridgedEcocredits } from 'lib/normalizers/bridge/normalizeBridgedEcocredits';
 import { getBridgeTxStatusQuery } from 'lib/queries/react-query/bridge/getBridgeTxStatusQuery/getBridgeTxStatusQuery';
 import { getGetTxsEventQuery } from 'lib/queries/react-query/cosmos/bank/getTxsEventQuery/getTxsEventQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { useBatchesWithMetadata } from 'hooks/batches/useBatchesWithMetadata';
 
@@ -57,7 +57,7 @@ export const useFetchBridgedEcocredits = ({ address }: Props): Output => {
 
   // AllCreditClasses
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // TxsEvent

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.loader.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.loader.ts
@@ -8,7 +8,7 @@ import { getAllowedDenomQuery } from 'lib/queries/react-query/ecocredit/marketpl
 import { getSellOrdersExtendedQuery } from 'lib/queries/react-query/ecocredit/marketplace/getSellOrdersExtendedQuery/getSellOrdersExtendedQuery';
 import { getProjectByHandleQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByHandleQuery/getProjectByHandleQuery';
 import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getAllProjectPageQuery } from 'lib/queries/react-query/sanity/getAllProjectPageQuery/getAllProjectPageQuery';
 import { getFromCacheOrFetch } from 'lib/queries/react-query/utils/getFromCacheOrFetch';
 
@@ -32,7 +32,9 @@ export const projectDetailsLoader =
 
     // Queries
     const allProjectPageQuery = getAllProjectPageQuery({ sanityClient });
-    const allCreditClassesQuery = getAllCreditClassesQuery({ sanityClient });
+    const allCreditClassesQuery = getAllSanityCreditClassesQuery({
+      sanityClient,
+    });
     const projectQuery = getProjectQuery({
       request: { projectId },
       client: ecocreditClient,

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -25,7 +25,7 @@ import { getGeocodingQuery } from 'lib/queries/react-query/mapbox/getGeocodingQu
 import { getMetadataQuery } from 'lib/queries/react-query/registry-server/getMetadataQuery/getMetadataQuery';
 import { getProjectByHandleQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByHandleQuery/getProjectByHandleQuery';
 import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getAllProjectPageQuery } from 'lib/queries/react-query/sanity/getAllProjectPageQuery/getAllProjectPageQuery';
 import { getProjectByIdQuery } from 'lib/queries/react-query/sanity/getProjectByIdQuery/getProjectByIdQuery';
 import { getSoldOutProjectsQuery } from 'lib/queries/react-query/sanity/getSoldOutProjectsQuery/getSoldOutProjectsQuery';
@@ -95,7 +95,7 @@ function ProjectDetails(): JSX.Element {
   });
 
   const { data: sanityCreditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   const [isBuyFlowStarted, setIsBuyFlowStarted] = useState(false);

--- a/web-marketplace/src/hooks/batches/usePaginatedBatches.ts
+++ b/web-marketplace/src/hooks/batches/usePaginatedBatches.ts
@@ -9,7 +9,7 @@ import { UseStateSetter } from 'types/react/use-state';
 import { useLedger } from 'ledger';
 import { getAddDataToBatchesQuery } from 'lib/queries/react-query/ecocredit/getAddDataToBatchesQuery/getAddDataToBatchesQuery';
 import { getBatchesQuery } from 'lib/queries/react-query/ecocredit/getBatchesQuery/getBatchesQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { client as sanityClient } from '../../lib/clients/sanity';
 
@@ -35,7 +35,7 @@ export const usePaginatedBatches = (): {
   const { rowsPerPage } = paginationParams;
 
   const sanityCreditClassDataResult = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   /* Fetch current page batches */

--- a/web-marketplace/src/hooks/batches/usePaginatedBatchesByProject.ts
+++ b/web-marketplace/src/hooks/batches/usePaginatedBatchesByProject.ts
@@ -8,7 +8,7 @@ import { UseStateSetter } from 'types/react/use-state';
 import { useLedger } from 'ledger';
 import { getAddDataToBatchesQuery } from 'lib/queries/react-query/ecocredit/getAddDataToBatchesQuery/getAddDataToBatchesQuery';
 import { getBatchesByProjectQuery } from 'lib/queries/react-query/ecocredit/getBatchesByProjectQuery/getBatchesByProjectQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { client as sanityClient } from '../../lib/clients/sanity';
 
@@ -34,7 +34,7 @@ export const usePaginatedBatchesByProject = ({
   const { rowsPerPage, page } = paginationParams;
 
   const sanityCreditClassDataResult = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   /* Fetch current page batches */

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -14,7 +14,7 @@ import { getProjectsQuery } from 'lib/queries/react-query/ecocredit/getProjectsQ
 import { getSellOrdersExtendedQuery } from 'lib/queries/react-query/ecocredit/marketplace/getSellOrdersExtendedQuery/getSellOrdersExtendedQuery';
 import { getMetadataQuery } from 'lib/queries/react-query/registry-server/getMetadataQuery/getMetadataQuery';
 import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
 import { ProjectsSellOrders } from 'pages/Projects/hooks/useProjectsSellOrders.types';
@@ -99,7 +99,7 @@ export function useProjectsWithOrders({
 
   // AllCreditClasses
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   /* Normalization/Filtering/Sorting */

--- a/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassItems.ts
+++ b/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassItems.ts
@@ -5,7 +5,7 @@ import { IndexerClassesByIssuerQuery, Maybe } from 'generated/indexer-graphql';
 import { AllCreditClassQuery } from 'generated/sanity-graphql';
 import { CreditClassMetadataLD } from 'lib/db/types/json-ld';
 
-import { CreditClassOption } from './normalizeCreditClassOptions.types';
+import { CreditClassItem } from './normalizeCreditClassItems.types';
 
 type Params = {
   classesByIssuer?: Maybe<IndexerClassesByIssuerQuery>;
@@ -14,12 +14,12 @@ type Params = {
   offChainCreditClasses?: AllCreditClassesQuery;
 };
 
-export const normalizeCreditClassOptions = ({
+export const normalizeCreditClassItems = ({
   classesByIssuer,
   classesMetadata,
   sanityCreditClasses,
   offChainCreditClasses,
-}: Params): CreditClassOption[] => {
+}: Params): CreditClassItem[] => {
   return (
     classesByIssuer?.allClassIssuers?.nodes.map((creditClass, index) => {
       const metadata = classesMetadata?.[index];

--- a/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassItems.types.ts
+++ b/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassItems.types.ts
@@ -1,4 +1,4 @@
-export interface CreditClassOption {
+export interface CreditClassItem {
   id: string;
   onChainId: string;
   imageSrc: string;

--- a/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassOption.ts
+++ b/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassOption.ts
@@ -1,0 +1,43 @@
+import { getClassImageWithGreenDefault } from 'utils/image/classImage';
+
+import { IndexerClassesByIssuerQuery, Maybe } from 'generated/indexer-graphql';
+import { AllCreditClassQuery } from 'generated/sanity-graphql';
+import { CreditClassMetadataLD } from 'lib/db/types/json-ld';
+
+import { CreditClassOption } from './normalizeCreditClassOptions.types';
+
+type Params = {
+  classesByIssuer?: Maybe<IndexerClassesByIssuerQuery>;
+  classesMetadata?: (CreditClassMetadataLD | undefined)[];
+  sanityCreditClasses?: AllCreditClassQuery;
+};
+
+export const normalizeCreditClassOptions = ({
+  classesByIssuer,
+  classesMetadata,
+  sanityCreditClasses,
+}: Params): CreditClassOption[] => {
+  return (
+    classesByIssuer?.allClassIssuers?.nodes.map((creditClass, index) => {
+      const metadata = classesMetadata?.[index];
+      const creditClassId = creditClass?.classId;
+      const sanityCreditClass = sanityCreditClasses?.allCreditClass.find(
+        sanityCreditClass => sanityCreditClass.path === sanityCreditClass,
+      );
+
+      const name = metadata?.['schema:name'];
+      const title = name ? `${name} (${creditClassId})` : creditClassId;
+
+      return {
+        id: creditClassId ?? '',
+        imageSrc: getClassImageWithGreenDefault({
+          metadata,
+          sanityClass: sanityCreditClass,
+        }),
+        onChainId: creditClassId ?? '',
+        title: title ?? '',
+        description: metadata?.['schema:description'],
+      };
+    }) ?? []
+  );
+};

--- a/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassOptions.types.ts
+++ b/web-marketplace/src/lib/normalizers/creditClass/normalizeCreditClassOptions.types.ts
@@ -1,0 +1,8 @@
+export interface CreditClassOption {
+  id: string;
+  onChainId: string;
+  imageSrc: string;
+  title: string;
+  description?: string;
+  disabled?: boolean;
+}

--- a/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.constants.ts
+++ b/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.constants.ts
@@ -1,0 +1,1 @@
+export const ALL_CREDIT_CLASSES_KEY = 'AllCreditClassesQuery';

--- a/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.ts
+++ b/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.ts
@@ -1,0 +1,25 @@
+import {
+  AllCreditClassesDocument,
+  AllCreditClassesQuery,
+} from 'generated/graphql';
+
+import { ALL_CREDIT_CLASSES_KEY } from './getAllCreditClassesQuery.constants';
+import {
+  ReactQueryGetAllCreditClassesParams,
+  ReactQueryGetAllCreditClassesResponse,
+} from './getAllCreditClassesQuery.types';
+
+export const getAllCreditClassesQuery = ({
+  client,
+  ...params
+}: ReactQueryGetAllCreditClassesParams): ReactQueryGetAllCreditClassesResponse => ({
+  queryKey: [ALL_CREDIT_CLASSES_KEY],
+  queryFn: async () => {
+    const { data } = await client.query<AllCreditClassesQuery>({
+      query: AllCreditClassesDocument,
+    });
+
+    return data;
+  },
+  ...params,
+});

--- a/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.types.ts
+++ b/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery.types.ts
@@ -1,0 +1,13 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { QueryObserverOptions } from '@tanstack/react-query';
+
+import { AllCreditClassesQuery } from 'generated/graphql';
+
+import { ReactQueryBuilderResponse } from '../../../types/react-query.types';
+
+export type ReactQueryGetAllCreditClassesResponse =
+  QueryObserverOptions<AllCreditClassesQuery>;
+
+export type ReactQueryGetAllCreditClassesParams = {
+  client: ApolloClient<NormalizedCacheObject>;
+} & ReactQueryBuilderResponse<ReactQueryGetAllCreditClassesResponse>;

--- a/web-marketplace/src/lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery.ts
+++ b/web-marketplace/src/lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery.ts
@@ -8,7 +8,7 @@ import {
   ReactQueryGetAllCreditClassesResponse,
 } from './getAllCreditClassesQuery.types';
 
-export const getAllCreditClassesQuery = ({
+export const getAllSanityCreditClassesQuery = ({
   sanityClient,
   ...params
 }: ReactQueryGetAllCreditClassesParams): ReactQueryGetAllCreditClassesResponse => ({

--- a/web-marketplace/src/pages/BasketDetails/hooks/useFetchBasketEcocredits.ts
+++ b/web-marketplace/src/pages/BasketDetails/hooks/useFetchBasketEcocredits.ts
@@ -8,7 +8,7 @@ import { UseStateSetter } from 'types/react/use-state';
 import { useLedger } from 'ledger';
 import { client as sanityClient } from 'lib/clients/sanity';
 import { getBasketBalancesQuery } from 'lib/queries/react-query/ecocredit/basket/getBasketBalances/getBasketBalancesQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { useBatchesWithMetadata } from 'hooks/batches/useBatchesWithMetadata';
 
@@ -80,7 +80,7 @@ export const useFetchBasketEcocredits = ({
 
   // AllCreditClasses
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // Normalization

--- a/web-marketplace/src/pages/Buyers/hooks/useFetchProjectsByIds.ts
+++ b/web-marketplace/src/pages/Buyers/hooks/useFetchProjectsByIds.ts
@@ -7,7 +7,7 @@ import { ProjectCardProps } from 'web-components/lib/components/cards/ProjectCar
 import { client as sanityClient } from 'lib/clients/sanity';
 import { normalizeProjectsWithCreditClass } from 'lib/normalizers/projects/normalizeProjectsWithCreditClass';
 import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { useProjectsWithMetadata } from 'hooks/projects/useProjectsWithMetadata';
 
@@ -24,7 +24,7 @@ export const useFetchProjectsByIds = ({ projectIds }: Props): Response => {
   const graphqlClient = useApolloClient();
 
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   const { projects, isProjectsLoading, projectsMetadata, classesMetadata } =

--- a/web-marketplace/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
+++ b/web-marketplace/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
@@ -14,14 +14,14 @@ import { useUpdateProjectByIdMutation } from '../../generated/graphql';
 import { ChooseCreditClassGrid } from './ChooseCreditClass.Grid';
 import { ChooseCreditClassItem } from './ChooseCreditClass.Item';
 import { useErrorTimeout } from './hooks/useErrorTimeout';
-import { useGetCreditClassOptions } from './hooks/useGetCreditClassOptions';
+import { useGetCreditClassItems } from './hooks/useGetCreditClassOptions';
 
 const ChooseCreditClass: React.FC<React.PropsWithChildren<unknown>> = () => {
   const navigate = useNavigate();
   const graphqlClient = useApolloClient();
   const [error, setError] = useErrorTimeout();
   const { projectId } = useParams();
-  const { creditClassOptions, loading } = useGetCreditClassOptions();
+  const { creditClassItems, loading } = useGetCreditClassItems();
   const { setCreditClassId } = useCreateProjectContext();
   const [updateProject] = useUpdateProjectByIdMutation();
   const { data, isFetching } = useQuery(
@@ -72,24 +72,19 @@ const ChooseCreditClass: React.FC<React.PropsWithChildren<unknown>> = () => {
       adminAddr={adminAddr}
     >
       <ChooseCreditClassGrid
-        justifyContent={
-          creditClassOptions?.length > 1 ? 'flex-start' : 'center'
-        }
+        justifyContent={creditClassItems?.length > 1 ? 'flex-start' : 'center'}
         loading={loading}
         error={error}
       >
-        {creditClassOptions?.length > 0 ? (
-          creditClassOptions?.map(creditClassOption => (
+        {creditClassItems?.length > 0 ? (
+          creditClassItems?.map(creditClassItem => (
             <ChooseCreditClassItem
-              key={creditClassOption.onChainId}
-              title={creditClassOption.title}
-              imgSrc={creditClassOption.imageSrc}
-              description={creditClassOption.description}
+              key={creditClassItem.onChainId}
+              title={creditClassItem.title}
+              imgSrc={creditClassItem.imageSrc}
+              description={creditClassItem.description}
               onClick={() =>
-                handleSelection(
-                  creditClassOption.id,
-                  creditClassOption.onChainId,
-                )
+                handleSelection(creditClassItem.id, creditClassItem.onChainId)
               }
             />
           ))

--- a/web-marketplace/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
+++ b/web-marketplace/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
@@ -6,7 +6,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 
 import { client as sanityClient } from 'lib/clients/sanity';
-import { normalizeCreditClassOptions } from 'lib/normalizers/creditClass/normalizeCreditClassOption';
+import { normalizeCreditClassItems } from 'lib/normalizers/creditClass/normalizeCreditClassItems';
 import { getAllCreditClassesQuery } from 'lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getClassesByIssuerQuery } from 'lib/queries/react-query/registry-server/graphql/indexer/getClassesByIssuer/getClassesByIssuer';
 import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
@@ -14,7 +14,7 @@ import { useWallet } from 'lib/wallet/wallet';
 
 import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
 
-interface CreditClassOption {
+interface CreditClassItem {
   id: string;
   onChainId: string;
   imageSrc: string;
@@ -23,8 +23,8 @@ interface CreditClassOption {
   disabled?: boolean;
 }
 
-function useGetCreditClassOptions(): {
-  creditClassOptions: CreditClassOption[];
+function useGetCreditClassItems(): {
+  creditClassItems: CreditClassItem[];
   loading: boolean;
 } {
   const graphqlClient =
@@ -57,14 +57,14 @@ function useGetCreditClassOptions(): {
 
   const { classesMetadata } = useClassesWithMetadata(classIds);
 
-  const creditClassOptions = normalizeCreditClassOptions({
+  const creditClassItems = normalizeCreditClassItems({
     classesByIssuer: classesByIssuerData?.data,
     classesMetadata,
     sanityCreditClasses,
     offChainCreditClasses,
   });
 
-  return { creditClassOptions, loading: isLoading };
+  return { creditClassItems, loading: isLoading };
 }
 
-export { useGetCreditClassOptions };
+export { useGetCreditClassItems };

--- a/web-marketplace/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
+++ b/web-marketplace/src/pages/ChooseCreditClass/hooks/useGetCreditClassOptions.tsx
@@ -7,8 +7,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { client as sanityClient } from 'lib/clients/sanity';
 import { normalizeCreditClassOptions } from 'lib/normalizers/creditClass/normalizeCreditClassOption';
+import { getAllCreditClassesQuery } from 'lib/queries/react-query/registry-server/graphql/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getClassesByIssuerQuery } from 'lib/queries/react-query/registry-server/graphql/indexer/getClassesByIssuer/getClassesByIssuer';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
 import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
@@ -39,8 +40,15 @@ function useGetCreditClassOptions(): {
     }),
   );
 
+  const { data: offChainCreditClasses } = useQuery(
+    getAllCreditClassesQuery({
+      client: graphqlClient,
+      enabled: !!graphqlClient,
+    }),
+  );
+
   const { data: sanityCreditClasses } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   const classIds = classesByIssuerData?.data.allClassIssuers?.nodes.map(
@@ -53,6 +61,7 @@ function useGetCreditClassOptions(): {
     classesByIssuer: classesByIssuerData?.data,
     classesMetadata,
     sanityCreditClasses,
+    offChainCreditClasses,
   });
 
   return { creditClassOptions, loading: isLoading };

--- a/web-marketplace/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
+++ b/web-marketplace/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
@@ -9,7 +9,7 @@ import { UseStateSetter } from 'types/react/use-state';
 import { useLedger } from 'ledger';
 import { normalizeEcocredits } from 'lib/normalizers/ecocredits/normalizeEcocredits';
 import { getBalancesQuery } from 'lib/queries/react-query/ecocredit/getBalancesQuery/getBalancesQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
 import { useBatchesWithMetadata } from '../../../../hooks/batches/useBatchesWithMetadata';
@@ -98,7 +98,7 @@ export const useFetchEcocredits = ({
 
   // AllCreditClasses
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // Normalization

--- a/web-marketplace/src/pages/Home/Home.loader.ts
+++ b/web-marketplace/src/pages/Home/Home.loader.ts
@@ -6,7 +6,7 @@ import { getSimplePriceQuery } from 'lib/queries/react-query/coingecko/simplePri
 import { getProjectsQuery } from 'lib/queries/react-query/ecocredit/getProjectsQuery/getProjectsQuery';
 import { getAllowedDenomQuery } from 'lib/queries/react-query/ecocredit/marketplace/getAllowedDenomQuery/getAllowedDenomQuery';
 import { getSellOrdersExtendedQuery } from 'lib/queries/react-query/ecocredit/marketplace/getSellOrdersExtendedQuery/getSellOrdersExtendedQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getAllHomePageQuery } from 'lib/queries/react-query/sanity/getAllHomePageQuery/getAllHomePageQuery';
 import { getFromCacheOrFetch } from 'lib/queries/react-query/utils/getFromCacheOrFetch';
 
@@ -25,7 +25,9 @@ export const homeLoader =
 
     // Queries
     const allHomePageQuery = getAllHomePageQuery({ sanityClient });
-    const allCreditClassesQuery = getAllCreditClassesQuery({ sanityClient });
+    const allCreditClassesQuery = getAllSanityCreditClassesQuery({
+      sanityClient,
+    });
     const simplePriceQuery = getSimplePriceQuery({});
     const projectsQuery = getProjectsQuery({
       client: ecocreditClient,

--- a/web-marketplace/src/pages/Home/hooks/useCreditClasses.ts
+++ b/web-marketplace/src/pages/Home/hooks/useCreditClasses.ts
@@ -7,7 +7,7 @@ import { useQueries, useQuery } from '@tanstack/react-query';
 
 import { client as sanityClient } from 'lib/clients/sanity';
 import { getCreditClassByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getCreditClassByOnChainIdQuery/getCreditClassByOnChainIdQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { getDisplayParty } from 'components/templates/ProjectDetails/ProjectDetails.utils';
 import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
@@ -22,7 +22,7 @@ export const useCreditClasses = ({ skippedClassId }: Props) => {
 
   // All credit class from sanity
   const { data: creditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // Filtered based on env variable

--- a/web-marketplace/src/pages/Marketplace/Storefront/Storefront.loader.ts
+++ b/web-marketplace/src/pages/Marketplace/Storefront/Storefront.loader.ts
@@ -6,7 +6,7 @@ import { getSimplePriceQuery } from 'lib/queries/react-query/coingecko/simplePri
 import { getProjectsQuery } from 'lib/queries/react-query/ecocredit/getProjectsQuery/getProjectsQuery';
 import { getAllowedDenomQuery } from 'lib/queries/react-query/ecocredit/marketplace/getAllowedDenomQuery/getAllowedDenomQuery';
 import { getSellOrdersExtendedQuery } from 'lib/queries/react-query/ecocredit/marketplace/getSellOrdersExtendedQuery/getSellOrdersExtendedQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { getFromCacheOrFetch } from 'lib/queries/react-query/utils/getFromCacheOrFetch';
 
 import { client as sanityClient } from '../../../lib/clients/sanity';
@@ -28,7 +28,9 @@ export const storefrontLoader =
       reactQueryClient: queryClient,
       request: {},
     });
-    const allCreditClassesQuery = getAllCreditClassesQuery({ sanityClient });
+    const allCreditClassesQuery = getAllSanityCreditClassesQuery({
+      sanityClient,
+    });
     const projectsQuery = getProjectsQuery({
       client: ecocreditClient,
       request: {},

--- a/web-marketplace/src/pages/Marketplace/Storefront/hooks/useNormalizedSellOrders.tsx
+++ b/web-marketplace/src/pages/Marketplace/Storefront/hooks/useNormalizedSellOrders.tsx
@@ -19,7 +19,7 @@ import { getBatchQuery } from 'lib/queries/react-query/ecocredit/getBatchQuery/g
 import { getProjectsQuery } from 'lib/queries/react-query/ecocredit/getProjectsQuery/getProjectsQuery';
 import { getMetadataQuery } from 'lib/queries/react-query/registry-server/getMetadataQuery/getMetadataQuery';
 import { getAllProjectsQuery } from 'lib/queries/react-query/registry-server/graphql/getAllProjectsQuery/getAllProjectsQuery';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 
 import { useFetchSellOrders } from 'features/marketplace/BuySellOrderFlow/hooks/useFetchSellOrders';
 import { normalizeToUISellOrderInfo } from 'pages/Projects/hooks/useProjectsSellOrders.utils';
@@ -90,7 +90,7 @@ export const useNormalizedSellOrders = (): ResponseType => {
   );
 
   const { data: sanityCreditClassData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   // Batch pagination

--- a/web-marketplace/src/pages/Projects/Projects.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.tsx
@@ -19,7 +19,7 @@ import {
   useAllSoldOutProjectsQuery,
 } from 'generated/sanity-graphql';
 import { client as sanityClient } from 'lib/clients/sanity';
-import { getAllCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
+import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useTracker } from 'lib/tracker/useTracker';
 
 import { BuySellOrderFlow } from 'features/marketplace/BuySellOrderFlow/BuySellOrderFlow';
@@ -65,7 +65,7 @@ export const Projects: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { creditClassesWithMetadata } = useFetchCreditClasses();
 
   const { data: sanityCreditClassesData } = useQuery(
-    getAllCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
+    getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
   );
 
   const { creditClassFilters } = normalizeCreditClassFilters({

--- a/web-marketplace/src/pages/Projects/hooks/useFetchCreditClasses.tsx
+++ b/web-marketplace/src/pages/Projects/hooks/useFetchCreditClasses.tsx
@@ -49,7 +49,4 @@ export const useFetchCreditClasses = (): UseFetchCreditClassesResponse => {
   return {
     creditClassesWithMetadata,
   };
-
-  // Return creditClasses with metadata
-  // Create normalizer in useProjects to return {name: string, path: string, isCommunity: boolean}
 };


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2000

- Improve loading performance for `Choose a credit class`
- rename `getAllCreditClassesQuery` to `getAllSanityCreditClassesQuery` to avoid name conflicts with `getAllCreditClassesQuery` from the graphql server

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. Go to https://deploy-preview-2049--regen-marketplace.netlify.app/ecocredits/projects
2. Click create project

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
