### PR TITLE
fix: ecocredit table with ghost credits on first page

### DIFF
--- a/web-marketplace/src/components/organisms/EcocreditsTable.tsx
+++ b/web-marketplace/src/components/organisms/EcocreditsTable.tsx
@@ -37,7 +37,10 @@ export const EcocreditsTable: React.FC<
   initialPaginationParams,
   isIgnoreOffset = false,
 }) => {
-  if (!credits?.length) {
+  const hasMorePages =
+    (initialPaginationParams?.count ?? 0) >
+    (initialPaginationParams?.rowsPerPage ?? 0);
+  if (!credits || (!credits?.length && !hasMorePages)) {
     return (
       <NoCredits
         title="No ecocredits to display"

--- a/web-marketplace/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
+++ b/web-marketplace/src/pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits.ts
@@ -41,7 +41,7 @@ export const useFetchEcocredits = ({
   const [paginationParams, setPaginationParams] =
     useState<TablePaginationParams>({
       page: 0,
-      rowsPerPage: DEFAULT_ROWS_PER_PAGE,
+      rowsPerPage: 10,
       offset: 0,
     });
   const { page, rowsPerPage } = paginationParams;


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2097

- display ecocredits table when the first page is full of ghost credits.

The problem here was, for this specific account on main net, about ghost credits (empty balances on credits that used to have one returned by the ledger). We took the decision to hide those ghost credits before so we ended up with a first page without credit and the empty state was displayed for that reason.

In this PR we display the table if there are no rows on the first page but the table has more pages.

![empty table - page 1](https://github.com/regen-network/regen-web/assets/530644/b39162af-d3b6-4766-bc6e-ece43d0376fe)
![empty table - page 2](https://github.com/regen-network/regen-web/assets/530644/edc1f852-604a-4427-bbb2-46410c110609)


---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
