### PR TITLE
fix: make sure project admin wallet id is always set

### DIFF
--- a/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
+++ b/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
@@ -52,7 +52,10 @@ export const useCreateOrUpdateProject = () => {
           variables: {
             input: {
               id: offChainProjectId,
-              projectPatch,
+              projectPatch: {
+                adminWalletId: walletData?.walletByAddr?.id,
+                ...projectPatch,
+              },
             },
           },
         });

--- a/web-marketplace/src/pages/Roles/Roles.tsx
+++ b/web-marketplace/src/pages/Roles/Roles.tsx
@@ -41,7 +41,6 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { rolesSubmit } = useRolesSubmit({
     projectEditSubmit,
     offChainProject,
-    onChainProject,
     metadata,
     isEdit,
     metadataReload,


### PR DESCRIPTION
## Description

Closes: regen-network/regen-registry#1791

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

Moving forward, this should prevent projects to have a null admin_wallet_id (which causes the 401 when trying to upload an image since we check that this is the project admin that does upload the image using the off-chain admin_wallet_id).
For existing projects without any admin_wallet_id, this should be updated manually in the db (which was the case for projects created on staging when the project creation/edit flows weren't updated to use the keplr login system).

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
