### PR TITLE
fix: update project metadata submit to account for @context overwrite

### DIFF
--- a/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
+++ b/web-marketplace/src/pages/ProjectMetadata/hooks/useProjectMetadataSubmit.tsx
@@ -31,8 +31,12 @@ export const useProjectMetadataSubmit = ({
   const projectMetadataSubmit = useCallback(
     async ({ values }: SubmitParams): Promise<void> => {
       const parsedMetaData = JSON.parse(values.metadata);
-      const baseMetadata = pick(metadata, OMITTED_METADATA_KEYS);
+      const baseMetadata = pick(metadata, [
+        '@context',
+        ...OMITTED_METADATA_KEYS,
+      ]);
       merge(baseMetadata, parsedMetaData);
+
       if (baseMetadata) {
         await metadataSubmit({
           values: baseMetadata,

--- a/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
+++ b/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
@@ -5,6 +5,7 @@ import { useApolloClient } from '@apollo/client';
 import { DeliverTxResponse } from '@cosmjs/stargate';
 import { Box, Card, CardMedia, useMediaQuery, useTheme } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { omit } from 'lodash';
 
 import ErrorBanner from 'web-components/lib/components/banner/ErrorBanner';
 import { ReviewCard } from 'web-components/lib/components/cards/ReviewCard/ReviewCard';
@@ -24,6 +25,7 @@ import {
   qudtUnit,
 } from 'lib/rdf';
 
+import { OMITTED_METADATA_KEYS } from 'pages/ProjectMetadata/ProjectMetadata.config';
 import {
   STORY_LABEL,
   STORY_TITLE_LABEL,
@@ -283,7 +285,10 @@ export const ProjectReview: React.FC<React.PropsWithChildren<unknown>> = () => {
               overflowY: 'scroll',
             })}
           >
-            <pre>{!!metadata && JSON.stringify(metadata, null, 2)}</pre>
+            <pre>
+              {!!metadata &&
+                JSON.stringify(omit(metadata, OMITTED_METADATA_KEYS), null, 2)}
+            </pre>
           </Box>
         )}
       </ReviewCard>


### PR DESCRIPTION
## Description

Closes: #2084

The issue described in #2084 can happen as soon as you completely overwrite the metadata as part of the metadata form, meaning that the context was getting overwritten too, which causes the part of the `@context` related to the unanchored metadata to be lost, causing issues with some unanchored metadata fields which require some `@context` (eg for defining a field as a `@list`).
This is because the current metadata form wasn't meant for overwriting the metadata completely, eg providing fields such as `schema:name` that already get filled up as part of other forms, but it was meant primarily for adding custom fields that cannot be provided with other forms. Now it should just supports both use cases.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

Create a new project from https://deploy-preview-2110--regen-marketplace.netlify.app/profile/projects
Go through the various steps, using "Rutherford, California, United States" as location and the following metadata in the final Metadata form (this is more or less what @S4mmyb had tried to submit which caused the issue):
```json
{
  "@context": {
    "schema": "http://schema.org/",
    "regen": "https://schema.regen.network#",
    "qudt": "http://qudt.org/schema/qudt/",
    "unit": "http://qudt.org/vocab/unit/",
    "xsd": "http://www.w3.org/2001/XMLSchema#",
    "schema:url": {
      "@type": "schema:URL"
    },
    "qudt:unit": {
      "@type": "qudt:Unit"
    },
    "qudt:numericValue": {
      "@type": "xsd:double"
    },
    "regen:projectStartDate": {
      "@type": "xsd:date"
    },
    "regen:projectEndDate": {
      "@type": "xsd:date"
    },
    "regen:monitoringFrequency": {
      "@type": "schema:Duration"
    }
  },
  "@type": "regen:KSH01-Project",
  "schema:name": "Grgich Hills Estate Regenerative Sheep Grazing",
  "schema:location": {
    "@context": {
      "type": "@type",
      "@vocab": "https://purl.org/geojson/vocab#",
      "coordinates": {
        "@container": "@list"
      },
      "bbox": {
        "@container": "@list"
      }
    },
    "type": "Feature",
    "place_name": "Rutherford, California",
    "geometry": {
      "type": "Point",
      "coordinates": [
          -122.3754,
          38.4082
      ]
    }
  },
  "regen:projectSize": {
    "qudt:unit": "unit:HA",
    "qudt:numericValue": 126.6
  },
  "regen:projectActivity": "High Density, Short Duration Sheep Grazing",
  "regen:projectType": "Environmental Stewardship",
  "regen:projectStartDate": "2019-01-01",
  "regen:projectEndDate": "2023-05-31"
}
```
Create the project on-chain and go check the project page that the additional info does appear based on the metadata above.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
