### PR TITLE
fix: trigger form validation on preview photo upload

### DIFF
--- a/web-marketplace/src/components/organisms/MediaForm/MediaFormPhotos.tsx
+++ b/web-marketplace/src/components/organisms/MediaForm/MediaFormPhotos.tsx
@@ -74,7 +74,9 @@ export const MediaFormPhotos = ({
   /* Setter */
 
   const setPreviewPhoto = (value: string): void => {
-    setValue('regen:previewPhoto.schema:url', encodeURI(value));
+    setValue('regen:previewPhoto.schema:url', encodeURI(value), {
+      shouldDirty: true,
+    });
     isDirtyRef.current = true;
   };
   const setGalleryPhotos = (value: string, fieldIndex: number): void => {

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -24,10 +24,20 @@ const Media = (): JSX.Element => {
       anchored: false,
     });
 
+  // Handle old metadata schema
+  const previewPhoto = metadata?.['regen:previewPhoto'];
+  const isPreviewPhotoString = typeof previewPhoto === 'string';
+  const previewPhotoUrl = isPreviewPhotoString
+    ? previewPhoto
+    : previewPhoto?.['schema:url'] ?? '';
+  const previewPhotoCredit = isPreviewPhotoString
+    ? ''
+    : previewPhoto?.['schema:creditText'] ?? '';
+
   const initialValues: MediaFormSchemaType = {
-    'regen:previewPhoto': metadata?.['regen:previewPhoto'] ?? {
-      'schema:url': '',
-      'schema:creditText': '',
+    'regen:previewPhoto': {
+      'schema:url': previewPhotoUrl,
+      'schema:creditText': previewPhotoCredit,
     },
     'regen:galleryPhotos': metadata?.['regen:galleryPhotos'],
     'regen:storyMedia': metadata?.['regen:storyMedia'] ?? {

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -24,20 +24,10 @@ const Media = (): JSX.Element => {
       anchored: false,
     });
 
-  // Handle old metadata schema
-  const previewPhoto = metadata?.['regen:previewPhoto'];
-  const isPreviewPhotoString = typeof previewPhoto === 'string';
-  const previewPhotoUrl = isPreviewPhotoString
-    ? previewPhoto
-    : previewPhoto?.['schema:url'] ?? '';
-  const previewPhotoCredit = isPreviewPhotoString
-    ? ''
-    : previewPhoto?.['schema:creditText'] ?? '';
-
   const initialValues: MediaFormSchemaType = {
-    'regen:previewPhoto': {
-      'schema:url': previewPhotoUrl,
-      'schema:creditText': previewPhotoCredit,
+    'regen:previewPhoto': metadata?.['regen:previewPhoto'] ?? {
+      'schema:url': '',
+      'schema:creditText': '',
     },
     'regen:galleryPhotos': metadata?.['regen:galleryPhotos'],
     'regen:storyMedia': metadata?.['regen:storyMedia'] ?? {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1775

- Allow to submit form after uploading a preview photo
- Handle old metadata schema for `regen:previewPhoto` (string instead of object)

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
