### PR TITLE
fix: handle save and exit in creation form

### DIFF
--- a/web-components/src/components/section/OnBoardingSection.tsx
+++ b/web-components/src/components/section/OnBoardingSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
+import { Link } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import { Body } from '../typography';
@@ -57,9 +58,6 @@ const useStyles = makeStyles()(theme => ({
     fontFamily: theme.typography.fontFamily,
     fontWeight: 'bold',
     cursor: 'pointer',
-    '&.disabled': {
-      color: theme.palette.grey[50],
-    },
     '&:hover': {
       textDecoration: 'none',
     },
@@ -94,18 +92,14 @@ const OnBoardingSection: React.FC<
         titleWrap: cx(titleWrap, !!classes && classes.titleWrap),
       }}
       title={p.title}
-      titleAlign={!!linkText ? 'left' : 'center'}
+      titleAlign={onLinkClick ? 'left' : 'center'}
       titleVariant="h3"
       topRight={
-        !!linkText ? (
-          <div
-            role="button"
-            className={cx(styles.link, !onLinkClick && 'disabled')}
-            onClick={onLinkClick}
-          >
+        onLinkClick && (
+          <Link className={styles.link} onClick={onLinkClick}>
             {linkText}
-          </div>
-        ) : undefined
+          </Link>
+        )
       }
     >
       <div

--- a/web-components/src/components/section/OnBoardingSection.tsx
+++ b/web-components/src/components/section/OnBoardingSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Link } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
 import { Body } from '../typography';
@@ -58,6 +57,9 @@ const useStyles = makeStyles()(theme => ({
     fontFamily: theme.typography.fontFamily,
     fontWeight: 'bold',
     cursor: 'pointer',
+    '&.disabled': {
+      color: theme.palette.grey[50],
+    },
     '&:hover': {
       textDecoration: 'none',
     },
@@ -92,14 +94,18 @@ const OnBoardingSection: React.FC<
         titleWrap: cx(titleWrap, !!classes && classes.titleWrap),
       }}
       title={p.title}
-      titleAlign={onLinkClick ? 'left' : 'center'}
+      titleAlign={!!linkText ? 'left' : 'center'}
       titleVariant="h3"
       topRight={
-        onLinkClick && (
-          <Link className={styles.link} onClick={onLinkClick}>
+        !!linkText ? (
+          <div
+            role="button"
+            className={cx(styles.link, !onLinkClick && 'disabled')}
+            onClick={onLinkClick}
+          >
             {linkText}
-          </Link>
-        )
+          </div>
+        ) : undefined
       }
     >
       <div

--- a/web-marketplace/src/components/molecules/Form/Form.tsx
+++ b/web-marketplace/src/components/molecules/Form/Form.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, MutableRefObject, useImperativeHandle } from 'react';
 import {
   FieldValues,
   FormProvider,
@@ -18,29 +18,44 @@ interface Props<T extends FieldValues>
   form: UseFormReturn<T>;
   onSubmit?: SubmitHandler<T>;
   sx?: SxProps<Theme>;
+  formRef?: MutableRefObject<{ submitForm: () => void } | undefined>;
 }
 
 const Form = <T extends FieldValues>({
   form,
   onSubmit,
   children,
+  formRef,
   sx = [],
   ...props
-}: Props<T>): JSX.Element => (
-  <FormProvider {...form}>
-    <form onSubmit={onSubmit && form.handleSubmit(onSubmit)} {...props}>
-      {/* <fieldset> passes the form's 'disabled' state to all of its elements,
+}: Props<T>): JSX.Element => {
+  useImperativeHandle(formRef, () => ({
+    isFormValid() {
+      return form.formState.isValid;
+    },
+    async submitForm() {
+      if (onSubmit) {
+        await form.handleSubmit(onSubmit)();
+      }
+    },
+  }));
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={onSubmit && form.handleSubmit(onSubmit)} {...props}>
+        {/* <fieldset> passes the form's 'disabled' state to all of its elements,
           allowing us to handle disabled style variants with just css */}
-      <Box
-        component="fieldset"
-        disabled={form.formState.isSubmitting}
-        sx={[{ borderWidth: 0, padding: 0, margin: 0 }, ...sxToArray(sx)]}
-      >
-        {children}
-      </Box>
-    </form>
-    {IS_DEV && <DevTool control={form.control} />}
-  </FormProvider>
-);
+        <Box
+          component="fieldset"
+          disabled={form.formState.isSubmitting}
+          sx={[{ borderWidth: 0, padding: 0, margin: 0 }, ...sxToArray(sx)]}
+        >
+          {children}
+        </Box>
+      </form>
+      {IS_DEV && <DevTool control={form.control} />}
+    </FormProvider>
+  );
+};
 
 export default Form;

