### PR TITLE
fix: update offchainProject props in ChooseCreditClass

### DIFF
--- a/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
@@ -26,7 +26,6 @@ const ProjectFormAccessTemplate: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
   const { wallet } = useWallet();
   const isAdmin = adminAddr && adminAddr === wallet?.address;
-  console.log(offChainProject);
   const hasProject = !!onChainProject || !!offChainProject;
   return (
     <>

--- a/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
@@ -26,6 +26,7 @@ const ProjectFormAccessTemplate: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
   const { wallet } = useWallet();
   const isAdmin = adminAddr && adminAddr === wallet?.address;
+  console.log(offChainProject);
   const hasProject = !!onChainProject || !!offChainProject;
   return (
     <>

--- a/web-marketplace/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
+++ b/web-marketplace/src/pages/ChooseCreditClass/ChooseCreditClass.tsx
@@ -74,7 +74,7 @@ const ChooseCreditClass: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <ProjectFormAccessTemplate
       loading={isFetching}
-      project={project}
+      offChainProject={project}
       adminAddr={adminAddr}
     >
       <ChooseCreditClassGrid


### PR DESCRIPTION
## Description

Fixing a bug that got introduced as part of https://github.com/regen-network/regen-web/pull/2060

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

This bug was causing the choose credit class page to always render 404 because the offchain project wasn't provided. Try to create a new project and everything should work back again normally.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
