### PR TITLE
fix: key in activity table

### DIFF
--- a/web-marketplace/src/components/organisms/CreditActivityTable/CreditActivityTable.tsx
+++ b/web-marketplace/src/components/organisms/CreditActivityTable/CreditActivityTable.tsx
@@ -164,12 +164,12 @@ const CreditActivityTable: React.FC<React.PropsWithChildren<unknown>> = () => {
           <TableBody sx={{ bgcolor: 'primary.main' }}>
             {ledgerRESTUri && !isLoading ? (
               stableSort(txs as any, getComparator(order, orderBy)).map(
-                (tx: any) => {
+                (tx: any, index) => {
                   return (
                     <StyledTableRow
                       sx={{ whiteSpace: 'nowrap', cursor: 'pointer' }}
                       tabIndex={-1}
-                      key={tx.txhash}
+                      key={index}
                       onClick={() => handleClickNavigate(tx.txhash)}
                     >
                       <StyledTableCell sx={{ color: 'info.main' }}>


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1789

Fix duplicate keys in the activity table.
Before we were using `txhash` but it's a unique identifier (there can be duplicates in the indexer responses). We replace it by the index in order to prevent duplicate rows in the table.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
