### PR TITLE
fix: disable default push with lerna bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "start-auth": "lerna run --scope web-auth start --stream",
     "watch": "lerna run watch --stream",
     "test-update-snapshot": "lerna run --scope web-marketplace test-update-snapshot --stream",
-    "bump": "lerna version --conventional-commits",
+    "bump": "lerna version --no-push --conventional-commits",
+    "bump-and-push": "lerna version --conventional-commits",
     "postinstall": "patch-package"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#1803

- rename `bump` command to `bump-and-push`
- add `bump` command using `no-push` option

Release process document has been updated accordingly.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
