### PR TITLE
feat: edit profiles created with the Project Roles Form

### DIFF
--- a/web-marketplace/graphql.schema.json
+++ b/web-marketplace/graphql.schema.json
@@ -193,6 +193,333 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "partiesByCreatorId",
+            "description": "Reads and enables pagination through a set of `Party`.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "The method to use when ordering `Party`.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PartiesOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[PRIMARY_KEY_ASC]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "condition",
+                "description": "A condition to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyCondition",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PartiesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountsByPartyAccountIdAndCreatorId",
+            "description": "Reads and enables pagination through a set of `Account`.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "The method to use when ordering `Account`.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "AccountsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[PRIMARY_KEY_ASC]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "condition",
+                "description": "A condition to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountCondition",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccountAccountsByPartyAccountIdAndCreatorIdManyToManyConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountsByPartyCreatorIdAndAccountId",
+            "description": "Reads and enables pagination through a set of `Account`.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "The method to use when ordering `Account`.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "AccountsOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[PRIMARY_KEY_ASC]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "condition",
+                "description": "A condition to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountCondition",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccountAccountsByPartyCreatorIdAndAccountIdManyToManyConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -233,6 +560,468 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAccountsByPartyAccountIdAndCreatorIdManyToManyConnection",
+        "description": "A connection to a list of `Account` values, with data from `Party`.",
+        "fields": [
+          {
+            "name": "nodes",
+            "description": "A list of `Account` objects.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Account",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "A list of edges which contains the `Account`, info from the `Party`, and the cursor to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Information to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "The count of *all* `Account` you could get from the connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdge",
+        "description": "A `Account` edge in the connection, with data from `Party`.",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Cursor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The `Account` at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "partiesByCreatorId",
+            "description": "Reads and enables pagination through a set of `Party`.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "The method to use when ordering `Party`.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PartiesOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[PRIMARY_KEY_ASC]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "condition",
+                "description": "A condition to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyCondition",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PartiesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAccountsByPartyCreatorIdAndAccountIdManyToManyConnection",
+        "description": "A connection to a list of `Account` values, with data from `Party`.",
+        "fields": [
+          {
+            "name": "nodes",
+            "description": "A list of `Account` objects.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Account",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "A list of edges which contains the `Account`, info from the `Party`, and the cursor to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": "Information to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "The count of *all* `Account` you could get from the connection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdge",
+        "description": "A `Account` edge in the connection, with data from `Party`.",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Cursor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The `Account` at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "partiesByAccountId",
+            "description": "Reads and enables pagination through a set of `Party`.",
+            "args": [
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor\nbased pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": "The method to use when ordering `Party`.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PartiesOrderBy",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": "[PRIMARY_KEY_ASC]",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "condition",
+                "description": "A condition to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyCondition",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PartiesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1621,6 +2410,18 @@
           },
           {
             "name": "accountByAccountId",
+            "description": "Reads a single `Account` that is related to this `Party`.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountByCreatorId",
             "description": "Reads a single `Account` that is related to this `Party`.",
             "args": [],
             "type": {
@@ -7112,6 +7913,18 @@
             "deprecationReason": null
           },
           {
+            "name": "accountByCreatorId",
+            "description": "Reads a single `Account` that is related to this `Party`.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "partyEdge",
             "description": "An edge for our `Party`. May be used by Relay 1.",
             "args": [
@@ -12389,6 +13202,18 @@
             "deprecationReason": null
           },
           {
+            "name": "CREATOR_ID_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CREATOR_ID_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "PRIMARY_KEY_ASC",
             "description": null,
             "isDeprecated": false,
@@ -12589,6 +13414,18 @@
             "deprecationReason": null
           },
           {
+            "name": "creatorId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UUID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "walletByWalletId",
             "description": "Reads a single `Wallet` that is related to this `Party`.",
             "args": [],
@@ -12602,6 +13439,18 @@
           },
           {
             "name": "accountByAccountId",
+            "description": "Reads a single `Account` that is related to this `Party`.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountByCreatorId",
             "description": "Reads a single `Account` that is related to this `Party`.",
             "args": [],
             "type": {
@@ -13899,6 +14748,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "creatorId",
+            "description": "Checks for equality with the object’s `creatorId` field.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "UUID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -14544,6 +15405,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "creatorId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "UUID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -15180,6 +16053,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creatorId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "UUID",
               "ofType": null
             },
             "defaultValue": null,
@@ -15854,6 +16739,18 @@
             "deprecationReason": null
           },
           {
+            "name": "approved",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "partyByDeveloperId",
             "description": "Reads a single `Party` that is related to this `Project`.",
             "args": [],
@@ -16268,6 +17165,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "approved",
+            "description": "Checks for equality with the object’s `approved` field.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -16474,6 +17383,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "approved",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -16600,6 +17521,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "UUID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "approved",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -16863,6 +17796,18 @@
           },
           {
             "name": "VERIFIER_ID_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "APPROVED_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "APPROVED_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -21679,6 +22624,18 @@
           },
           {
             "name": "accountByAccountId",
+            "description": "Reads a single `Account` that is related to this `Party`.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountByCreatorId",
             "description": "Reads a single `Account` that is related to this `Party`.",
             "args": [],
             "type": {

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.schema.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.schema.ts
@@ -5,8 +5,8 @@ import { profileModalSchema } from './components/ProfileModal/ProfileModal.schem
 
 export const rolesFormSchema = z
   .object({
-    projectDeveloper: profileModalSchema.nullable(),
-    verifier: profileModalSchema.nullable(),
+    projectDeveloper: profileModalSchema.nullable().optional(),
+    verifier: profileModalSchema.nullable().optional(),
     admin: addressSchema,
   })
   .required({ admin: true });

--- a/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.schema.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.schema.ts
@@ -10,7 +10,8 @@ import { chainInfo } from 'lib/wallet/chainInfo/chainInfo';
 
 export const profileModalSchema = z.object({
   id: z.string().optional(),
-  accountId: z.string().optional(),
+  accountId: z.string().nullable().optional(),
+  creatorId: z.string().nullable().optional(),
   profileType: z.custom<PartyType>(),
   name: z.string(),
   profileImage: z.string(),

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.styles.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.styles.ts
@@ -45,11 +45,4 @@ export const useStyles = makeStyles()(theme => ({
   popupIndicator: {
     color: theme.palette.secondary.main,
   },
-  edit: {
-    alignSelf: 'flex-end',
-    border: 'none',
-    fontSize: theme.typography.pxToRem(12),
-    marginTop: theme.spacing(2),
-    padding: theme.spacing(1, 2),
-  },
 }));

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useEffect, useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 
+import OutlinedButton from 'web-components/lib/components/buttons/OutlinedButton';
 import FieldFormControl from 'web-components/lib/components/inputs/new/FieldFormControl/FieldFormControl';
 import { UseStateSetter } from 'web-components/lib/types/react/useState';
 
@@ -38,9 +39,13 @@ interface Props {
   setDebouncedValue: UseStateSetter<string>;
   setValue: (value: ProfileModalSchemaType | null) => void;
   value?: ProfileModalSchemaType | null;
+  initialValue?: ProfileModalSchemaType | null;
   partiesByAccountId?: PartiesByAccountIdQuery | null;
   parties?: GetPartiesByNameOrAddrQuery | null;
-  saveProfile: (profile: ProfileModalSchemaType) => Promise<string | undefined>;
+  saveProfile: (
+    profile: ProfileModalSchemaType,
+    initialValue?: ProfileModalSchemaType,
+  ) => Promise<string | undefined>;
   accountId?: string;
 }
 
@@ -54,6 +59,7 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
       description,
       setValue,
       value,
+      initialValue,
       setDebouncedValue,
       partiesByAccountId,
       parties,
@@ -112,6 +118,7 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
       partiesByAccountId?.accountById?.partiesByAccountId?.nodes,
       value,
     ]);
+
     const closeProfileModal = (): void => {
       setProfileAdd(null);
     };
@@ -175,12 +182,20 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
             autoComplete
           />
         </FieldFormControl>
+        {value && value.id && value.creatorId === accountId && (
+          <OutlinedButton
+            className={styles.edit}
+            onClick={() => setProfileAdd(value)}
+          >
+            edit entity
+          </OutlinedButton>
+        )}
         {profileAdd && (
           <ProfileModal
             initialValues={profileAdd}
             onClose={closeProfileModal}
             onSubmit={async profile => {
-              const id = await saveProfile(profile);
+              const id = await saveProfile(profile, initialValue);
               if (id) {
                 closeProfileModal();
                 setInputValue(profile.name);

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
@@ -125,7 +125,7 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
     };
 
     const valueWithGroup = getValue(value, accountId);
-    console.log('value', value);
+
     return (
       <div className={cx(styles.root, classes && classes.root)}>
         <FieldFormControl

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
@@ -46,7 +46,7 @@ interface Props {
   saveProfile: (
     profile: ProfileModalSchemaType,
     initialValue?: ProfileModalSchemaType | null,
-  ) => Promise<string | undefined>;
+  ) => Promise<{ id: string; creatorId: string } | undefined>;
   accountId?: string;
 }
 
@@ -125,7 +125,7 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
     };
 
     const valueWithGroup = getValue(value, accountId);
-
+    console.log('value', value);
     return (
       <div className={cx(styles.root, classes && classes.root)}>
         <FieldFormControl
@@ -209,11 +209,13 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
             initialValues={profileAdd}
             onClose={closeProfileModal}
             onSubmit={async profile => {
-              const id = await saveProfile(profile, initialValue);
-              if (id) {
+              const party = await saveProfile(profile, initialValue);
+              const id = party?.id;
+              const creatorId = party?.creatorId;
+              if (id && creatorId) {
                 closeProfileModal();
                 setInputValue(profile.name);
-                setValue({ id, ...profile });
+                setValue({ id, creatorId, ...profile });
               }
             }}
           />

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 
 import OutlinedButton from 'web-components/lib/components/buttons/OutlinedButton';
+import EditIcon from 'web-components/lib/components/icons/EditIcon';
 import FieldFormControl from 'web-components/lib/components/inputs/new/FieldFormControl/FieldFormControl';
 import { UseStateSetter } from 'web-components/lib/types/react/useState';
 
@@ -44,7 +45,7 @@ interface Props {
   parties?: GetPartiesByNameOrAddrQuery | null;
   saveProfile: (
     profile: ProfileModalSchemaType,
-    initialValue?: ProfileModalSchemaType,
+    initialValue?: ProfileModalSchemaType | null,
   ) => Promise<string | undefined>;
   accountId?: string;
 }
@@ -184,10 +185,23 @@ export const RoleField = forwardRef<HTMLInputElement, Props>(
         </FieldFormControl>
         {value && value.id && value.creatorId === accountId && (
           <OutlinedButton
-            className={styles.edit}
+            size="small"
+            sx={{
+              p: [0],
+              border: 'none',
+              alignSelf: 'flex-end',
+              marginTop: 2.5,
+            }}
             onClick={() => setProfileAdd(value)}
           >
-            edit entity
+            <EditIcon
+              sx={{
+                width: 18,
+                height: 18,
+                pr: 1.25,
+              }}
+            />
+            edit profile
           </OutlinedButton>
         )}
         {profileAdd && (

--- a/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.utils.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/RoleField/RoleField.utils.tsx
@@ -24,7 +24,8 @@ export const group = (value: ProfileModalSchemaType, accountId?: string) =>
 
 export const getParties = (parties?: Maybe<PartyWithAccountFieldsFragment>[]) =>
   parties?.map(party => ({
-    accountId: party?.accountId as string,
+    accountId: party?.accountId,
+    creatorId: party?.creatorId,
     id: party?.id as string,
     name: party?.name || DEFAULT_NAME,
     profileType: party?.type as PartyType,

--- a/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
@@ -23,7 +23,7 @@ export const useSaveProfile = () => {
     async (
       profile: ProfileModalSchemaType,
       initialValue?: ProfileModalSchemaType | null,
-    ): Promise<string | undefined> => {
+    ): Promise<{ id: string; creatorId: string } | undefined> => {
       const edit =
         !!profile.creatorId && profile.creatorId === accountId && !!profile.id;
       try {
@@ -57,7 +57,7 @@ export const useSaveProfile = () => {
               },
             },
           });
-          return profile.id;
+          return { id: profile.id, creatorId: accountId };
         } else {
           const partyRes = await createParty({
             variables: {
@@ -73,7 +73,10 @@ export const useSaveProfile = () => {
               },
             },
           });
-          return partyRes.data?.createParty?.party?.id;
+          return {
+            id: partyRes.data?.createParty?.party?.id,
+            creatorId: accountId,
+          };
         }
       } catch (e) {
         setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);

--- a/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
@@ -5,22 +5,31 @@ import { useSetAtom } from 'jotai';
 import {
   useCreatePartyMutation,
   useCreateWalletMutation,
+  useUpdatePartyByIdMutation,
 } from 'generated/graphql';
 import { errorBannerTextAtom } from 'lib/atoms/error.atoms';
+import { useWallet } from 'lib/wallet/wallet';
 
 import { ProfileModalSchemaType } from '../components/ProfileModal/ProfileModal.schema';
 
 export const useSaveProfile = () => {
   const [createWallet] = useCreateWalletMutation();
   const [createParty] = useCreatePartyMutation();
+  const [updateParty] = useUpdatePartyByIdMutation();
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
+  const { accountId } = useWallet();
 
   const saveProfile = useCallback(
-    async (profile: ProfileModalSchemaType): Promise<string | undefined> => {
+    async (
+      profile: ProfileModalSchemaType,
+      initialValue?: ProfileModalSchemaType,
+    ): Promise<string | undefined> => {
+      const edit =
+        !!profile.creatorId && profile.creatorId === accountId && !!profile.id;
       try {
         let walletId;
         const addr = profile.address;
-        if (addr) {
+        if (!!addr && addr !== initialValue?.address) {
           const walletRes = await createWallet({
             variables: {
               input: {
@@ -32,26 +41,46 @@ export const useSaveProfile = () => {
           });
           walletId = walletRes.data?.createWallet?.wallet?.id;
         }
-        const partyRes = await createParty({
-          variables: {
-            input: {
-              party: {
-                type: profile.profileType,
-                name: profile.name,
-                description: profile.description,
-                image: profile.profileImage,
-                walletId,
+        if (edit) {
+          await updateParty({
+            variables: {
+              input: {
+                id: profile.id,
+                partyPatch: {
+                  type: profile.profileType,
+                  name: profile.name,
+                  description: profile.description,
+                  image: profile.profileImage,
+                  walletId,
+                  creatorId: accountId,
+                },
               },
             },
-          },
-        });
-        return partyRes.data?.createParty?.party?.id;
+          });
+          return profile.id;
+        } else {
+          const partyRes = await createParty({
+            variables: {
+              input: {
+                party: {
+                  type: profile.profileType,
+                  name: profile.name,
+                  description: profile.description,
+                  image: profile.profileImage,
+                  walletId,
+                  creatorId: accountId,
+                },
+              },
+            },
+          });
+          return partyRes.data?.createParty?.party?.id;
+        }
       } catch (e) {
         setErrorBannerTextAtom(errorsMapping[ERRORS.DEFAULT].title);
         return undefined;
       }
     },
-    [createParty, createWallet, setErrorBannerTextAtom],
+    [accountId, createParty, createWallet, setErrorBannerTextAtom, updateParty],
   );
 
   return saveProfile;

--- a/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/hooks/useSaveProfile.tsx
@@ -22,7 +22,7 @@ export const useSaveProfile = () => {
   const saveProfile = useCallback(
     async (
       profile: ProfileModalSchemaType,
-      initialValue?: ProfileModalSchemaType,
+      initialValue?: ProfileModalSchemaType | null,
     ): Promise<string | undefined> => {
       const edit =
         !!profile.creatorId && profile.creatorId === accountId && !!profile.id;

--- a/web-marketplace/src/generated/graphql.tsx
+++ b/web-marketplace/src/generated/graphql.tsx
@@ -37,10 +37,121 @@ export type Account = Node & {
   nonce: Scalars['String'];
   /** Reads and enables pagination through a set of `Party`. */
   partiesByAccountId: PartiesConnection;
+  /** Reads and enables pagination through a set of `Party`. */
+  partiesByCreatorId: PartiesConnection;
+  /** Reads and enables pagination through a set of `Account`. */
+  accountsByPartyAccountIdAndCreatorId: AccountAccountsByPartyAccountIdAndCreatorIdManyToManyConnection;
+  /** Reads and enables pagination through a set of `Account`. */
+  accountsByPartyCreatorIdAndAccountId: AccountAccountsByPartyCreatorIdAndAccountIdManyToManyConnection;
 };
 
 
 export type AccountPartiesByAccountIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<PartiesOrderBy>>;
+  condition?: Maybe<PartyCondition>;
+};
+
+
+export type AccountPartiesByCreatorIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<PartiesOrderBy>>;
+  condition?: Maybe<PartyCondition>;
+};
+
+
+export type AccountAccountsByPartyAccountIdAndCreatorIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<AccountsOrderBy>>;
+  condition?: Maybe<AccountCondition>;
+};
+
+
+export type AccountAccountsByPartyCreatorIdAndAccountIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<AccountsOrderBy>>;
+  condition?: Maybe<AccountCondition>;
+};
+
+/** A connection to a list of `Account` values, with data from `Party`. */
+export type AccountAccountsByPartyAccountIdAndCreatorIdManyToManyConnection = {
+  __typename?: 'AccountAccountsByPartyAccountIdAndCreatorIdManyToManyConnection';
+  /** A list of `Account` objects. */
+  nodes: Array<Maybe<Account>>;
+  /** A list of edges which contains the `Account`, info from the `Party`, and the cursor to aid in pagination. */
+  edges: Array<AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Account` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Account` edge in the connection, with data from `Party`. */
+export type AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdge = {
+  __typename?: 'AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Account` at the end of the edge. */
+  node?: Maybe<Account>;
+  /** Reads and enables pagination through a set of `Party`. */
+  partiesByCreatorId: PartiesConnection;
+};
+
+
+/** A `Account` edge in the connection, with data from `Party`. */
+export type AccountAccountsByPartyAccountIdAndCreatorIdManyToManyEdgePartiesByCreatorIdArgs = {
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  orderBy?: Maybe<Array<PartiesOrderBy>>;
+  condition?: Maybe<PartyCondition>;
+};
+
+/** A connection to a list of `Account` values, with data from `Party`. */
+export type AccountAccountsByPartyCreatorIdAndAccountIdManyToManyConnection = {
+  __typename?: 'AccountAccountsByPartyCreatorIdAndAccountIdManyToManyConnection';
+  /** A list of `Account` objects. */
+  nodes: Array<Maybe<Account>>;
+  /** A list of edges which contains the `Account`, info from the `Party`, and the cursor to aid in pagination. */
+  edges: Array<AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdge>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Account` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Account` edge in the connection, with data from `Party`. */
+export type AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdge = {
+  __typename?: 'AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Account` at the end of the edge. */
+  node?: Maybe<Account>;
+  /** Reads and enables pagination through a set of `Party`. */
+  partiesByAccountId: PartiesConnection;
+};
+
+
+/** A `Account` edge in the connection, with data from `Party`. */
+export type AccountAccountsByPartyCreatorIdAndAccountIdManyToManyEdgePartiesByAccountIdArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
@@ -386,6 +497,8 @@ export type CreatePartyPayload = {
   walletByWalletId?: Maybe<Wallet>;
   /** Reads a single `Account` that is related to this `Party`. */
   accountByAccountId?: Maybe<Account>;
+  /** Reads a single `Account` that is related to this `Party`. */
+  accountByCreatorId?: Maybe<Account>;
   /** An edge for our `Party`. May be used by Relay 1. */
   partyEdge?: Maybe<PartiesEdge>;
 };
@@ -1414,6 +1527,8 @@ export type DeletePartyPayload = {
   walletByWalletId?: Maybe<Wallet>;
   /** Reads a single `Account` that is related to this `Party`. */
   accountByAccountId?: Maybe<Account>;
+  /** Reads a single `Account` that is related to this `Party`. */
+  accountByCreatorId?: Maybe<Account>;
   /** An edge for our `Party`. May be used by Relay 1. */
   partyEdge?: Maybe<PartiesEdge>;
 };
@@ -2555,6 +2670,8 @@ export enum PartiesOrderBy {
   TwitterLinkDesc = 'TWITTER_LINK_DESC',
   WebsiteLinkAsc = 'WEBSITE_LINK_ASC',
   WebsiteLinkDesc = 'WEBSITE_LINK_DESC',
+  CreatorIdAsc = 'CREATOR_ID_ASC',
+  CreatorIdDesc = 'CREATOR_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -2575,10 +2692,13 @@ export type Party = Node & {
   bgImage?: Maybe<Scalars['String']>;
   twitterLink?: Maybe<Scalars['String']>;
   websiteLink?: Maybe<Scalars['String']>;
+  creatorId?: Maybe<Scalars['UUID']>;
   /** Reads a single `Wallet` that is related to this `Party`. */
   walletByWalletId?: Maybe<Wallet>;
   /** Reads a single `Account` that is related to this `Party`. */
   accountByAccountId?: Maybe<Account>;
+  /** Reads a single `Account` that is related to this `Party`. */
+  accountByCreatorId?: Maybe<Account>;
   /** Reads and enables pagination through a set of `CreditClass`. */
   creditClassesByRegistryId: CreditClassesConnection;
   /** Reads a single `Organization` that is related to this `Party`. */
@@ -2744,6 +2864,8 @@ export type PartyCondition = {
   twitterLink?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `websiteLink` field. */
   websiteLink?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `creatorId` field. */
+  creatorId?: Maybe<Scalars['UUID']>;
 };
 
 /** A connection to a list of `CreditClass` values, with data from `Project`. */
@@ -2834,6 +2956,7 @@ export type PartyInput = {
   bgImage?: Maybe<Scalars['String']>;
   twitterLink?: Maybe<Scalars['String']>;
   websiteLink?: Maybe<Scalars['String']>;
+  creatorId?: Maybe<Scalars['UUID']>;
 };
 
 /** A connection to a list of `Party` values, with data from `Project`. */
@@ -2924,6 +3047,7 @@ export type PartyPatch = {
   bgImage?: Maybe<Scalars['String']>;
   twitterLink?: Maybe<Scalars['String']>;
   websiteLink?: Maybe<Scalars['String']>;
+  creatorId?: Maybe<Scalars['UUID']>;
 };
 
 export enum PartyType {
@@ -3019,6 +3143,7 @@ export type Project = Node & {
   onChainId?: Maybe<Scalars['String']>;
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
+  approved?: Maybe<Scalars['Boolean']>;
   /** Reads a single `Party` that is related to this `Project`. */
   partyByDeveloperId?: Maybe<Party>;
   /** Reads a single `CreditClass` that is related to this `Project`. */
@@ -3078,6 +3203,8 @@ export type ProjectCondition = {
   adminWalletId?: Maybe<Scalars['UUID']>;
   /** Checks for equality with the object’s `verifierId` field. */
   verifierId?: Maybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `approved` field. */
+  approved?: Maybe<Scalars['Boolean']>;
 };
 
 /** A filter to be used against `Project` object types. All fields are combined with a logical ‘and.’ */
@@ -3104,6 +3231,7 @@ export type ProjectInput = {
   onChainId?: Maybe<Scalars['String']>;
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
+  approved?: Maybe<Scalars['Boolean']>;
 };
 
 /** Represents an update to a `Project`. Fields that are set will be updated. */
@@ -3118,6 +3246,7 @@ export type ProjectPatch = {
   onChainId?: Maybe<Scalars['String']>;
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
+  approved?: Maybe<Scalars['Boolean']>;
 };
 
 /** A connection to a list of `Project` values. */
@@ -3165,6 +3294,8 @@ export enum ProjectsOrderBy {
   AdminWalletIdDesc = 'ADMIN_WALLET_ID_DESC',
   VerifierIdAsc = 'VERIFIER_ID_ASC',
   VerifierIdDesc = 'VERIFIER_ID_DESC',
+  ApprovedAsc = 'APPROVED_ASC',
+  ApprovedDesc = 'APPROVED_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -4131,6 +4262,8 @@ export type UpdatePartyPayload = {
   walletByWalletId?: Maybe<Wallet>;
   /** Reads a single `Account` that is related to this `Party`. */
   accountByAccountId?: Maybe<Account>;
+  /** Reads a single `Account` that is related to this `Party`. */
+  accountByCreatorId?: Maybe<Account>;
   /** An edge for our `Party`. May be used by Relay 1. */
   partyEdge?: Maybe<PartiesEdge>;
 };
@@ -4604,7 +4737,7 @@ export type PartiesByAccountIdQuery = (
 
 export type PartyWithAccountFieldsFragment = (
   { __typename?: 'Party' }
-  & Pick<Party, 'id' | 'accountId' | 'name' | 'type' | 'image' | 'description'>
+  & Pick<Party, 'id' | 'accountId' | 'creatorId' | 'name' | 'type' | 'image' | 'description'>
   & { walletByWalletId?: Maybe<(
     { __typename?: 'Wallet' }
     & Pick<Wallet, 'addr'>
@@ -4876,7 +5009,7 @@ export type PartyByIdQuery = (
 
 export type PartyFieldsFragment = (
   { __typename?: 'Party' }
-  & Pick<Party, 'id' | 'accountId' | 'type' | 'name' | 'description' | 'image' | 'websiteLink' | 'twitterLink'>
+  & Pick<Party, 'id' | 'accountId' | 'creatorId' | 'type' | 'name' | 'description' | 'image' | 'websiteLink' | 'twitterLink'>
   & { organizationByPartyId?: Maybe<(
     { __typename?: 'Organization' }
     & OrganizationFieldsFragment
@@ -5097,6 +5230,7 @@ export const PartyWithAccountFieldsFragmentDoc = gql`
     fragment partyWithAccountFields on Party {
   id
   accountId
+  creatorId
   name
   type
   image
@@ -5130,6 +5264,7 @@ export const PartyFieldsFragmentDoc = gql`
     fragment partyFields on Party {
   id
   accountId
+  creatorId
   type
   name
   description

--- a/web-marketplace/src/graphql/AccountById.graphql
+++ b/web-marketplace/src/graphql/AccountById.graphql
@@ -11,6 +11,7 @@ query partiesByAccountId($id: UUID!){
 fragment partyWithAccountFields on Party {
   id
   accountId
+  creatorId
   name
   type
   image

--- a/web-marketplace/src/graphql/ProjectByHandle.graphql
+++ b/web-marketplace/src/graphql/ProjectByHandle.graphql
@@ -1,6 +1,7 @@
 fragment partyFields on Party {
   id
   accountId
+  creatorId
   type
   name
   description

--- a/web-marketplace/src/pages/Roles/Roles.utils.ts
+++ b/web-marketplace/src/pages/Roles/Roles.utils.ts
@@ -9,6 +9,7 @@ export const getProjectStakeholderInitialValues = (
     ? {
         id: party.id,
         accountId: party.accountId,
+        creatorId: party.creatorId,
         name: party.name || DEFAULT_NAME,
         profileImage: party?.image || getDefaultAvatar(party),
         profileType: party.type,

--- a/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
+++ b/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
@@ -85,7 +85,6 @@ const useRolesSubmit = ({
             projectPatch.adminWalletId = adminWalletId;
           }
         }
-
         const newMetadata = {
           ...metadata,
           ...getProjectStakeholders(values),


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1727
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

Create a new project or go to an existing project from https://deploy-preview-2100--regen-marketplace.netlify.app/profile/projects
Go to the Roles form and add a new profile for project developer or verifier.
You should then see the "edit profile" below the field, click and try to edit the profile.
Please be aware that "edit profile" won't get displayed for profiles that got added from the Roles form before this PR since we didn't assign a creator_id to those at the time. This has been added as part of this work to ensure that only the creator of a profile can edit it (until it's claimed by someone else who would log in using the profile wallet address if that was provided).

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
