### PR TITLE
feat: use resized image on profile and gallery

### DIFF
--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent } from 'react';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 import { GeocodeResponse } from '@mapbox/mapbox-sdk/services/geocoding';
+import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
 
 import PhoneIcon from 'web-components/lib/components/icons/PhoneIcon';
 import StaticMap from 'web-components/lib/components/map/StaticMap';
@@ -156,7 +157,11 @@ export const getProjectGalleryPhotos = ({
 }: GetProjectGalleryPhotosProps) => {
   const photos: GalleryPhoto[] =
     offChainProjectMetadata?.['regen:galleryPhotos']?.map(photo => ({
-      href: photo['schema:url'],
+      href: getResizedImageUrl({
+        url: photo['schema:url'],
+        startPattern: '/projects',
+        width: 1400,
+      }),
       caption: photo['schema:caption'],
       credit: photo['schema:creditText'],
     })) ?? [];

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
@@ -159,7 +159,6 @@ export const getProjectGalleryPhotos = ({
     offChainProjectMetadata?.['regen:galleryPhotos']?.map(photo => ({
       href: getResizedImageUrl({
         url: photo['schema:url'],
-        startPattern: '/projects',
         width: 1400,
       }),
       caption: photo['schema:caption'],

--- a/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
+++ b/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
@@ -8,7 +8,6 @@ import {
   useUpdateProjectByIdMutation,
 } from 'generated/graphql';
 import { getCreditClassByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getCreditClassByOnChainIdQuery/getCreditClassByOnChainIdQuery';
-import { getProjectByOnChainIdKey } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery.constants';
 import { getWalletByAddrQuery } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery';
 import { getWalletByAddrQueryKey } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery.utils';
 import { getUnanchoredProjectBaseMetadata } from 'lib/rdf';

--- a/web-marketplace/src/lib/env.ts
+++ b/web-marketplace/src/lib/env.ts
@@ -1,6 +1,7 @@
 export const IS_DEV = import.meta.env.DEV;
 export const apiServerUrl = import.meta.env.VITE_API_URI;
 export const SKIPPED_CLASS_ID = import.meta.env.VITE_SKIPPED_CLASS_ID;
+export const API_URI = import.meta.env.VITE_API_URI;
 export const IMAGE_STORAGE_BASE_URL =
   import.meta.env.VITE_IMAGE_STORAGE_BASE_URL ??
   'https://regen-registry.s3.amazonaws.com/';

--- a/web-marketplace/src/lib/normalizers/retirements/normalizeRetirement.ts
+++ b/web-marketplace/src/lib/normalizers/retirements/normalizeRetirement.ts
@@ -1,7 +1,6 @@
 import {
   ClassInfo,
   ProjectInfo,
-  QueryProjectResponse,
 } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 
 import { Party } from 'web-components/lib/components/user/UserInfo';

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -100,7 +100,6 @@ const Dashboard = (): JSX.Element => {
           party?.bgImage
             ? getResizedImageUrl({
                 url: party?.bgImage,
-                startPattern: '/profiles',
                 width: 1400,
               })
             : DEFAULT_PROFILE_BG
@@ -109,7 +108,6 @@ const Dashboard = (): JSX.Element => {
           party?.image
             ? getResizedImageUrl({
                 url: party?.image,
-                startPattern: '/profiles',
                 width: 140,
               })
             : defaultAvatar

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Box } from '@mui/material';
+import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
 
 import { Flex } from 'web-components/lib/components/box';
 import BridgeIcon from 'web-components/lib/components/icons/BridgeIcon';
@@ -94,9 +95,25 @@ const Dashboard = (): JSX.Element => {
   return (
     <>
       <ProfileHeader
-        name={party?.name ? party?.name : DEFAULT_NAME}
-        backgroundImage={party?.bgImage ? party?.bgImage : DEFAULT_PROFILE_BG}
-        avatar={party?.image ? party?.image : defaultAvatar}
+        name={party?.name ? party.name : DEFAULT_NAME}
+        backgroundImage={
+          party?.bgImage
+            ? getResizedImageUrl({
+                url: party?.bgImage,
+                startPattern: '/profiles',
+                width: 1400,
+              })
+            : DEFAULT_PROFILE_BG
+        }
+        avatar={
+          party?.image
+            ? getResizedImageUrl({
+                url: party?.image,
+                startPattern: '/profiles',
+                width: 140,
+              })
+            : defaultAvatar
+        }
         infos={{
           addressLink: {
             href: getAccountUrl(wallet?.address, true),

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Box } from '@mui/material';
-import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
 
 import { Flex } from 'web-components/lib/components/box';
 import BridgeIcon from 'web-components/lib/components/icons/BridgeIcon';
@@ -23,7 +22,6 @@ import { useWallet } from 'lib/wallet/wallet';
 import { usePartyInfos } from 'pages/ProfileEdit/hooks/usePartyInfos';
 import {
   DEFAULT_NAME,
-  DEFAULT_PROFILE_BG,
   profileVariantMapping,
 } from 'pages/ProfileEdit/ProfileEdit.constants';
 import { Link } from 'components/atoms';
@@ -32,7 +30,7 @@ import { useQueryIsIssuer } from 'hooks/useQueryIsIssuer';
 import { useQueryIsProjectAdmin } from 'hooks/useQueryIsProjectAdmin';
 
 import { dashBoardStyles } from './Dashboard.styles';
-import { getSocialsLinks } from './Dashboard.utils';
+import { getSocialsLinks, getUserImages } from './Dashboard.utils';
 
 const Dashboard = (): JSX.Element => {
   const isIssuer = useQueryIsIssuer();
@@ -42,7 +40,8 @@ const Dashboard = (): JSX.Element => {
   const { wallet, accountId, partyByAddr } = useWallet();
   const location = useLocation();
 
-  const { party, defaultAvatar } = usePartyInfos({ partyByAddr });
+  const { party } = usePartyInfos({ partyByAddr });
+  const { avatarImage, backgroundImage } = getUserImages({ party });
 
   const socialsLinks: SocialLink[] = useMemo(
     () =>
@@ -96,22 +95,8 @@ const Dashboard = (): JSX.Element => {
     <>
       <ProfileHeader
         name={party?.name ? party.name : DEFAULT_NAME}
-        backgroundImage={
-          party?.bgImage
-            ? getResizedImageUrl({
-                url: party?.bgImage,
-                width: 1400,
-              })
-            : DEFAULT_PROFILE_BG
-        }
-        avatar={
-          party?.image
-            ? getResizedImageUrl({
-                url: party?.image,
-                width: 190,
-              })
-            : defaultAvatar
-        }
+        backgroundImage={backgroundImage}
+        avatar={avatarImage}
         infos={{
           addressLink: {
             href: getAccountUrl(wallet?.address, true),

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -108,7 +108,7 @@ const Dashboard = (): JSX.Element => {
           party?.image
             ? getResizedImageUrl({
                 url: party?.image,
-                width: 140,
+                width: 190,
               })
             : defaultAvatar
         }

--- a/web-marketplace/src/pages/Dashboard/Dashboard.utils.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.utils.tsx
@@ -1,8 +1,15 @@
+import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
+
 import TwitterIcon2 from 'web-components/lib/components/icons/social/TwitterIcon2';
 import WebsiteLinkIcon from 'web-components/lib/components/icons/social/WebsiteLinkIcon';
 import { SocialLink } from 'web-components/lib/components/organisms/ProfileHeader/ProfileHeader.types';
 
 import { Party } from 'generated/graphql';
+
+import { DEFAULT_PROFILE_BG } from 'pages/ProfileEdit/ProfileEdit.constants';
+import { getDefaultAvatar } from 'pages/ProfileEdit/ProfileEdit.utils';
+
+/* getSocialsLinks */
 
 type GetSocialsLinksParams = {
   party?: Pick<
@@ -34,4 +41,28 @@ export const getSocialsLinks = ({
   ].filter((link): link is SocialLink => {
     return !!link.href;
   });
+};
+
+/* getSocialsLinks */
+
+type GetUserImagesParams = {
+  party?: Partial<Party> | null;
+};
+
+export const getUserImages = ({ party }: GetUserImagesParams) => {
+  const backgroundImage = party?.bgImage
+    ? getResizedImageUrl({
+        url: party?.bgImage,
+        width: 1400,
+      })
+    : DEFAULT_PROFILE_BG;
+
+  const avatarImage = party?.image
+    ? getResizedImageUrl({
+        url: party?.image,
+        width: 190,
+      })
+    : getDefaultAvatar(party);
+
+  return { backgroundImage, avatarImage };
 };

--- a/web-marketplace/src/pages/Dashboard/Dashboard.utils.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.utils.tsx
@@ -4,7 +4,7 @@ import TwitterIcon2 from 'web-components/lib/components/icons/social/TwitterIcon
 import WebsiteLinkIcon from 'web-components/lib/components/icons/social/WebsiteLinkIcon';
 import { SocialLink } from 'web-components/lib/components/organisms/ProfileHeader/ProfileHeader.types';
 
-import { Party } from 'generated/graphql';
+import { Maybe, Party } from 'generated/graphql';
 
 import { DEFAULT_PROFILE_BG } from 'pages/ProfileEdit/ProfileEdit.constants';
 import { getDefaultAvatar } from 'pages/ProfileEdit/ProfileEdit.utils';
@@ -46,7 +46,7 @@ export const getSocialsLinks = ({
 /* getSocialsLinks */
 
 type GetUserImagesParams = {
-  party?: Partial<Party> | null;
+  party?: Pick<Party, 'type' | 'image' | 'bgImage'> | null;
 };
 
 export const getUserImages = ({ party }: GetUserImagesParams) => {

--- a/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -73,7 +73,6 @@ export const EcocreditsByAccount = (): JSX.Element => {
           party?.bgImage
             ? getResizedImageUrl({
                 url: party?.bgImage,
-                startPattern: '/profiles',
                 width: 1400,
               })
             : DEFAULT_PROFILE_BG
@@ -82,7 +81,6 @@ export const EcocreditsByAccount = (): JSX.Element => {
           party?.image
             ? getResizedImageUrl({
                 url: party?.image,
-                startPattern: '/profiles',
                 width: 140,
               })
             : defaultAvatar

--- a/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { Box } from '@mui/material';
+import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
 
 import { Flex } from 'web-components/lib/components/box';
 import BridgeIcon from 'web-components/lib/components/icons/BridgeIcon';
@@ -68,8 +69,24 @@ export const EcocreditsByAccount = (): JSX.Element => {
     <>
       <ProfileHeader
         name={party?.name ? party?.name : DEFAULT_NAME}
-        backgroundImage={party?.bgImage ? party?.bgImage : DEFAULT_PROFILE_BG}
-        avatar={party?.image ? party?.image : defaultAvatar}
+        backgroundImage={
+          party?.bgImage
+            ? getResizedImageUrl({
+                url: party?.bgImage,
+                startPattern: '/profiles',
+                width: 1400,
+              })
+            : DEFAULT_PROFILE_BG
+        }
+        avatar={
+          party?.image
+            ? getResizedImageUrl({
+                url: party?.image,
+                startPattern: '/profiles',
+                width: 140,
+              })
+            : defaultAvatar
+        }
         infos={{
           addressLink: {
             href: address

--- a/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { Outlet, useLocation, useParams } from 'react-router-dom';
 import { Box } from '@mui/material';
-import { getResizedImageUrl } from 'utils/image/getResizedImageUrl';
 
 import { Flex } from 'web-components/lib/components/box';
 import BridgeIcon from 'web-components/lib/components/icons/BridgeIcon';
@@ -15,13 +14,14 @@ import { truncate } from 'web-components/lib/utils/truncate';
 
 import { getAccountUrl } from 'lib/block-explorer';
 
-import { getSocialsLinks } from 'pages/Dashboard/Dashboard.utils';
+import {
+  getSocialsLinks,
+  getUserImages,
+} from 'pages/Dashboard/Dashboard.utils';
 import {
   DEFAULT_NAME,
-  DEFAULT_PROFILE_BG,
   profileVariantMapping,
 } from 'pages/ProfileEdit/ProfileEdit.constants';
-import { getDefaultAvatar } from 'pages/ProfileEdit/ProfileEdit.utils';
 import { Link } from 'components/atoms';
 
 import { ecocreditsByAccountStyles } from './EcocreditsByAccount.styles';
@@ -32,7 +32,7 @@ export const EcocreditsByAccount = (): JSX.Element => {
   const location = useLocation();
 
   const { address, party } = useProfileData();
-  const defaultAvatar = getDefaultAvatar(party);
+  const { avatarImage, backgroundImage } = getUserImages({ party });
 
   const socialsLinks = useMemo(() => getSocialsLinks({ party }), [party]);
 
@@ -69,22 +69,8 @@ export const EcocreditsByAccount = (): JSX.Element => {
     <>
       <ProfileHeader
         name={party?.name ? party?.name : DEFAULT_NAME}
-        backgroundImage={
-          party?.bgImage
-            ? getResizedImageUrl({
-                url: party?.bgImage,
-                width: 1400,
-              })
-            : DEFAULT_PROFILE_BG
-        }
-        avatar={
-          party?.image
-            ? getResizedImageUrl({
-                url: party?.image,
-                width: 190,
-              })
-            : defaultAvatar
-        }
+        backgroundImage={backgroundImage}
+        avatar={avatarImage}
         infos={{
           addressLink: {
             href: address

--- a/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -81,7 +81,7 @@ export const EcocreditsByAccount = (): JSX.Element => {
           party?.image
             ? getResizedImageUrl({
                 url: party?.image,
-                width: 140,
+                width: 190,
               })
             : defaultAvatar
         }

--- a/web-marketplace/src/pages/ProfileEdit/ProfileEdit.utils.ts
+++ b/web-marketplace/src/pages/ProfileEdit/ProfileEdit.utils.ts
@@ -1,11 +1,11 @@
-import { Maybe, Party, PartyType } from 'generated/graphql';
+import { Party, PartyType } from 'generated/graphql';
 
 import {
   DEFAULT_PROFILE_COMPANY_AVATAR,
   DEFAULT_PROFILE_USER_AVATAR,
 } from './ProfileEdit.constants';
 
-export const getDefaultAvatar = (party?: Maybe<Pick<Party, 'type'>>) => {
+export const getDefaultAvatar = (party?: Partial<Party> | null) => {
   const isOrganization = party?.type === PartyType.Organization;
   const defaultAvatar = isOrganization
     ? DEFAULT_PROFILE_COMPANY_AVATAR

--- a/web-marketplace/src/pages/ProfileEdit/ProfileEdit.utils.ts
+++ b/web-marketplace/src/pages/ProfileEdit/ProfileEdit.utils.ts
@@ -1,11 +1,11 @@
-import { Party, PartyType } from 'generated/graphql';
+import { Maybe, Party, PartyType } from 'generated/graphql';
 
 import {
   DEFAULT_PROFILE_COMPANY_AVATAR,
   DEFAULT_PROFILE_USER_AVATAR,
 } from './ProfileEdit.constants';
 
-export const getDefaultAvatar = (party?: Partial<Party> | null) => {
+export const getDefaultAvatar = (party?: Maybe<Pick<Party, 'type'>>) => {
   const isOrganization = party?.type === PartyType.Organization;
   const defaultAvatar = isOrganization
     ? DEFAULT_PROFILE_COMPANY_AVATAR

--- a/web-marketplace/src/utils/image/getResizedImageUrl.ts
+++ b/web-marketplace/src/utils/image/getResizedImageUrl.ts
@@ -1,17 +1,14 @@
-import { API_URI } from 'lib/env';
+import { getOptimizedImageSrc } from 'web-components/lib/utils/optimizedImageSrc';
+
+import { API_URI, IMAGE_STORAGE_BASE_URL } from 'lib/env';
 
 type Params = {
   url: string;
-  startPattern: string;
   width: number;
 };
 
-const IMAGE_ENDPOINT = '/marketplace/v1/image';
+export const getResizedImageUrl = ({ url, width }: Params) => {
+  const imageSrc = getOptimizedImageSrc(url, IMAGE_STORAGE_BASE_URL, API_URI);
 
-export const getResizedImageUrl = ({ startPattern, url, width }: Params) => {
-  const startPatternIndex = url.indexOf(startPattern);
-  const endIndex = url.length;
-  const imagePath = url.substring(startPatternIndex, endIndex);
-
-  return `${API_URI}${IMAGE_ENDPOINT}${imagePath}?w=${width}`;
+  return `${imageSrc}?w=${width}`;
 };

--- a/web-marketplace/src/utils/image/getResizedImageUrl.ts
+++ b/web-marketplace/src/utils/image/getResizedImageUrl.ts
@@ -1,0 +1,17 @@
+import { API_URI } from 'lib/env';
+
+type Params = {
+  url: string;
+  startPattern: string;
+  width: number;
+};
+
+const IMAGE_ENDPOINT = '/marketplace/v1/image';
+
+export const getResizedImageUrl = ({ startPattern, url, width }: Params) => {
+  const startPatternIndex = url.indexOf(startPattern);
+  const endIndex = url.length;
+  const imagePath = url.substring(startPatternIndex, endIndex);
+
+  return `${API_URI}${IMAGE_ENDPOINT}${imagePath}?w=${width}`;
+};


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1713

- use resized images for profile (public and private) and gallery

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2106--regen-marketplace.netlify.app/profiles/regen1df675r9vnf7pdedn4sf26svdsem3ugavgxmy46/portfolio

In this example, we went from: 
- background image: 1.7 MB -> 30 kB
- profile: 373 kB -> 1.7 kB

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