--- a/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
@@ -72,7 +72,10 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
             values,
             shouldNavigate: shouldNavigateRef?.current,
           });
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         }

--- a/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
@@ -12,8 +12,10 @@ import TextField from 'web-components/lib/components/inputs/new/TextField/TextFi
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 
 import { useProjectEditContext } from 'pages';
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
+import { MetadataSubmitProps } from 'hooks/projects/useProjectWithMetadata';
 
 import { ProjectPageFooter } from '../../molecules';
 import {
@@ -29,7 +31,7 @@ import {
 import { useBasicInfoStyles } from './BasicInfoForm.styles';
 
 interface BasicInfoFormProps {
-  onSubmit: ({ values }: { values: BasicInfoFormSchemaType }) => Promise<void>;
+  onSubmit: (props: MetadataSubmitProps) => Promise<void>;
   onNext?: () => void;
   onPrev?: () => void;
   initialValues?: BasicInfoFormSchemaType;
@@ -54,6 +56,7 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
   });
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const { confirmSave, isEdit, isDirtyRef } = useProjectEditContext();
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
 
   useEffect(() => {
     isDirtyRef.current = isDirty;
@@ -62,9 +65,10 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
   return (
     <Form
       form={form}
+      formRef={formRef}
       onSubmit={async values => {
         try {
-          await onSubmit({ values });
+          await onSubmit({ values, shouldNavigate: shouldNavigateRef.current });
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);

--- a/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
@@ -68,7 +68,10 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
       formRef={formRef}
       onSubmit={async values => {
         try {
-          await onSubmit({ values, shouldNavigate: shouldNavigateRef.current });
+          await onSubmit({
+            values,
+            shouldNavigate: shouldNavigateRef?.current,
+          });
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);

--- a/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
+++ b/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
@@ -9,9 +9,11 @@ import { TextAreaFieldChartCounter } from 'web-components/lib/components/inputs/
 
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { useProjectEditContext } from 'pages/ProjectEdit';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
+import { MetadataSubmitProps } from 'hooks/projects/useProjectWithMetadata';
 
 import { ProjectPageFooter } from '../../molecules';
 import {
@@ -31,7 +33,7 @@ import {
 } from './DescriptionForm.schema';
 
 interface DescriptionFormProps {
-  onSubmit: ({ values }: { values: DescriptionSchemaType }) => Promise<void>;
+  onSubmit: (props: MetadataSubmitProps) => Promise<void>;
   onNext?: () => void;
   onPrev?: () => void;
   initialValues?: DescriptionSchemaType;
@@ -53,7 +55,7 @@ const DescriptionForm: React.FC<DescriptionFormProps> = ({
   const { isValid, isSubmitting, isDirty, errors } = useFormState({
     control: form.control,
   });
-
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
   const description = useWatch({
     control: form.control,
     name: 'schema:description',
@@ -77,9 +79,10 @@ const DescriptionForm: React.FC<DescriptionFormProps> = ({
   return (
     <Form
       form={form}
+      formRef={formRef}
       onSubmit={async values => {
         try {
-          await onSubmit({ values });
+          await onSubmit({ values, shouldNavigate: shouldNavigateRef.current });
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);

--- a/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
+++ b/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
@@ -52,6 +52,7 @@ const DescriptionForm: React.FC<DescriptionFormProps> = ({
     },
     mode: 'onBlur',
   });
+
   const { isValid, isSubmitting, isDirty, errors } = useFormState({
     control: form.control,
   });
@@ -86,7 +87,10 @@ const DescriptionForm: React.FC<DescriptionFormProps> = ({
             values,
             shouldNavigate: shouldNavigateRef?.current,
           });
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         }

--- a/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
+++ b/web-marketplace/src/components/organisms/DescriptionForm/DescriptionForm.tsx
@@ -82,7 +82,10 @@ const DescriptionForm: React.FC<DescriptionFormProps> = ({
       formRef={formRef}
       onSubmit={async values => {
         try {
-          await onSubmit({ values, shouldNavigate: shouldNavigateRef.current });
+          await onSubmit({
+            values,
+            shouldNavigate: shouldNavigateRef?.current,
+          });
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);

--- a/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
+++ b/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
@@ -76,7 +76,7 @@ const LocationForm: React.FC<LocationFormProps> = ({
           if (isGeocodingFeature(location)) {
             await onSubmit({
               values: { 'schema:location': location },
-              shouldNavigate: shouldNavigateRef.current,
+              shouldNavigate: shouldNavigateRef?.current,
             });
           }
           if (isEdit && confirmSave) confirmSave();

--- a/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
+++ b/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
@@ -79,7 +79,10 @@ const LocationForm: React.FC<LocationFormProps> = ({
               shouldNavigate: shouldNavigateRef?.current,
             });
           }
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         }

--- a/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
+++ b/web-marketplace/src/components/organisms/LocationForm/LocationForm.tsx
@@ -10,8 +10,10 @@ import { isGeocodingFeature } from 'web-components/lib/components/inputs/new/Loc
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 
 import { useProjectEditContext } from 'pages';
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
+import { MetadataSubmitProps } from 'hooks/projects/useProjectWithMetadata';
 
 import { ProjectPageFooter } from '../../molecules';
 import {
@@ -22,16 +24,11 @@ import {
 import {
   locationFormSchema,
   LocationFormSchemaType,
-  SimplifiedLocationFormSchemaType,
 } from './LocationForm.schema';
 
 interface LocationFormProps {
   mapToken: string;
-  onSubmit: ({
-    values,
-  }: {
-    values: SimplifiedLocationFormSchemaType;
-  }) => Promise<void>;
+  onSubmit: (props: MetadataSubmitProps) => Promise<void>;
   onNext?: () => void;
   onPrev?: () => void;
   initialValues?: LocationFormSchemaType;
@@ -58,6 +55,7 @@ const LocationForm: React.FC<LocationFormProps> = ({
 
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const { confirmSave, isEdit, isDirtyRef } = useProjectEditContext();
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
 
   const location = useWatch({
     control: form.control,
@@ -71,11 +69,15 @@ const LocationForm: React.FC<LocationFormProps> = ({
   return (
     <Form
       form={form}
+      formRef={formRef}
       onSubmit={async values => {
         try {
           const location = values['schema:location'];
           if (isGeocodingFeature(location)) {
-            await onSubmit({ values: { 'schema:location': location } });
+            await onSubmit({
+              values: { 'schema:location': location },
+              shouldNavigate: shouldNavigateRef.current,
+            });
           }
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {

--- a/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
+++ b/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
@@ -71,7 +71,7 @@ export const MediaForm = ({
           // Submit
           await submit({
             values: filteredData,
-            shouldNavigate: shouldNavigateRef.current,
+            shouldNavigate: shouldNavigateRef?.current,
           });
           // Delete any images that were removed on S3
           await Promise.all(

--- a/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
+++ b/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
@@ -9,10 +9,12 @@ import { deleteImage } from 'web-components/lib/utils/s3';
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 import { apiServerUrl } from 'lib/env';
 
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { useProjectEditContext } from 'pages/ProjectEdit';
 import { ProjectPageFooter } from 'components/molecules';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
+import { MetadataSubmitProps } from 'hooks/projects/useProjectWithMetadata';
 
 import { DEFAULT_URL } from './MediaForm.constants';
 import { mediaFormSchema, MediaFormSchemaType } from './MediaForm.schema';
@@ -20,7 +22,7 @@ import { MediaFormPhotos } from './MediaFormPhotos';
 import { MediaFormStory } from './MediaFormStory';
 
 interface MediaFormProps {
-  submit: ({ values }: { values: MediaFormSchemaType }) => Promise<void>;
+  submit: (props: MetadataSubmitProps) => Promise<void>;
   onPrev?: () => void;
   onNext?: () => void;
   initialValues: MediaFormSchemaType;
@@ -44,15 +46,17 @@ export const MediaForm = ({
   const { isSubmitting, isDirty, isValid } = useFormState({
     control: form.control,
   });
-  const fileNamesToDeleteRef = useRef<string[]>([]);
-  const { isDirtyRef } = useProjectEditContext();
 
-  const { confirmSave, isEdit } = useProjectEditContext();
+  const fileNamesToDeleteRef = useRef<string[]>([]);
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
+
+  const { confirmSave, isEdit, isDirtyRef } = useProjectEditContext();
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const [offChainProjectId, setOffChainProjectId] = useState(projectId);
 
   return (
     <Form
+      formRef={formRef}
       form={form}
       onSubmit={async data => {
         try {
@@ -65,7 +69,10 @@ export const MediaForm = ({
             'regen:storyMedia': data?.['regen:storyMedia'],
           };
           // Submit
-          await submit({ values: filteredData });
+          await submit({
+            values: filteredData,
+            shouldNavigate: shouldNavigateRef.current,
+          });
           // Delete any images that were removed on S3
           await Promise.all(
             fileNamesToDeleteRef?.current.map(

--- a/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
+++ b/web-marketplace/src/components/organisms/MediaForm/MediaForm.tsx
@@ -86,7 +86,10 @@ export const MediaForm = ({
           );
           fileNamesToDeleteRef.current = [];
           // Save callback
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
           // Reset dirty state
           isDirtyRef.current = false;
         } catch (e) {

--- a/web-marketplace/src/components/organisms/MetadataForm/MetadataForm.tsx
+++ b/web-marketplace/src/components/organisms/MetadataForm/MetadataForm.tsx
@@ -66,7 +66,10 @@ const MetadataForm: React.FC<MetadataFormFormProps> = ({
       onSubmit={async values => {
         try {
           await onSubmit({ values });
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         }

--- a/web-marketplace/src/components/organisms/MetadataForm/MetadataForm.tsx
+++ b/web-marketplace/src/components/organisms/MetadataForm/MetadataForm.tsx
@@ -12,6 +12,7 @@ import { ShaclGraphByUriQuery } from 'generated/graphql';
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 
 import { useProjectEditContext } from 'pages';
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
 
@@ -52,6 +53,7 @@ const MetadataForm: React.FC<MetadataFormFormProps> = ({
   });
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const { confirmSave, isEdit, isDirtyRef } = useProjectEditContext();
+  const { formRef } = useCreateProjectContext();
 
   useEffect(() => {
     isDirtyRef.current = isDirty;
@@ -60,6 +62,7 @@ const MetadataForm: React.FC<MetadataFormFormProps> = ({
   return (
     <Form
       form={form}
+      formRef={formRef}
       onSubmit={async values => {
         try {
           await onSubmit({ values });

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
@@ -140,7 +140,7 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
           await submit({
             values,
             adminWalletId: adminWalletData?.walletByAddr?.id,
-            shouldNavigate: shouldNavigateRef.current,
+            shouldNavigate: shouldNavigateRef?.current,
           });
           if (isEdit && confirmSave) confirmSave();
         } catch (e) {

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
@@ -17,7 +17,8 @@ import TextField from 'web-components/lib/components/inputs/new/TextField/TextFi
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
 import { getWalletByAddrQuery } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery';
 
-import { Return } from 'pages/Roles/hooks/useRolesSubmit';
+import { useCreateProjectContext } from 'pages/ProjectCreate';
+import { RoleSubmitProps } from 'pages/Roles/hooks/useRolesSubmit';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
 
@@ -33,7 +34,7 @@ import { useSaveProfile } from './hooks/useSaveProfile';
 import { rolesFormSchema, RolesFormSchemaType } from './RolesForm.schema';
 
 interface RolesFormProps {
-  submit: Return['rolesSubmit'];
+  submit: (props: RoleSubmitProps) => Promise<void>;
   onNext?: () => void;
   onPrev?: () => void;
   initialValues?: RolesFormSchemaType;
@@ -57,6 +58,7 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
   });
   const { isDirtyRef } = useProjectEditContext();
   const { confirmSave, isEdit } = useProjectEditContext();
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const [adminModalOpen, setAdminModalOpen] = useState<boolean>(false);
 
@@ -130,7 +132,22 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
   const saveProfile = useSaveProfile();
 
   return (
-    <Form form={form}>
+    <Form
+      form={form}
+      formRef={formRef}
+      onSubmit={async values => {
+        try {
+          await submit({
+            values,
+            adminWalletId: adminWalletData?.walletByAddr?.id,
+            shouldNavigate: shouldNavigateRef.current,
+          });
+          if (isEdit && confirmSave) confirmSave();
+        } catch (e) {
+          setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
+        }
+      }}
+    >
       <OnBoardingCard>
         <RoleField
           label="Project Developer"
@@ -191,14 +208,6 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
         </Flex>
       </OnBoardingCard>
       <ProjectPageFooter
-        onSave={form.handleSubmit(async data => {
-          try {
-            await submit(data, adminWalletData?.walletByAddr?.id);
-            if (isEdit && confirmSave) confirmSave();
-          } catch (e) {
-            setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
-          }
-        })}
         onPrev={onPrev}
         onNext={onNext}
         isValid={isValid}

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
@@ -142,7 +142,10 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
             adminWalletId: adminWalletData?.walletByAddr?.id,
             shouldNavigate: shouldNavigateRef?.current,
           });
-          if (isEdit && confirmSave) confirmSave();
+          if (isEdit && confirmSave) {
+            confirmSave();
+            form.reset({}, { keepValues: true });
+          }
         } catch (e) {
           setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         }

--- a/web-marketplace/src/components/templates/ProjectFormTemplate/OnboardingFormTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/OnboardingFormTemplate.tsx
@@ -24,8 +24,8 @@ const OnboardingFormTemplate: React.FC<React.PropsWithChildren<Props>> =
           // Only commenting this for now if at some point,
           // we want to add back the "save & exit" feature
           // https://github.com/regen-network/regen-registry/issues/553
-          // linkText="Save & Exit"
-          // onLinkClick={props.saveAndExit}
+          linkText="Save & Exit"
+          onLinkClick={props.saveAndExit}
           // exampleProjectUrl="/project/wilmot"
         >
           {props.loading ? (

--- a/web-marketplace/src/components/templates/ProjectFormTemplate/OnboardingFormTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/OnboardingFormTemplate.tsx
@@ -21,9 +21,6 @@ const OnboardingFormTemplate: React.FC<React.PropsWithChildren<Props>> =
         <OnBoardingSection
           title={props.title}
           formContainer
-          // Only commenting this for now if at some point,
-          // we want to add back the "save & exit" feature
-          // https://github.com/regen-network/regen-registry/issues/553
           linkText="Save & Exit"
           onLinkClick={props.saveAndExit}
           // exampleProjectUrl="/project/wilmot"

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -41,6 +41,7 @@ interface Props {
 export interface MetadataSubmitProps {
   values: Values;
   overwrite?: boolean;
+  shouldNavigate?: boolean;
 }
 
 interface Res {
@@ -145,6 +146,7 @@ export const useProjectWithMetadata = ({
     async ({
       values,
       overwrite = false,
+      shouldNavigate = true,
     }: MetadataSubmitProps): Promise<void> => {
       let newMetadata = values;
       if (!overwrite) {
@@ -159,7 +161,7 @@ export const useProjectWithMetadata = ({
             projectPatch: { metadata: newMetadata },
           });
 
-          !isEdit && navigateNext();
+          !isEdit && shouldNavigate && navigateNext();
         }
         await metadataReload();
       } catch (e) {

--- a/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
+++ b/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import { useProjectEditContext } from 'pages/ProjectEdit';
 import { BasicInfoForm } from 'components/organisms';
 import { BasicInfoFormSchemaType } from 'components/organisms/BasicInfoForm/BasicInfoForm.schema';
@@ -32,9 +33,7 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
     [metadata],
   );
 
-  async function saveAndExit(): Promise<void> {
-    // TODO: functionality
-  }
+  const saveAndExit = useProjectSaveAndExit();
 
   return (
     <ProjectFormTemplate

--- a/web-marketplace/src/pages/Description/Description.tsx
+++ b/web-marketplace/src/pages/Description/Description.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import { useProjectEditContext } from 'pages/ProjectEdit';
 import WithLoader from 'components/atoms/WithLoader';
 import { DescriptionForm } from 'components/organisms/DescriptionForm/DescriptionForm';
@@ -12,7 +13,8 @@ import { useProjectWithMetadata } from 'hooks/projects/useProjectWithMetadata';
 const Description: React.FC<React.PropsWithChildren<unknown>> = () => {
   const navigate = useNavigate();
   const { projectId } = useParams();
-  const { isEdit, onChainProject, projectEditSubmit } = useProjectEditContext();
+  const { isEdit, onChainProject, projectEditSubmit, isLoading } =
+    useProjectEditContext();
   const { navigateNext } = useNavigateNext({ step: 'media', projectId });
 
   const { metadata, metadataSubmit, offChainProject, loading } =
@@ -34,10 +36,7 @@ const Description: React.FC<React.PropsWithChildren<unknown>> = () => {
     [metadata],
   );
 
-  const saveAndExit = (): Promise<void> => {
-    // TODO: functionality
-    return Promise.resolve();
-  };
+  const saveAndExit = useProjectSaveAndExit();
 
   function navigatePrev(): void {
     navigate(`/project-pages/${projectId}/roles`);
@@ -53,7 +52,7 @@ const Description: React.FC<React.PropsWithChildren<unknown>> = () => {
       loading={loading}
     >
       <WithLoader
-        isLoading={loading}
+        isLoading={isLoading}
         sx={{ textAlign: 'center', mt: { xs: 6.5, sm: 9 } }}
       >
         <DescriptionForm

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import WithLoader from 'components/atoms/WithLoader';
 import { MediaFormSchemaType } from 'components/organisms/MediaForm/MediaForm.schema';
 import { ProjectFormTemplate } from 'components/templates/ProjectFormTemplate';
@@ -15,7 +15,6 @@ const Media = (): JSX.Element => {
   const { projectId } = useParams();
   const { isEdit, onChainProject, projectEditSubmit } = useProjectEditContext();
   const { navigateNext } = useNavigateNext({ step: 'metadata', projectId });
-  const { formRef, shouldNavigateRef } = useCreateProjectContext();
   const { offChainProject, metadata, metadataSubmit, loading } =
     useProjectWithMetadata({
       projectId,
@@ -39,14 +38,7 @@ const Media = (): JSX.Element => {
     },
   };
 
-  const saveAndExit = async (): Promise<void> => {
-    shouldNavigateRef.current = false;
-    await formRef.current?.submitForm();
-    shouldNavigateRef.current = true;
-    if (formRef.current?.isFormValid) {
-      navigate('/ecocredits/projects');
-    }
-  };
+  const saveAndExit = useProjectSaveAndExit();
 
   function navigatePrev(): void {
     navigate(`/project-pages/${projectId}/description`);

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
 import WithLoader from 'components/atoms/WithLoader';
 import { MediaFormSchemaType } from 'components/organisms/MediaForm/MediaForm.schema';
@@ -14,6 +15,7 @@ const Media = (): JSX.Element => {
   const { projectId } = useParams();
   const { isEdit, onChainProject, projectEditSubmit } = useProjectEditContext();
   const { navigateNext } = useNavigateNext({ step: 'metadata', projectId });
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
   const { offChainProject, metadata, metadataSubmit, loading } =
     useProjectWithMetadata({
       projectId,
@@ -23,6 +25,7 @@ const Media = (): JSX.Element => {
       onChainProject,
       anchored: false,
     });
+  const isFormValid = formRef?.current?.isFormValid();
 
   const initialValues: MediaFormSchemaType = {
     'regen:previewPhoto': metadata?.['regen:previewPhoto'] ?? {
@@ -37,9 +40,11 @@ const Media = (): JSX.Element => {
     },
   };
 
-  const saveAndExit = (): Promise<void> => {
-    // TODO: functionality
-    return Promise.resolve();
+  const saveAndExit = async (): Promise<void> => {
+    shouldNavigateRef.current = false;
+    await formRef.current?.submitForm();
+    shouldNavigateRef.current = true;
+    navigate('/ecocredits/projects');
   };
 
   function navigatePrev(): void {

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -25,7 +25,6 @@ const Media = (): JSX.Element => {
       onChainProject,
       anchored: false,
     });
-  const isFormValid = formRef?.current?.isFormValid();
 
   const initialValues: MediaFormSchemaType = {
     'regen:previewPhoto': metadata?.['regen:previewPhoto'] ?? {
@@ -44,7 +43,9 @@ const Media = (): JSX.Element => {
     shouldNavigateRef.current = false;
     await formRef.current?.submitForm();
     shouldNavigateRef.current = true;
-    navigate('/ecocredits/projects');
+    if (formRef.current?.isFormValid) {
+      navigate('/ecocredits/projects');
+    }
   };
 
   function navigatePrev(): void {

--- a/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
+++ b/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { MutableRefObject, useRef, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 
@@ -7,6 +7,10 @@ type ContextType = {
   setDeliverTxResponse: (deliverTxResponse?: DeliverTxResponse) => void;
   creditClassId?: string;
   setCreditClassId: (creditClassId?: string) => void;
+  formRef: MutableRefObject<
+    { submitForm: () => void; isFormValid: () => boolean } | undefined
+  >;
+  shouldNavigateRef: MutableRefObject<boolean>;
 };
 
 export const ProjectCreate = (): JSX.Element => {
@@ -14,6 +18,8 @@ export const ProjectCreate = (): JSX.Element => {
   const [deliverTxResponse, setDeliverTxResponse] =
     useState<DeliverTxResponse>();
   const [creditClassId, setCreditClassId] = useState<string>('');
+  const formRef = useRef();
+  const shouldNavigateRef = useRef(true);
 
   return (
     <Outlet
@@ -22,6 +28,8 @@ export const ProjectCreate = (): JSX.Element => {
         setDeliverTxResponse,
         creditClassId,
         setCreditClassId,
+        formRef,
+        shouldNavigateRef,
       }}
     />
   );

--- a/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
+++ b/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, useRef, useState } from 'react';
+import { createContext, MutableRefObject, useRef, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 
@@ -7,11 +7,20 @@ type ContextType = {
   setDeliverTxResponse: (deliverTxResponse?: DeliverTxResponse) => void;
   creditClassId?: string;
   setCreditClassId: (creditClassId?: string) => void;
-  formRef: MutableRefObject<
+  formRef?: MutableRefObject<
     { submitForm: () => void; isFormValid: () => boolean } | undefined
   >;
-  shouldNavigateRef: MutableRefObject<boolean>;
+  shouldNavigateRef?: MutableRefObject<boolean>;
 };
+
+const defaultProjectCreateContext = createContext<ContextType>({
+  deliverTxResponse: undefined,
+  setDeliverTxResponse: () => void 0,
+  creditClassId: undefined,
+  setCreditClassId: () => void 0,
+  formRef: undefined,
+  shouldNavigateRef: undefined,
+});
 
 export const ProjectCreate = (): JSX.Element => {
   // TODO: possibly replace these with `useMsgClient` and pass downstream
@@ -36,12 +45,8 @@ export const ProjectCreate = (): JSX.Element => {
 };
 
 export const useCreateProjectContext = (): ContextType => {
-  const context = useOutletContext<ContextType>();
+  const context =
+    useOutletContext<ContextType>() ?? defaultProjectCreateContext;
 
-  if (context === undefined) {
-    throw new Error(
-      'useCreateProjectContext must be used within a nested ProjectCreate route',
-    );
-  }
   return context;
 };

--- a/web-marketplace/src/pages/ProjectCreate/hooks/useProjectSaveAndExit.ts
+++ b/web-marketplace/src/pages/ProjectCreate/hooks/useProjectSaveAndExit.ts
@@ -7,10 +7,12 @@ export const useProjectSaveAndExit = () => {
   const navigate = useNavigate();
 
   const saveAndExit = async (): Promise<void> => {
-    shouldNavigateRef.current = false;
-    await formRef.current?.submitForm();
-    shouldNavigateRef.current = true;
-    if (formRef.current?.isFormValid()) {
+    if (shouldNavigateRef) {
+      shouldNavigateRef.current = false;
+      await formRef?.current?.submitForm();
+      shouldNavigateRef.current = true;
+    }
+    if (formRef?.current?.isFormValid()) {
       navigate('/ecocredits/projects');
     }
   };

--- a/web-marketplace/src/pages/ProjectCreate/hooks/useProjectSaveAndExit.ts
+++ b/web-marketplace/src/pages/ProjectCreate/hooks/useProjectSaveAndExit.ts
@@ -1,0 +1,19 @@
+import { useNavigate } from 'react-router-dom';
+
+import { useCreateProjectContext } from '../ProjectCreate';
+
+export const useProjectSaveAndExit = () => {
+  const { formRef, shouldNavigateRef } = useCreateProjectContext();
+  const navigate = useNavigate();
+
+  const saveAndExit = async (): Promise<void> => {
+    shouldNavigateRef.current = false;
+    await formRef.current?.submitForm();
+    shouldNavigateRef.current = true;
+    if (formRef.current?.isFormValid()) {
+      navigate('/ecocredits/projects');
+    }
+  };
+
+  return saveAndExit;
+};

--- a/web-marketplace/src/pages/ProjectLocation/ProjectLocation.tsx
+++ b/web-marketplace/src/pages/ProjectLocation/ProjectLocation.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import { useProjectEditContext } from 'pages/ProjectEdit';
 import { LocationFormSchemaType } from 'components/organisms/LocationForm/LocationForm.schema';
 import { ProjectFormTemplate } from 'components/templates/ProjectFormTemplate';
@@ -31,11 +32,7 @@ const ProjectLocation: React.FC<React.PropsWithChildren<unknown>> = () => {
     [metadata],
   );
 
-  async function saveAndExit(): Promise<void> {
-    // TODO functionality - might need to save form state in this file to pass
-    // to `OnboardingFormTemplate`, or wrap this whole page in the Formik Form
-    // so it can access values: https://github.com/regen-network/regen-registry/issues/561
-  }
+  const saveAndExit = useProjectSaveAndExit();
 
   function navigatePrev(): void {
     navigate(`/project-pages/${projectId}/basic-info`);

--- a/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.tsx
+++ b/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.tsx
@@ -9,6 +9,7 @@ import { getShaclGraphByUriQuery } from 'lib/queries/react-query/registry-server
 import { getProjectShapeIri } from 'lib/rdf';
 
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import { MetadataForm } from 'components/organisms/MetadataForm/MetadataForm';
 import { ProjectFormTemplate } from 'components/templates/ProjectFormTemplate';
 import { useProjectWithMetadata } from 'hooks/projects/useProjectWithMetadata';
@@ -58,6 +59,8 @@ export const ProjectMetadata: React.FC<React.PropsWithChildren<unknown>> =
       metadata: customMetadata ? JSON.stringify(customMetadata, null, 2) : '',
     };
 
+    const saveAndExit = useProjectSaveAndExit();
+
     return (
       <ProjectFormTemplate
         isEdit={isEdit}
@@ -65,6 +68,7 @@ export const ProjectMetadata: React.FC<React.PropsWithChildren<unknown>> =
         offChainProject={offChainProject}
         onChainProject={onChainProject}
         loading={loading}
+        saveAndExit={saveAndExit}
       >
         <MetadataForm
           onSubmit={projectMetadataSubmit}

--- a/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
+++ b/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
@@ -4,6 +4,7 @@ import { merge, pick } from 'lodash';
 import { NestedPartial } from 'types/nested-partial';
 import { ProjectMetadataLD } from 'lib/db/types/json-ld';
 
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { MetadataFormSchemaType } from 'components/organisms/MetadataForm/MetadataForm.schema';
 import { MetadataSubmitProps } from 'hooks/projects/useProjectWithMetadata';
 
@@ -26,16 +27,21 @@ export const useProjectMetadataSubmit = ({
   metadata,
   metadataSubmit,
 }: Params): UseProjectMetadataSubmitReturn => {
+  const { shouldNavigateRef } = useCreateProjectContext();
   const projectMetadataSubmit = useCallback(
     async ({ values }: SubmitParams): Promise<void> => {
       const parsedMetaData = JSON.parse(values.metadata);
       const baseMetadata = pick(metadata, OMITTED_METADATA_KEYS);
       merge(baseMetadata, parsedMetaData);
       if (baseMetadata) {
-        await metadataSubmit({ values: baseMetadata, overwrite: true });
+        await metadataSubmit({
+          values: baseMetadata,
+          overwrite: true,
+          shouldNavigate: shouldNavigateRef.current,
+        });
       }
     },
-    [metadata, metadataSubmit],
+    [metadata, metadataSubmit, shouldNavigateRef],
   );
 
   return projectMetadataSubmit;

--- a/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
+++ b/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
@@ -37,7 +37,7 @@ export const useProjectMetadataSubmit = ({
         await metadataSubmit({
           values: baseMetadata,
           overwrite: true,
-          shouldNavigate: shouldNavigateRef.current,
+          shouldNavigate: shouldNavigateRef?.current,
         });
       }
     },

--- a/web-marketplace/src/pages/Roles/Roles.tsx
+++ b/web-marketplace/src/pages/Roles/Roles.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
+import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import WithLoader from 'components/atoms/WithLoader';
 import { RolesForm } from 'components/organisms/RolesForm/RolesForm';
 import { RolesFormSchemaType } from 'components/organisms/RolesForm/RolesForm.schema';
@@ -68,9 +69,7 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
     ],
   );
 
-  async function saveAndExit(): Promise<void> {
-    // TODO: functionality
-  }
+  const saveAndExit = useProjectSaveAndExit();
 
   function navigatePrev(): void {
     navigate(`/project-pages/${projectId}/location`);
@@ -85,9 +84,7 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
       onChainProject={onChainProject}
       loading={withMetadataLoading}
     >
-      <WithLoader
-        isLoading={!loaded || editContextLoading || withMetadataLoading}
-      >
+      <WithLoader isLoading={!loaded || editContextLoading}>
         <RolesForm
           submit={rolesSubmit}
           onNext={navigateNext}

--- a/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
+++ b/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
@@ -28,11 +28,14 @@ interface Props {
   admin?: string;
 }
 
+export type RoleSubmitProps = {
+  values: RolesFormSchemaType;
+  adminWalletId?: string;
+  shouldNavigate?: boolean;
+};
+
 export type Return = {
-  rolesSubmit: (
-    values: RolesFormSchemaType,
-    adminWalletId?: string,
-  ) => Promise<void>;
+  rolesSubmit: (props: RoleSubmitProps) => Promise<void>;
 };
 
 const useRolesSubmit = ({
@@ -48,10 +51,11 @@ const useRolesSubmit = ({
   const { createOrUpdateProject } = useCreateOrUpdateProject();
 
   const rolesSubmit = useCallback(
-    async (
-      values: RolesFormSchemaType,
-      adminWalletId?: string,
-    ): Promise<void> => {
+    async ({
+      values,
+      adminWalletId,
+      shouldNavigate = true,
+    }: RoleSubmitProps): Promise<void> => {
       try {
         let doUpdateMetadata = false;
         let doUpdateAdmin = false;
@@ -113,7 +117,7 @@ const useRolesSubmit = ({
           await metadataReload();
         }
 
-        if (!isEdit) {
+        if (!isEdit && shouldNavigate) {
           navigateNext();
         }
       } catch (e) {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#553

- Enable `Save & Exit` in all project forms

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. Go to https://deploy-preview-2078--regen-marketplace.netlify.app/ecocredits/projects
2. Create a project and try the `Save & Exit` feature in the different steps

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
