### PR TITLE
fix: buy modal options trigger

### DIFF
--- a/web-marketplace/src/components/organisms/BuyModalOptions/BuyModalOptions.tsx
+++ b/web-marketplace/src/components/organisms/BuyModalOptions/BuyModalOptions.tsx
@@ -35,13 +35,12 @@ export const BuyModalOptions = ({
 }: Props) => {
   const cards = content?.cards ?? [];
   const setConnectWalletModalAtom = useSetAtom(connectWalletModalAtom);
-  const { loaded, wallet } = useWallet();
-  const connected = wallet?.address;
+  const { loaded, isConnected } = useWallet();
   const { trackBuyScheduleCall, trackBuyKeplr } = useBuyModalOptionsTracker();
 
   useEffect(() => {
-    if (loaded && connected) onClose();
-  }, [connected, loaded, onClose]);
+    if (loaded && isConnected) onClose();
+  }, [isConnected, loaded, onClose]);
 
   return (
     <Modal open={open} onClose={onClose}>

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.ConnectWalletModal.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.ConnectWalletModal.tsx
@@ -10,18 +10,17 @@ export const RegistryLayoutConnectWalletModal = (): JSX.Element => {
   const [connectWalletModal, setConnectWalletModal] = useAtom(
     connectWalletModalAtom,
   );
-  const { loaded, wallet } = useWallet();
-  const connected = wallet?.address;
+  const { loaded, isConnected } = useWallet();
   const { open, onClose } = connectWalletModal;
 
   const onCloseModal = useCallback(() => {
     setConnectWalletModal(atom => void (atom.open = false));
-    if (onClose && !connected) onClose();
-  }, [setConnectWalletModal, onClose, connected]);
+    if (onClose && !isConnected) onClose();
+  }, [setConnectWalletModal, onClose, isConnected]);
 
   useEffect(() => {
-    if (loaded && connected) onCloseModal();
-  }, [connected, loaded, onCloseModal]);
+    if (loaded && isConnected) onCloseModal();
+  }, [isConnected, loaded, onCloseModal]);
 
   return (
     <>

--- a/web-marketplace/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
+++ b/web-marketplace/src/features/marketplace/BuySellOrderFlow/BuySellOrderFlow.tsx
@@ -17,6 +17,7 @@ import { getHashUrl } from 'lib/block-explorer';
 import { client } from 'lib/clients/sanity';
 import { getBuyModalOptionsQuery } from 'lib/queries/react-query/sanity/getBuyModalOptionsQuery/getBuyModalOptionsQuery';
 import { Track } from 'lib/tracker/types';
+import { useWallet } from 'lib/wallet/wallet';
 
 import useBuySellOrderSubmit from 'pages/Marketplace/Storefront/hooks/useBuySellOrderSubmit';
 import { useCheckSellOrderAvailabilty } from 'pages/Marketplace/Storefront/hooks/useCheckSellOrderAvailabilty';
@@ -67,6 +68,7 @@ export const BuySellOrderFlow = ({
   const [txModalHeader, setTxModalHeader] = useState<string>('');
   const [cardItems, setCardItems] = useState<Item[] | undefined>(undefined);
   const { sellOrders, refetchSellOrders } = useFetchSellOrders();
+  const { isConnected, wallet } = useWallet();
   const { data: buyModalOptionsContent } = useQuery(
     getBuyModalOptionsQuery({ sanityClient: client }),
   );
@@ -119,7 +121,6 @@ export const BuySellOrderFlow = ({
   const {
     signAndBroadcast,
     setDeliverTxResponse,
-    wallet,
     deliverTxResponse,
     error,
     setError,
@@ -217,13 +218,13 @@ export const BuySellOrderFlow = ({
    * ui update effect
    */
   useEffect(() => {
-    if (isFlowStarted && accountAddress) {
+    if (isFlowStarted && isConnected) {
       refetchSellOrders();
       setIsBuyModalOpen(true);
-    } else if (isFlowStarted && !accountAddress) {
+    } else if (isFlowStarted && !isConnected) {
       setIsBuyModalOptionsOpen(true);
     }
-  }, [isFlowStarted, accountAddress, refetchSellOrders]);
+  }, [isFlowStarted, isConnected, refetchSellOrders]);
 
   return (
     <>


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2120

Check that the user as an account id in addition to an address to show the buy-sell orders modal.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2128--regen-marketplace.netlify.app/
2. Try to log but to not validate the sign arbitrary transaction
3. Click on the buy button on one of the cards
4. You should see the buy modal options instead of the buy-sell orders modal

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
