### PR TITLE
feat: add off-chain projects to projects page

### DIFF
--- a/web-marketplace/graphql.schema.json
+++ b/web-marketplace/graphql.schema.json
@@ -16751,6 +16751,18 @@
             "deprecationReason": null
           },
           {
+            "name": "published",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "partyByDeveloperId",
             "description": "Reads a single `Party` that is related to this `Project`.",
             "args": [],
@@ -17177,6 +17189,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "published",
+            "description": "Checks for equality with the object’s `published` field.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -17395,6 +17419,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "published",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -17529,6 +17565,18 @@
           },
           {
             "name": "approved",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "published",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -17808,6 +17856,18 @@
           },
           {
             "name": "APPROVED_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUBLISHED_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PUBLISHED_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/web-marketplace/src/generated/graphql.tsx
+++ b/web-marketplace/src/generated/graphql.tsx
@@ -3144,6 +3144,7 @@ export type Project = Node & {
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
   approved?: Maybe<Scalars['Boolean']>;
+  published?: Maybe<Scalars['Boolean']>;
   /** Reads a single `Party` that is related to this `Project`. */
   partyByDeveloperId?: Maybe<Party>;
   /** Reads a single `CreditClass` that is related to this `Project`. */
@@ -3205,6 +3206,8 @@ export type ProjectCondition = {
   verifierId?: Maybe<Scalars['UUID']>;
   /** Checks for equality with the object’s `approved` field. */
   approved?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `published` field. */
+  published?: Maybe<Scalars['Boolean']>;
 };
 
 /** A filter to be used against `Project` object types. All fields are combined with a logical ‘and.’ */
@@ -3232,6 +3235,7 @@ export type ProjectInput = {
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
   approved?: Maybe<Scalars['Boolean']>;
+  published?: Maybe<Scalars['Boolean']>;
 };
 
 /** Represents an update to a `Project`. Fields that are set will be updated. */
@@ -3247,6 +3251,7 @@ export type ProjectPatch = {
   adminWalletId?: Maybe<Scalars['UUID']>;
   verifierId?: Maybe<Scalars['UUID']>;
   approved?: Maybe<Scalars['Boolean']>;
+  published?: Maybe<Scalars['Boolean']>;
 };
 
 /** A connection to a list of `Project` values. */
@@ -3296,6 +3301,8 @@ export enum ProjectsOrderBy {
   VerifierIdDesc = 'VERIFIER_ID_DESC',
   ApprovedAsc = 'APPROVED_ASC',
   ApprovedDesc = 'APPROVED_DESC',
+  PublishedAsc = 'PUBLISHED_ASC',
+  PublishedDesc = 'PUBLISHED_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -4788,11 +4795,14 @@ export type AllProjectsQuery = (
     { __typename?: 'ProjectsConnection' }
     & { nodes: Array<Maybe<(
       { __typename?: 'Project' }
-      & Pick<Project, 'id' | 'slug' | 'metadata'>
+      & Pick<Project, 'id' | 'slug' | 'metadata' | 'onChainId'>
       & { creditClassByCreditClassId?: Maybe<(
         { __typename?: 'CreditClass' }
         & Pick<CreditClass, 'id' | 'onChainId'>
-        & { creditClassVersionsById: (
+        & { partyByRegistryId?: Maybe<(
+          { __typename?: 'Party' }
+          & PartyFieldsFragment
+        )>, creditClassVersionsById: (
           { __typename?: 'CreditClassVersionsConnection' }
           & { nodes: Array<Maybe<(
             { __typename?: 'CreditClassVersion' }
@@ -5445,9 +5455,13 @@ export const AllProjectsDocument = gql`
       id
       slug
       metadata
+      onChainId
       creditClassByCreditClassId {
         id
         onChainId
+        partyByRegistryId {
+          ...partyFields
+        }
         creditClassVersionsById {
           nodes {
             id
@@ -5460,7 +5474,7 @@ export const AllProjectsDocument = gql`
     }
   }
 }
-    `;
+    ${PartyFieldsFragmentDoc}`;
 
 /**
  * __useAllProjectsQuery__

--- a/web-marketplace/src/graphql/AllProjects.graphql
+++ b/web-marketplace/src/graphql/AllProjects.graphql
@@ -4,9 +4,13 @@ query AllProjects {
       id
       slug
       metadata
+      onChainId
       creditClassByCreditClassId {
         id
         onChainId
+        partyByRegistryId {
+          ...partyFields
+        }
         creditClassVersionsById {
           nodes {
             id

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -146,13 +146,8 @@ export function useProjectsWithOrders({
     sanityCreditClassData: creditClassData,
   });
 
-  // Merge on-chain and off-chain projects
-  const allProjectsWithOrderData = useOffChainProjects
-    ? [...projectsWithOrderData, ...allOffChainProjects]
-    : projectsWithOrderData;
-
   // Exclude community projects based on sanity credit class data
-  const projectsWithOrderDataFiltered = allProjectsWithOrderData.filter(
+  const projectsWithOrderDataFiltered = projectsWithOrderData.filter(
     project => !!project.sanityCreditClassData || useCommunityProjects,
   );
 
@@ -160,15 +155,19 @@ export function useProjectsWithOrders({
     project => !project.sanityCreditClassData,
   );
 
+  // Merge on-chain and off-chain projects
+  const allProject = useOffChainProjects
+    ? [...projectsWithOrderDataFiltered, ...allOffChainProjects]
+    : projectsWithOrderDataFiltered;
+
   // Filter projects by class ID
   const creditClassSelected = Object.keys(creditClassFilter).filter(
     creditClassId => creditClassFilter[creditClassId],
   );
-  const projectsFilteredByCreditClass = projectsWithOrderDataFiltered.filter(
-    project =>
-      creditClassSelected.length === 0
-        ? true
-        : creditClassSelected.includes(project.creditClassId ?? ''),
+  const projectsFilteredByCreditClass = allProject.filter(project =>
+    creditClassSelected.length === 0
+      ? true
+      : creditClassSelected.includes(project.creditClassId ?? ''),
   );
 
   const sortedProjects = sortProjects(

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -17,6 +17,7 @@ import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-ser
 import { getAllSanityCreditClassesQuery } from 'lib/queries/react-query/sanity/getAllCreditClassesQuery/getAllCreditClassesQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
+import { useFetchAllOffChainProjects } from 'pages/Projects/hooks/useOffChainProjects';
 import { ProjectsSellOrders } from 'pages/Projects/hooks/useProjectsSellOrders.types';
 import { sortProjects } from 'pages/Projects/utils/sortProjects';
 import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
@@ -30,6 +31,7 @@ export interface ProjectsWithOrdersProps {
   metadata?: boolean; // to discard projects without metadata prop
   random?: boolean; // to shuffle the projects (along with limit allows a random subselection)
   useCommunityProjects?: boolean; // to show community projects
+  useOffChainProjects?: boolean; // to show approved off-chain projects;
   projectId?: string; // to filter by project
   skippedProjectId?: string; // to discard a specific project
   classId?: string; // to filter by class
@@ -46,6 +48,7 @@ export function useProjectsWithOrders({
   metadata = false,
   random = false,
   useCommunityProjects = false,
+  useOffChainProjects = false,
   skippedProjectId,
   classId,
   sort = '',
@@ -103,6 +106,13 @@ export function useProjectsWithOrders({
       getAllSanityCreditClassesQuery({ sanityClient, enabled: !!sanityClient }),
     );
 
+  // OffChainProjects
+  const { allOffChainProjects, isAllOffChainProjectsLoading } =
+    useFetchAllOffChainProjects({
+      sanityCreditClassesData: creditClassData,
+      enabled: useOffChainProjects,
+    });
+
   /* Normalization/Filtering/Sorting */
 
   let projects: ProjectInfo[] | undefined;
@@ -136,8 +146,13 @@ export function useProjectsWithOrders({
     sanityCreditClassData: creditClassData,
   });
 
+  // Merge on-chain and off-chain projects
+  const allProjectsWithOrderData = useOffChainProjects
+    ? [...projectsWithOrderData, ...allOffChainProjects]
+    : projectsWithOrderData;
+
   // Exclude community projects based on sanity credit class data
-  const projectsWithOrderDataFiltered = projectsWithOrderData.filter(
+  const projectsWithOrderDataFiltered = allProjectsWithOrderData.filter(
     project => !!project.sanityCreditClassData || useCommunityProjects,
   );
 
@@ -231,6 +246,7 @@ export function useProjectsWithOrders({
       isLoadingProject ||
       isClassesMetadataLoading ||
       projectsMetadataLoading ||
+      isAllOffChainProjectsLoading ||
       offChainProjectLoading,
     hasCommunityProjects,
   };

--- a/web-marketplace/src/pages/Projects/Projects.OffChainFilter.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.OffChainFilter.tsx
@@ -1,0 +1,48 @@
+import { Box, FormControlLabel, SxProps, Theme } from '@mui/material';
+
+import { Flex } from 'web-components/lib/components/box';
+import Checkbox from 'web-components/lib/components/inputs/new/CheckBox/Checkbox';
+import InfoTooltipWithIcon from 'web-components/lib/components/tooltip/InfoTooltipWithIcon';
+
+import { UseStateSetter } from 'types/react/use-state';
+
+import { OFFCHAIN_FILTER } from './Projects.constants';
+
+type CommunityFilterProps = {
+  useOffChainProjects?: boolean;
+  setUseOffChainProjects: UseStateSetter<boolean | undefined>;
+  sx?: SxProps<Theme>;
+};
+
+export const OffChainFilter = ({
+  useOffChainProjects = false,
+  setUseOffChainProjects,
+  sx,
+}: CommunityFilterProps) => {
+  return (
+    <Flex sx={sx}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            sx={{ p: 0, mr: 3 }}
+            checked={useOffChainProjects}
+            onChange={event => {
+              setUseOffChainProjects(event.target.checked);
+            }}
+          />
+        }
+        label={OFFCHAIN_FILTER}
+        sx={{ whiteSpace: 'nowrap', mr: 1, ml: 0, fontSize: 14 }}
+      />
+      <InfoTooltipWithIcon
+        title={
+          <Box sx={{ textAlign: 'start' }}>
+            Off-chain projects are being worked on and not yet submitted
+            on-chain.
+          </Box>
+        }
+        outlined
+      />
+    </Flex>
+  );
+};

--- a/web-marketplace/src/pages/Projects/Projects.OffChainFilter.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.OffChainFilter.tsx
@@ -6,7 +6,7 @@ import InfoTooltipWithIcon from 'web-components/lib/components/tooltip/InfoToolt
 
 import { UseStateSetter } from 'types/react/use-state';
 
-import { OFFCHAIN_FILTER } from './Projects.constants';
+import { OFFCHAIN_FILTER, OFFCHAIN_FILTER_Tooltip } from './Projects.constants';
 
 type CommunityFilterProps = {
   useOffChainProjects?: boolean;
@@ -35,12 +35,7 @@ export const OffChainFilter = ({
         sx={{ whiteSpace: 'nowrap', mr: 1, ml: 0, fontSize: 14 }}
       />
       <InfoTooltipWithIcon
-        title={
-          <Box sx={{ textAlign: 'start' }}>
-            Off-chain projects are being worked on and not yet submitted
-            on-chain.
-          </Box>
-        }
+        title={<Box sx={{ textAlign: 'start' }}>{OFFCHAIN_FILTER_Tooltip}</Box>}
         outlined
       />
     </Flex>

--- a/web-marketplace/src/pages/Projects/Projects.SideFilter.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.SideFilter.tsx
@@ -173,7 +173,6 @@ export const ProjectsSideFilter = ({
                   useCommunityProjects={useCommunityProjects}
                   setUseCommunityProjects={setUseCommunityProjects}
                   sx={{
-                    mt: { xs: 6.25, lg: 0 },
                     mr: { xs: 0, lg: 7.5 },
                     width: { xs: '100%', lg: 'auto' },
                     order: { xs: 2, lg: 1 },
@@ -193,7 +192,6 @@ export const ProjectsSideFilter = ({
                 useOffChainProjects={useOffChainProjects}
                 setUseOffChainProjects={setUseOffChainProjects}
                 sx={{
-                  mt: { xs: 6.25, lg: 0 },
                   mr: { xs: 0, lg: 7.5 },
                   width: { xs: '100%', lg: 'auto' },
                   order: { xs: 2, lg: 1 },

--- a/web-marketplace/src/pages/Projects/Projects.SideFilter.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.SideFilter.tsx
@@ -23,10 +23,12 @@ import {
   COMMUNITY_FILTER_LABEL,
   CREDIT_CLASS_FILTER_LABEL,
   FILTERS_LABEL,
+  OFFCHAIN_FILTER_LABEL,
   RESET_FILTERS_LABEL,
   SIDE_FILTERS_BUTTON,
 } from './Projects.constants';
 import { CreditClassFilter } from './Projects.normalizers';
+import { OffChainFilter } from './Projects.OffChainFilter';
 import { FilterCreditClassEvent } from './Projects.types';
 import { getFilterSelected } from './Projects.utils';
 
@@ -35,9 +37,11 @@ type Props = {
   creditClassSelectedFilters: Record<string, boolean>;
   hasCommunityProjects: boolean;
   useCommunityProjects?: boolean;
+  useOffChainProjects?: boolean;
   showFiltersReset: boolean;
   setCreditClassFilter: UseStateSetter<Record<string, boolean>>;
   setUseCommunityProjects: UseStateSetter<boolean | undefined>;
+  setUseOffChainProjects: UseStateSetter<boolean | undefined>;
   resetFilter: () => void;
   sx?: SxProps<Theme>;
 };
@@ -47,9 +51,11 @@ export const ProjectsSideFilter = ({
   creditClassSelectedFilters,
   hasCommunityProjects,
   useCommunityProjects,
+  useOffChainProjects,
   showFiltersReset,
   setCreditClassFilter,
   setUseCommunityProjects,
+  setUseOffChainProjects,
   resetFilter,
   sx = [],
 }: Props) => {
@@ -176,6 +182,25 @@ export const ProjectsSideFilter = ({
               </Box>
             </>
           )}
+          <>
+            <Box sx={{ height: '1px', bgcolor: 'info.light', my: 7.5 }} />
+            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+              <Subtitle size="md" sx={{ mb: 3.75 }}>
+                {OFFCHAIN_FILTER_LABEL}
+              </Subtitle>
+
+              <OffChainFilter
+                useOffChainProjects={useOffChainProjects}
+                setUseOffChainProjects={setUseOffChainProjects}
+                sx={{
+                  mt: { xs: 6.25, lg: 0 },
+                  mr: { xs: 0, lg: 7.5 },
+                  width: { xs: '100%', lg: 'auto' },
+                  order: { xs: 2, lg: 1 },
+                }}
+              />
+            </Box>
+          </>
         </Box>
       </SwipeableDrawer>
     </>

--- a/web-marketplace/src/pages/Projects/Projects.constants.ts
+++ b/web-marketplace/src/pages/Projects/Projects.constants.ts
@@ -3,11 +3,13 @@ export const SOLD_OUT_TOOLTIP =
 export const NO_CREDITS_TOOLTIP =
   'There are currently no open sell orders for this project.';
 export const COMMUNITY_FILTER = 'Show community credits';
-export const OFFCHAIN_FILTER = 'Show off-chain credits';
+export const OFFCHAIN_FILTER = 'Show off-chain projects';
 export const SIDE_FILTERS_BUTTON = 'Add filters';
 export const FILTERS_LABEL = 'Filters';
 export const RESET_FILTERS_LABEL = 'Reset filters';
 export const CREDIT_CLASS_FILTER_LABEL = 'Credit Class';
 export const COMMUNITY_FILTER_LABEL = 'Community Credits';
 export const OFFCHAIN_FILTER_LABEL = 'Off-chain Projects';
+export const OFFCHAIN_FILTER_Tooltip =
+  'Off-chain projects are under development and have not yet been created on the Regen Ledger blockchain.';
 export const EMPTY_PROJECTS_LABEL = 'No matching results found';

--- a/web-marketplace/src/pages/Projects/Projects.constants.ts
+++ b/web-marketplace/src/pages/Projects/Projects.constants.ts
@@ -3,9 +3,11 @@ export const SOLD_OUT_TOOLTIP =
 export const NO_CREDITS_TOOLTIP =
   'There are currently no open sell orders for this project.';
 export const COMMUNITY_FILTER = 'Show community credits';
+export const OFFCHAIN_FILTER = 'Show off-chain credits';
 export const SIDE_FILTERS_BUTTON = 'Add filters';
 export const FILTERS_LABEL = 'Filters';
 export const RESET_FILTERS_LABEL = 'Reset filters';
 export const CREDIT_CLASS_FILTER_LABEL = 'Credit Class';
 export const COMMUNITY_FILTER_LABEL = 'Community Credits';
+export const OFFCHAIN_FILTER_LABEL = 'Off-chain Projects';
 export const EMPTY_PROJECTS_LABEL = 'No matching results found';

--- a/web-marketplace/src/pages/Projects/Projects.tsx
+++ b/web-marketplace/src/pages/Projects/Projects.tsx
@@ -54,6 +54,9 @@ export const Projects: React.FC<React.PropsWithChildren<unknown>> = () => {
   const [useCommunityProjects, setUseCommunityProjects] = useState<
     boolean | undefined
   >(undefined);
+  const [useOffChainProjects, setUseOffChainProjects] = useState<
+    boolean | undefined
+  >(undefined);
   const [creditClassSelectedFilters, setCreditClassSelectedFilters] = useState(
     {},
   );
@@ -103,6 +106,7 @@ export const Projects: React.FC<React.PropsWithChildren<unknown>> = () => {
       sort,
       offset: page * PROJECTS_PER_PAGE,
       useCommunityProjects,
+      useOffChainProjects,
       creditClassFilter: creditClassSelectedFilters,
     });
 
@@ -119,6 +123,7 @@ export const Projects: React.FC<React.PropsWithChildren<unknown>> = () => {
   const resetFilter = () => {
     setCreditClassSelectedFilters({});
     setUseCommunityProjects(undefined);
+    setUseOffChainProjects(undefined);
   };
 
   if (
@@ -179,9 +184,11 @@ export const Projects: React.FC<React.PropsWithChildren<unknown>> = () => {
                 creditClassFilters={creditClassFilters}
                 hasCommunityProjects={hasCommunityProjects}
                 useCommunityProjects={useCommunityProjects}
+                useOffChainProjects={useOffChainProjects}
                 showFiltersReset={showFiltersReset}
                 setCreditClassFilter={setCreditClassSelectedFilters}
                 setUseCommunityProjects={setUseCommunityProjects}
+                setUseOffChainProjects={setUseOffChainProjects}
                 resetFilter={resetFilter}
                 sx={{
                   mt: { xs: 6.25, lg: 0 },

--- a/web-marketplace/src/pages/Projects/hooks/useOffChainProjects.tsx
+++ b/web-marketplace/src/pages/Projects/hooks/useOffChainProjects.tsx
@@ -1,0 +1,56 @@
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  useApolloClient,
+} from '@apollo/client';
+import { useQuery } from '@tanstack/react-query';
+
+import { AllCreditClassQuery } from 'generated/sanity-graphql';
+import { normalizeProjectWithMetadata } from 'lib/normalizers/projects/normalizeProjectsWithMetadata';
+import { getAllProjectsQuery } from 'lib/queries/react-query/registry-server/graphql/getAllProjectsQuery/getAllProjectsQuery';
+
+import { findSanityCreditClass } from 'components/templates/ProjectDetails/ProjectDetails.utils';
+
+type Props = {
+  sanityCreditClassesData?: AllCreditClassQuery;
+  enabled?: boolean;
+};
+
+export const useFetchAllOffChainProjects = ({
+  sanityCreditClassesData,
+  enabled = true,
+}: Props) => {
+  const graphqlClient =
+    useApolloClient() as ApolloClient<NormalizedCacheObject>;
+
+  const { data: allProjectsData, isFetching } = useQuery(
+    getAllProjectsQuery({ client: graphqlClient, enabled }),
+  );
+
+  const offChainProjects = allProjectsData?.allProjects?.nodes.filter(
+    project => !project?.onChainId,
+  );
+
+  const onlyOffChainProjectsWithData =
+    offChainProjects?.map(project => ({
+      offChain: true,
+      ...normalizeProjectWithMetadata({
+        offChainProject: project,
+        projectMetadata: project?.metadata,
+        projectPageMetadata: project?.metadata,
+        programParty: project?.creditClassByCreditClassId?.partyByRegistryId,
+        sanityClass: findSanityCreditClass({
+          sanityCreditClassData: sanityCreditClassesData,
+          creditClassIdOrUrl:
+            project?.creditClassByCreditClassId?.onChainId ??
+            project?.metadata?.['regen:creditClassId'] ??
+            '',
+        }),
+      }),
+    })) ?? [];
+
+  return {
+    allOffChainProjects: onlyOffChainProjectsWithData,
+    isAllOffChainProjectsLoading: isFetching,
+  };
+};

--- a/web-marketplace/src/pages/Projects/hooks/useProjects.tsx
+++ b/web-marketplace/src/pages/Projects/hooks/useProjects.tsx
@@ -15,6 +15,7 @@ type Props = {
   sort: string;
   offset?: number;
   useCommunityProjects?: boolean;
+  useOffChainProjects?: boolean;
   creditClassFilter?: Record<string, boolean>;
 };
 
@@ -22,6 +23,7 @@ export const useProjects = ({
   offset = 0,
   sort,
   useCommunityProjects = false,
+  useOffChainProjects = false,
   creditClassFilter = {},
 }: Props): ResponseType => {
   // get normalized projects with sell order data
@@ -35,6 +37,7 @@ export const useProjects = ({
     offset,
     sort,
     useCommunityProjects,
+    useOffChainProjects,
     creditClassFilter,
   });
 


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2077

- display off-chain projects on `/projects`
- add off-chain projects filter

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2101--regen-marketplace.netlify.app/projects/1
2. toggle both filters to see off-chains projects

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
