### PR TITLE
fix: project card title height

### DIFF
--- a/web-components/src/components/cards/MediaCard.tsx
+++ b/web-components/src/components/cards/MediaCard.tsx
@@ -137,10 +137,7 @@ export default function MediaCard({
               borderTop: `1px solid ${theme.palette.grey[100]}`,
             }),
             !!truncateTitle && {
-              height: {
-                xs: 'inherit',
-                sm: titleVariant === 'h4' ? '94px' : 'inherit',
-              },
+              height: 'inherit',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               display: '-webkit-box',

--- a/web-components/src/components/cards/MediaCard.tsx
+++ b/web-components/src/components/cards/MediaCard.tsx
@@ -137,7 +137,6 @@ export default function MediaCard({
               borderTop: `1px solid ${theme.palette.grey[100]}`,
             }),
             !!truncateTitle && {
-              height: 'inherit',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               display: '-webkit-box',


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1807

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Testing on desktop:

https://deploy-preview-2163--regen-marketplace.netlify.app/projects/3 On this particular page, all titles take only one line so the location is moved higher everywhere
On https://deploy-preview-2163--regen-marketplace.netlify.app/projects/2, the first row of projects has at least one project title with 2 lines so the locations in this row are moved down so they all align, while the second row has projects titles with 1 line so the location is just displayed right below the title without any additional space.
This behavior can also be tested from the "More Projects" on individual project pages.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
