### PR TITLE
feat: update create/edit project forms to handle projects without credit class

### DIFF
--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.schema.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.schema.ts
@@ -1,14 +1,19 @@
 import { z } from 'zod';
 
-import { addressSchema } from './components/AdminModal/AdminModal.schema';
+import {
+  addressSchema,
+  optionalAddressSchema,
+} from './components/AdminModal/AdminModal.schema';
 import { profileModalSchema } from './components/ProfileModal/ProfileModal.schema';
 
-export const rolesFormSchema = z
-  .object({
+export const rolesFormSchema = (isOnChain: boolean) => {
+  const baseRolesSchema = z.object({
     projectDeveloper: profileModalSchema.nullable().optional(),
     verifier: profileModalSchema.nullable().optional(),
-    admin: addressSchema,
-  })
-  .required({ admin: true });
-
-export type RolesFormSchemaType = z.infer<typeof rolesFormSchema>;
+    admin: isOnChain ? addressSchema : optionalAddressSchema,
+  });
+  return isOnChain
+    ? baseRolesSchema.required({ admin: true })
+    : baseRolesSchema;
+};
+export type RolesFormSchemaType = z.infer<ReturnType<typeof rolesFormSchema>>;

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
@@ -107,9 +107,9 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
   );
   const { data: adminWalletData } = useQuery(
     getWalletByAddrQuery({
-      addr: admin,
+      addr: admin as string,
       client: graphqlClient,
-      enabled: admin !== initialValues?.admin && !!graphqlClient,
+      enabled: !!admin && admin !== initialValues?.admin && !!graphqlClient,
     }),
   );
 
@@ -180,7 +180,7 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
           accountId={accountId}
           {...form.register('verifier')}
         />
-        {isOnChain && (
+        {isOnChain && admin && (
           <Flex alignItems="flex-end" sx={{ mt: { xs: 8.25, sm: 10 } }}>
             <TextField
               type="text"

--- a/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/RolesForm.tsx
@@ -38,6 +38,7 @@ interface RolesFormProps {
   onNext?: () => void;
   onPrev?: () => void;
   initialValues?: RolesFormSchemaType;
+  isOnChain: boolean;
 }
 
 const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
@@ -45,9 +46,10 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
   submit,
   onNext,
   onPrev,
+  isOnChain,
 }) => {
   const form = useZodForm({
-    schema: rolesFormSchema,
+    schema: rolesFormSchema(isOnChain),
     defaultValues: {
       ...initialValues,
     },
@@ -178,37 +180,39 @@ const RolesForm: React.FC<React.PropsWithChildren<RolesFormProps>> = ({
           accountId={accountId}
           {...form.register('verifier')}
         />
-        <Flex alignItems="flex-end" sx={{ mt: { xs: 8.25, sm: 10 } }}>
-          <TextField
-            type="text"
-            label="Admin"
-            disabled
-            {...form.register('admin')}
-          />
-          <EditIcon
-            onClick={() => setAdminModalOpen(true)}
-            sx={{
-              width: 24,
-              height: 24,
-              cursor: 'pointer',
-              ml: { xs: 2, sm: 4.25 },
-              mb: { xs: 2.5, sm: 4.25 },
-            }}
-          />
-          {adminModalOpen && (
-            <AdminModal
-              initialValues={{
-                currentAddress: initialValues?.admin || '',
-                newAddress: initialValues?.admin === admin ? '' : admin,
-              }}
-              onClose={() => setAdminModalOpen(false)}
-              onSubmit={value => {
-                setAdmin(value.newAddress);
-                setAdminModalOpen(false);
+        {isOnChain && (
+          <Flex alignItems="flex-end" sx={{ mt: { xs: 8.25, sm: 10 } }}>
+            <TextField
+              type="text"
+              label="Admin"
+              disabled
+              {...form.register('admin')}
+            />
+            <EditIcon
+              onClick={() => setAdminModalOpen(true)}
+              sx={{
+                width: 24,
+                height: 24,
+                cursor: 'pointer',
+                ml: { xs: 2, sm: 4.25 },
+                mb: { xs: 2.5, sm: 4.25 },
               }}
             />
-          )}
-        </Flex>
+            {adminModalOpen && (
+              <AdminModal
+                initialValues={{
+                  currentAddress: initialValues?.admin || '',
+                  newAddress: initialValues?.admin === admin ? '' : admin,
+                }}
+                onClose={() => setAdminModalOpen(false)}
+                onSubmit={value => {
+                  setAdmin(value.newAddress);
+                  setAdminModalOpen(false);
+                }}
+              />
+            )}
+          </Flex>
+        )}
       </OnBoardingCard>
       <ProjectPageFooter
         onPrev={onPrev}

--- a/web-marketplace/src/components/organisms/RolesForm/components/AdminModal/AdminModal.schema.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/components/AdminModal/AdminModal.schema.ts
@@ -18,6 +18,19 @@ export const addressSchema = z
     },
   );
 
+export const optionalAddressSchema = z
+  .string()
+  .refine(
+    value =>
+      value
+        ? isValidAddress(value, chainInfo.bech32Config.bech32PrefixAccAddr)
+        : true,
+    {
+      message: invalidRegenAddress,
+    },
+  )
+  .optional();
+
 export const adminModalSchema = z
   .object({
     currentAddress: addressSchema,

--- a/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.schema.ts
+++ b/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.schema.ts
@@ -1,12 +1,8 @@
 import { z } from 'zod';
 
-import {
-  invalidRegenAddress,
-  isValidAddress,
-} from 'web-components/lib/components/inputs/validation';
-
 import { PartyType } from 'generated/graphql';
-import { chainInfo } from 'lib/wallet/chainInfo/chainInfo';
+
+import { optionalAddressSchema } from '../AdminModal/AdminModal.schema';
 
 export const profileModalSchema = z.object({
   id: z.string().optional(),
@@ -16,18 +12,7 @@ export const profileModalSchema = z.object({
   name: z.string(),
   profileImage: z.string(),
   description: z.string().max(160).optional(),
-  address: z
-    .string()
-    .refine(
-      value =>
-        value
-          ? isValidAddress(value, chainInfo.bech32Config.bech32PrefixAccAddr)
-          : true,
-      {
-        message: invalidRegenAddress,
-      },
-    )
-    .optional(),
+  address: optionalAddressSchema,
 });
 
 export type ProfileModalSchemaType = z.infer<typeof profileModalSchema>;

--- a/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormAccessTemplate.tsx
@@ -27,17 +27,18 @@ const ProjectFormAccessTemplate: React.FC<React.PropsWithChildren<Props>> = ({
   const { wallet } = useWallet();
   const isAdmin = adminAddr && adminAddr === wallet?.address;
   const hasProject = !!onChainProject || !!offChainProject;
+
   return (
     <>
       {!loading && !hasProject && <NotFoundPage />}
-      {hasProject && !isAdmin && (
+      {!loading && hasProject && !isAdmin && (
         <ProjectDenied
           isEdit={isEdit}
           address={adminAddr}
           projectId={onChainProject?.id || offChainProject?.id}
         />
       )}
-      {hasProject && isAdmin && <>{children}</>}
+      {!loading && hasProject && isAdmin && <>{children}</>}
     </>
   );
 };

--- a/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormTemplate.tsx
+++ b/web-marketplace/src/components/templates/ProjectFormTemplate/ProjectFormTemplate.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ProjectInfo } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 
 import { OffChainProject } from 'hooks/projects/useProjectWithMetadata';
 
+import {
+  getIsOffChainUuid,
+  getIsOnChainId,
+} from '../ProjectDetails/ProjectDetails.utils';
 import { EditFormTemplate } from './EditFormTemplate';
 import { OnboardingFormTemplate } from './OnboardingFormTemplate';
 import { ProjectFormAccessTemplate } from './ProjectFormAccessTemplate';
@@ -53,9 +57,11 @@ const ProjectFormTemplate: React.FC<React.PropsWithChildren<Props>> = ({
       offChainProject={offChainProject}
       adminAddr={adminAddr}
     >
-      {!!onChainProject && isEdit && (
-        <EditFormTemplate>{children}</EditFormTemplate>
-      )}
+      {isEdit &&
+        (!!onChainProject ||
+          (!onChainProject && offChainProject?.published)) && (
+          <EditFormTemplate>{children}</EditFormTemplate>
+        )}
       {!!offChainProject && !isEdit && (
         <OnboardingFormTemplate
           activeStep={0}

--- a/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
+++ b/web-marketplace/src/hooks/projects/UseCreateOrUpdateProject.ts
@@ -9,7 +9,6 @@ import {
 } from 'generated/graphql';
 import { getCreditClassByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getCreditClassByOnChainIdQuery/getCreditClassByOnChainIdQuery';
 import { getWalletByAddrQuery } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery';
-import { getWalletByAddrQueryKey } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery.utils';
 import { getUnanchoredProjectBaseMetadata } from 'lib/rdf';
 import { useWallet } from 'lib/wallet/wallet';
 
@@ -22,7 +21,6 @@ type CreateOrUpdateProjectParams = {
 
 export const useCreateOrUpdateProject = () => {
   const graphqlClient = useApolloClient();
-  const reactQueryClient = useQueryClient();
   const { wallet } = useWallet();
   const { isEdit, onChainProject } = useProjectEditContext();
   const [updateProject] = useUpdateProjectByIdMutation();
@@ -81,14 +79,6 @@ export const useCreateOrUpdateProject = () => {
         });
         const projectId = createRes?.data?.createProject?.project?.id;
         if (projectId) {
-          await reactQueryClient.invalidateQueries({
-            queryKey: getWalletByAddrQueryKey(
-              walletData?.walletByAddr?.addr ?? '',
-            ),
-          });
-          // await reactQueryClient.invalidateQueries({
-          //   queryKey: getProjectByOnChainIdKey(onChainProject.id),
-          // });
           return projectId;
         }
       }
@@ -98,9 +88,7 @@ export const useCreateOrUpdateProject = () => {
       createProject,
       isEdit,
       onChainProject,
-      reactQueryClient,
       updateProject,
-      walletData?.walletByAddr?.addr,
       walletData?.walletByAddr?.id,
     ],
   );

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -156,9 +156,10 @@ export const useProjectWithMetadata = ({
       });
     }
   }, [
+    reactQueryClient,
+    wallet?.address,
     createOrEditOffChain,
     editOnChain,
-    reactQueryClient,
     projectId,
     onChainProject?.admin,
   ]);

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -15,6 +15,8 @@ import { getProjectByIdQuery } from 'lib/queries/react-query/registry-server/gra
 import { getProjectByIdKey } from 'lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery.constants';
 import { getProjectByOnChainIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery';
 import { getProjectByOnChainIdKey } from 'lib/queries/react-query/registry-server/graphql/getProjectByOnChainIdQuery/getProjectByOnChainIdQuery.constants';
+import { getWalletByAddrQueryKey } from 'lib/queries/react-query/registry-server/graphql/getWalletByAddrQuery/getWalletByAddrQuery.utils';
+import { useWallet } from 'lib/wallet/wallet';
 
 import { UseProjectEditSubmitParams } from 'pages/ProjectEdit/hooks/useProjectEditSubmit';
 import { BasicInfoFormSchemaType } from 'components/organisms/BasicInfoForm/BasicInfoForm.schema';
@@ -76,6 +78,7 @@ export const useProjectWithMetadata = ({
   const graphqlClient = useApolloClient();
   const reactQueryClient = useQueryClient();
   const { dataClient } = useLedger();
+  const { wallet } = useWallet();
 
   const { createOrUpdateProject } = useCreateOrUpdateProject();
   const isOnChainId = getIsOnChainId(projectId);
@@ -133,6 +136,9 @@ export const useProjectWithMetadata = ({
   }
   // Create Reload and Submit callbacks
   const metadataReload = useCallback(async (): Promise<void> => {
+    await reactQueryClient.invalidateQueries({
+      queryKey: getWalletByAddrQueryKey(wallet?.address ?? ''),
+    });
     if (createOrEditOffChain) {
       await reactQueryClient.invalidateQueries({
         queryKey: getProjectByIdKey(projectId),

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -140,13 +140,13 @@ export const useProjectWithMetadata = ({
     }
     if (editOnChain) {
       await reactQueryClient.invalidateQueries({
-        queryKey: getProjectKey(projectId),
-      });
-      await reactQueryClient.invalidateQueries({
         queryKey: getProjectByOnChainIdKey(projectId),
       });
       await reactQueryClient.invalidateQueries({
         queryKey: getProjectsByAdminKey({ admin: onChainProject?.admin }),
+      });
+      await reactQueryClient.invalidateQueries({
+        queryKey: getProjectKey(projectId),
       });
     }
   }, [
@@ -198,7 +198,6 @@ export const useProjectWithMetadata = ({
       navigateNext,
     ],
   );
-
   return {
     offChainProject,
     metadata,

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -21,6 +21,10 @@ import { BasicInfoFormSchemaType } from 'components/organisms/BasicInfoForm/Basi
 import { DescriptionSchemaType } from 'components/organisms/DescriptionForm/DescriptionForm.schema';
 import { SimplifiedLocationFormSchemaType } from 'components/organisms/LocationForm/LocationForm.schema';
 import { MediaFormSchemaType } from 'components/organisms/MediaForm/MediaForm.schema';
+import {
+  getIsOffChainUuid,
+  getIsOnChainId,
+} from 'components/templates/ProjectDetails/ProjectDetails.utils';
 
 import { useLedger } from '../../ledger';
 import { useCreateOrUpdateProject } from './UseCreateOrUpdateProject';
@@ -74,32 +78,37 @@ export const useProjectWithMetadata = ({
   const { dataClient } = useLedger();
 
   const { createOrUpdateProject } = useCreateOrUpdateProject();
+  const isOnChainId = getIsOnChainId(projectId);
+  const isOffChainUuid = getIsOffChainUuid(projectId);
 
-  // In project creation mode, we query the off-chain project since there's no on-chain project yet.
+  // In project creation mode or off-chain project edit mode,
+  // we query the off-chain project since there's no on-chain project yet.
   // In this case, the router param projectId is the off-chain project uuid.
-  const create = !!projectId && !isEdit;
+  const createOrEditOffChain =
+    !!projectId && (!isEdit || (isEdit && isOffChainUuid));
   const { data: projectByOffChainIdRes, isFetching: isFetchingProjectById } =
     useQuery(
       getProjectByIdQuery({
         client: graphqlClient,
-        enabled: create,
+        enabled: createOrEditOffChain,
         id: projectId,
       }),
     );
   const projectById = projectByOffChainIdRes?.data?.projectById;
-  if (create && projectById) {
+  if (createOrEditOffChain && projectById) {
     offChainProject = projectById;
     metadata = projectById.metadata;
   }
 
-  // In project edit mode, we can query the on-chain (anchored) project metadata.
+  // In on-chain project edit mode, we can query the on-chain (anchored) project metadata.
   // In this case, the router param projectId is the on-chain project id.
-  const edit = !!projectId && isEdit;
+  const editOnChain = !!projectId && isEdit && isOnChainId;
   // Metadata
   const { data: anchoredMetadata, isFetching: isFetchingMetadata } = useQuery(
     getMetadataQuery({
       iri: onChainProject?.metadata,
-      enabled: !!onChainProject?.metadata && edit && anchored && !!dataClient,
+      enabled:
+        !!onChainProject?.metadata && editOnChain && anchored && !!dataClient,
       dataClient,
     }),
   );
@@ -109,12 +118,12 @@ export const useProjectWithMetadata = ({
   } = useQuery(
     getProjectByOnChainIdQuery({
       client: graphqlClient,
-      enabled: edit,
+      enabled: editOnChain,
       onChainId: projectId as string,
     }),
   );
   // Select metadata
-  if (edit) {
+  if (editOnChain) {
     offChainProject = projectByOnChainIdRes?.data?.projectByOnChainId;
     if (anchored) {
       metadata = anchoredMetadata as AnchoredProjectMetadataLD | undefined;
@@ -124,12 +133,12 @@ export const useProjectWithMetadata = ({
   }
   // Create Reload and Submit callbacks
   const metadataReload = useCallback(async (): Promise<void> => {
-    if (create) {
+    if (createOrEditOffChain) {
       await reactQueryClient.invalidateQueries({
         queryKey: getProjectByIdKey(projectId),
       });
     }
-    if (edit) {
+    if (editOnChain) {
       await reactQueryClient.invalidateQueries({
         queryKey: getProjectKey(projectId),
       });
@@ -140,7 +149,13 @@ export const useProjectWithMetadata = ({
         queryKey: getProjectsByAdminKey({ admin: onChainProject?.admin }),
       });
     }
-  }, [create, edit, reactQueryClient, projectId, onChainProject?.admin]);
+  }, [
+    createOrEditOffChain,
+    editOnChain,
+    reactQueryClient,
+    projectId,
+    onChainProject?.admin,
+  ]);
 
   const metadataSubmit = useCallback(
     async ({
@@ -153,7 +168,7 @@ export const useProjectWithMetadata = ({
         newMetadata = { ...metadata, ...values };
       }
       try {
-        if (isEdit && anchored) {
+        if (isEdit && anchored && !!onChainProject) {
           await projectEditSubmit(newMetadata);
         } else {
           await createOrUpdateProject({
@@ -175,10 +190,11 @@ export const useProjectWithMetadata = ({
       metadata,
       isEdit,
       anchored,
+      onChainProject,
       metadataReload,
       projectEditSubmit,
       createOrUpdateProject,
-      offChainProject,
+      offChainProject?.id,
       navigateNext,
     ],
   );

--- a/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery.constants.ts
+++ b/web-marketplace/src/lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery.constants.ts
@@ -1,5 +1,5 @@
-export const getProjectByIdKey = (handle: string): string[] => [
+export const getProjectByIdKey = (id: string): string[] => [
   'graphql',
   'projectById',
-  handle,
+  id,
 ];

--- a/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
+++ b/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
@@ -34,7 +34,7 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
   );
 
   const saveAndExit = useProjectSaveAndExit();
-  console.log('offChainProject', offChainProject);
+
   return (
     <ProjectFormTemplate
       isEdit={isEdit}

--- a/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
+++ b/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
@@ -34,7 +34,7 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
   );
 
   const saveAndExit = useProjectSaveAndExit();
-
+  console.log('offChainProject', offChainProject);
   return (
     <ProjectFormTemplate
       isEdit={isEdit}

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
@@ -71,7 +71,10 @@ const MyProjects = (): JSX.Element => {
                     {...DEFAULT_PROJECT}
                     {...project}
                     onButtonClick={() => {
-                      if (!project.offChain) {
+                      if (
+                        !project.offChain ||
+                        (project.offChain && project.published)
+                      ) {
                         navigate(
                           `/project-pages/${project.id}/edit/basic-info`,
                         );

--- a/web-marketplace/src/pages/Dashboard/MyProjects/hooks/useFetchProjectsByAdmin.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/hooks/useFetchProjectsByAdmin.tsx
@@ -71,6 +71,7 @@ export const useFetchProjectByAdmin = ({
   const onlyOffChainProjectsWithData =
     onlyOffChainProjects?.map(project => ({
       offChain: true,
+      published: project?.published,
       ...normalizeProjectWithMetadata({
         offChainProject: project,
         projectMetadata: project?.metadata,

--- a/web-marketplace/src/pages/Media/Media.tsx
+++ b/web-marketplace/src/pages/Media/Media.tsx
@@ -1,5 +1,14 @@
 import { useNavigate, useParams } from 'react-router-dom';
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  useApolloClient,
+} from '@apollo/client';
+import { useQuery } from '@tanstack/react-query';
 
+import { getProjectByIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery';
+
+import { useCreateProjectContext } from 'pages/ProjectCreate';
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
 import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import WithLoader from 'components/atoms/WithLoader';
@@ -14,7 +23,21 @@ const Media = (): JSX.Element => {
   const navigate = useNavigate();
   const { projectId } = useParams();
   const { isEdit, onChainProject, projectEditSubmit } = useProjectEditContext();
-  const { navigateNext } = useNavigateNext({ step: 'metadata', projectId });
+  const graphqlClient =
+    useApolloClient() as ApolloClient<NormalizedCacheObject>;
+  const { data } = useQuery(
+    getProjectByIdQuery({
+      client: graphqlClient,
+      enabled: !isEdit,
+      id: projectId,
+    }),
+  );
+  const creditClassId =
+    data?.data?.projectById?.metadata?.['regen:creditClassId'];
+  const { navigateNext } = useNavigateNext({
+    step: creditClassId ? 'metadata' : 'review',
+    projectId,
+  });
   const { offChainProject, metadata, metadataSubmit, loading } =
     useProjectWithMetadata({
       projectId,

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.Nav.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.Nav.tsx
@@ -13,15 +13,17 @@ export const ProjectEditNav = ({ section, onNavClick, isOnChain }: Props) => {
   return (
     <Navigation
       classes={{ root: styles.nav, listItem: styles.navItem }}
-      categories={[
-        'basic info',
-        'location',
-        'roles',
-        'description',
-        'media',
-        isOnChain ? 'metadata' : undefined,
-        'settings',
-      ].filter(category => Boolean(category))}
+      categories={
+        [
+          'basic info',
+          'location',
+          'roles',
+          'description',
+          'media',
+          isOnChain ? 'metadata' : undefined,
+          'settings',
+        ].filter(category => Boolean(category)) as string[]
+      }
       category={section?.replace('-', ' ')}
       onClick={onNavClick}
       showIcon

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.Nav.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.Nav.tsx
@@ -5,9 +5,10 @@ import { useProjectEditStyles } from './ProjectEdit.styles';
 type Props = {
   section?: string;
   onNavClick: (sectionName: string) => void;
+  isOnChain: boolean;
 };
 
-export const ProjectEditNav = ({ section, onNavClick }: Props) => {
+export const ProjectEditNav = ({ section, onNavClick, isOnChain }: Props) => {
   const { classes: styles } = useProjectEditStyles();
   return (
     <Navigation
@@ -18,9 +19,9 @@ export const ProjectEditNav = ({ section, onNavClick }: Props) => {
         'roles',
         'description',
         'media',
-        'metadata',
+        isOnChain ? 'metadata' : undefined,
         'settings',
-      ]}
+      ].filter(category => Boolean(category))}
       category={section?.replace('-', ' ')}
       onClick={onNavClick}
       showIcon

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useApolloClient } from '@apollo/client';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import { ProjectInfo } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 import { useQuery } from '@tanstack/react-query';
@@ -25,11 +26,16 @@ import {
   txSuccessfulModalAtom,
 } from 'lib/atoms/modals.atoms';
 import { getProjectQuery } from 'lib/queries/react-query/ecocredit/getProjectQuery/getProjectQuery';
+import { getProjectByIdQuery } from 'lib/queries/react-query/registry-server/graphql/getProjectByIdQuery/getProjectByIdQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
 import { OnTxSuccessfulProps } from 'pages/Dashboard/MyEcocredits/MyEcocredits.types';
 import NotFoundPage from 'pages/NotFound';
 import WithLoader from 'components/atoms/WithLoader';
+import {
+  getIsOffChainUuid,
+  getIsOnChainId,
+} from 'components/templates/ProjectDetails/ProjectDetails.utils';
 import { useMsgClient } from 'hooks';
 
 import { ProjectDenied } from '../../components/organisms/ProjectDenied/ProjectDenied';
@@ -72,6 +78,7 @@ function ProjectEdit(): JSX.Element {
     string | undefined
   >(undefined);
   const navigate = useNavigate();
+  const graphqlClient = useApolloClient();
 
   const setProcessingModalAtom = useSetAtom(processingModalAtom);
   const setErrorCodeAtom = useSetAtom(errorCodeAtom);
@@ -104,19 +111,36 @@ function ProjectEdit(): JSX.Element {
   };
 
   const { signAndBroadcast } = useMsgClient();
-  const { data: projectRes, isLoading } = useQuery(
+  const isOnChainId = getIsOnChainId(projectId);
+  const isOffChainUUid = getIsOffChainUuid(projectId);
+  const { data: projectRes, isFetching: isFetchingProject } = useQuery(
     getProjectQuery({
       request: {
         projectId,
       },
-      enabled: !!projectId,
+      enabled: !!projectId && isOnChainId,
     }),
   );
   const onChainProject = projectRes?.project;
+  const { data: projectByOffChainIdRes, isFetching: isFetchingProjectById } =
+    useQuery(
+      getProjectByIdQuery({
+        client: graphqlClient,
+        enabled: !!projectId && isOffChainUUid,
+        id: projectId,
+      }),
+    );
+  const offChainProject = projectByOffChainIdRes?.data?.projectById;
+  console.log(offChainProject);
+  const isLoading = isFetchingProject || isFetchingProjectById;
+
   const isNotAdmin =
-    onChainProject?.admin &&
-    wallet?.address !== onChainProject.admin &&
+    ((onChainProject?.admin && wallet?.address !== onChainProject.admin) ||
+      (offChainProject?.walletByAdminWalletId?.addr &&
+        wallet?.address !== offChainProject?.walletByAdminWalletId?.addr)) &&
     !isLoading;
+  const hasProject = !!onChainProject || !!offChainProject;
+  const isOnChain = !isLoading && !!onChainProject;
 
   const projectEditSubmit = useProjectEditSubmit({
     projectId,
@@ -147,7 +171,7 @@ function ProjectEdit(): JSX.Element {
       />
     );
   }
-  if (!isLoading && !onChainProject) {
+  if (!isLoading && !hasProject) {
     return <NotFoundPage />;
   }
 
@@ -213,7 +237,11 @@ function ProjectEdit(): JSX.Element {
               </Box>
             </div>
             {!isMobile && (
-              <ProjectEditNav section={section} onNavClick={onNavClick} />
+              <ProjectEditNav
+                isOnChain={isOnChain}
+                section={section}
+                onNavClick={onNavClick}
+              />
             )}
           </div>
           <div className={styles.right}>
@@ -225,7 +253,11 @@ function ProjectEdit(): JSX.Element {
                   </Title>
                 </div>
                 {isMobile && !section && (
-                  <ProjectEditNav section={section} onNavClick={onNavClick} />
+                  <ProjectEditNav
+                    isOnChain={isOnChain}
+                    section={section}
+                    onNavClick={onNavClick}
+                  />
                 )}
                 <Outlet />
               </div>

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
@@ -131,7 +131,6 @@ function ProjectEdit(): JSX.Element {
       }),
     );
   const offChainProject = projectByOffChainIdRes?.data?.projectById;
-  console.log(offChainProject);
   const isLoading = isFetchingProject || isFetchingProjectById;
 
   const isNotAdmin =

--- a/web-marketplace/src/pages/ProjectEdit/hooks/useProjectEditSubmit.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/hooks/useProjectEditSubmit.tsx
@@ -126,6 +126,7 @@ const useProjectEditSubmit = ({
       });
     },
     [
+      creditClassId,
       projectId,
       admin,
       signAndBroadcast,

--- a/web-marketplace/src/pages/ProjectFinished/ProjectFinished.tsx
+++ b/web-marketplace/src/pages/ProjectFinished/ProjectFinished.tsx
@@ -31,8 +31,8 @@ const ProjectFinished: React.FC<React.PropsWithChildren<unknown>> = () => {
     }),
   );
 
-  const projectOnChainId = data?.data?.projectById?.onChainId || '';
-  const projectOffChainId = data?.data?.projectById?.id || '';
+  const projectOnChainId = data?.data?.projectById?.onChainId;
+  const projectOffChainId = data?.data?.projectById?.id;
   const currentProjectId = projectOnChainId ?? projectOffChainId;
   const projectUrl = `${window.location.origin}/project/${currentProjectId}`;
 
@@ -51,21 +51,33 @@ const ProjectFinished: React.FC<React.PropsWithChildren<unknown>> = () => {
       >
         <OnBoardingCard>
           <Title variant="h5">Create Project</Title>
-          <CardItem
-            label="project id"
-            value={{
-              name: projectOnChainId,
-            }}
-            linkComponent={Link}
-          />
-          <CardItem
-            label="hash"
-            value={{
-              name: truncateHash(deliverTxResponse?.transactionHash) || '',
-              url: getHashUrl(deliverTxResponse?.transactionHash),
-            }}
-            linkComponent={Link}
-          />
+          {projectOnChainId ? (
+            <CardItem
+              label="project id"
+              value={{
+                name: projectOnChainId,
+              }}
+              linkComponent={Link}
+            />
+          ) : (
+            <CardItem
+              label="project name"
+              value={{
+                name: data?.data?.projectById?.metadata?.['schema:name'],
+              }}
+              linkComponent={Link}
+            />
+          )}
+          {!!deliverTxResponse?.transactionHash && (
+            <CardItem
+              label="hash"
+              value={{
+                name: truncateHash(deliverTxResponse?.transactionHash) || '',
+                url: getHashUrl(deliverTxResponse?.transactionHash),
+              }}
+              linkComponent={Link}
+            />
+          )}
           <CardItem
             label="url"
             value={{

--- a/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.tsx
+++ b/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.tsx
@@ -8,6 +8,7 @@ import { AnchoredProjectMetadataLD } from 'lib/db/types/json-ld';
 import { getShaclGraphByUriQuery } from 'lib/queries/react-query/registry-server/graphql/getShaclGraphByUriQuery/getShaclGraphByUriQuery';
 import { getProjectShapeIri } from 'lib/rdf';
 
+import { NotFoundPage } from 'pages/NotFound/NotFound';
 import { useNavigateNext } from 'pages/ProjectCreate/hooks/useNavigateNext';
 import { useProjectSaveAndExit } from 'pages/ProjectCreate/hooks/useProjectSaveAndExit';
 import { MetadataForm } from 'components/organisms/MetadataForm/MetadataForm';
@@ -62,22 +63,29 @@ export const ProjectMetadata: React.FC<React.PropsWithChildren<unknown>> =
     const saveAndExit = useProjectSaveAndExit();
 
     return (
-      <ProjectFormTemplate
-        isEdit={isEdit}
-        title="Metadata"
-        offChainProject={offChainProject}
-        onChainProject={onChainProject}
-        loading={loading}
-        saveAndExit={saveAndExit}
-      >
-        <MetadataForm
-          onSubmit={projectMetadataSubmit}
-          initialValues={initialValues}
-          graphData={data?.data}
-          creditClassId={creditClassId}
-          onNext={navigateNext}
-          onPrev={() => navigate(`/project-pages/${projectId}/media`)}
-        />
-      </ProjectFormTemplate>
+      <>
+        {creditClassId ? (
+          <ProjectFormTemplate
+            isEdit={isEdit}
+            title="Metadata"
+            offChainProject={offChainProject}
+            onChainProject={onChainProject}
+            loading={loading}
+            saveAndExit={saveAndExit}
+          >
+            <MetadataForm
+              onSubmit={projectMetadataSubmit}
+              initialValues={initialValues}
+              graphData={data?.data}
+              creditClassId={creditClassId}
+              onNext={navigateNext}
+              onPrev={() => navigate(`/project-pages/${projectId}/media`)}
+            />
+          </ProjectFormTemplate>
+        ) : (
+          // Metadata form is not available for projects without any credit class
+          <NotFoundPage />
+        )}
+      </>
     );
   };

--- a/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
+++ b/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
@@ -266,35 +266,45 @@ export const ProjectReview: React.FC<React.PropsWithChildren<unknown>> = () => {
           </>
         )}
       </ReviewCard>
-      <ReviewCard
-        title="Metadata"
-        onEditClick={() => navigate(`${editPath}/metadata`)}
-      >
-        {isVCS ? (
-          <VCSMetadata metadata={metadata} />
-        ) : (
-          <Box
-            sx={theme => ({
-              backgroundColor: theme.palette.primary.main,
-              maxHeight: theme.spacing(88),
-              fontSize: theme.spacing(3.5),
-              padding: theme.spacing(4),
-              marginTop: theme.spacing(3.5),
-              border: `1px solid ${theme.palette.grey[600]}`,
-              overflowX: 'scroll',
-              overflowY: 'scroll',
-            })}
-          >
-            <pre>
-              {!!metadata &&
-                JSON.stringify(omit(metadata, OMITTED_METADATA_KEYS), null, 2)}
-            </pre>
-          </Box>
-        )}
-      </ReviewCard>
+      {!!creditClassId && (
+        <ReviewCard
+          title="Metadata"
+          onEditClick={() => navigate(`${editPath}/metadata`)}
+        >
+          {isVCS ? (
+            <VCSMetadata metadata={metadata} />
+          ) : (
+            <Box
+              sx={theme => ({
+                backgroundColor: theme.palette.primary.main,
+                maxHeight: theme.spacing(88),
+                fontSize: theme.spacing(3.5),
+                padding: theme.spacing(4),
+                marginTop: theme.spacing(3.5),
+                border: `1px solid ${theme.palette.grey[600]}`,
+                overflowX: 'scroll',
+                overflowY: 'scroll',
+              })}
+            >
+              <pre>
+                {!!metadata &&
+                  JSON.stringify(
+                    omit(metadata, OMITTED_METADATA_KEYS),
+                    null,
+                    2,
+                  )}
+              </pre>
+            </Box>
+          )}
+        </ReviewCard>
+      )}
       <ProjectPageFooter
         onSave={submit}
-        onPrev={() => navigate(`${editPath}/metadata`)}
+        onPrev={() =>
+          creditClassId
+            ? navigate(`${editPath}/metadata`)
+            : navigate(`${editPath}/media`)
+        }
         isSubmitting={isSubmitModalOpen}
       />
       <ProcessingModal open={isSubmitModalOpen} onClose={closeSubmitModal} />

--- a/web-marketplace/src/pages/Projects/Projects.types.ts
+++ b/web-marketplace/src/pages/Projects/Projects.types.ts
@@ -15,6 +15,7 @@ export interface ProjectWithOrderData extends ProjectCardProps {
   metadata?: string;
   sanityCreditClassData?: AllCreditClassQuery['allCreditClass'][0];
   offChain?: boolean;
+  published?: boolean;
 }
 
 export type FilterCommunityCreditsEvent = {

--- a/web-marketplace/src/pages/Roles/Roles.tsx
+++ b/web-marketplace/src/pages/Roles/Roles.tsx
@@ -26,6 +26,7 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
     projectEditSubmit,
     isLoading: editContextLoading,
   } = useProjectEditContext();
+
   const {
     metadata,
     offChainProject,
@@ -41,6 +42,7 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { rolesSubmit } = useRolesSubmit({
     projectEditSubmit,
     offChainProject,
+    onChainProject,
     metadata,
     isEdit,
     metadataReload,
@@ -89,6 +91,9 @@ const Roles: React.FC<React.PropsWithChildren<unknown>> = () => {
           onNext={navigateNext}
           onPrev={navigatePrev}
           initialValues={initialValues}
+          isOnChain={
+            !editContextLoading && !!onChainProject && !!wallet?.address
+          }
         />
       </WithLoader>
     </ProjectFormTemplate>

--- a/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
+++ b/web-marketplace/src/pages/Roles/hooks/useRolesSubmit.tsx
@@ -123,8 +123,6 @@ const useRolesSubmit = ({
         // In creation or edit mode, we always store references to the project stakeholders in the project table
         // which should be in projectPatch if new or updated
         if (doUpdateMetadata || doUpdateAdmin) {
-          console.log(onChainProject);
-
           // In on-chain edit mode, we need to update the project on-chain metadata and/or admin if needed
           if (isEdit && !!onChainProject) {
             await projectEditSubmit(

--- a/web-marketplace/src/pages/Settings/Settings.tsx
+++ b/web-marketplace/src/pages/Settings/Settings.tsx
@@ -35,7 +35,11 @@ const Settings: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   const initialValues: SettingsFormSchemaType = useMemo(
     () => ({
-      slug: offChainProject?.slug ?? onChainProject?.id ?? '',
+      slug:
+        offChainProject?.slug ??
+        onChainProject?.id ??
+        offChainProject?.id ??
+        '',
     }),
     [offChainProject, onChainProject],
   );


### PR DESCRIPTION
## Description

Closes: #2161

For projects without credit class:
- Removes the metadata form
- At the end of the create flow, do not submit the project on chain but just set it as "published" off-chain
- Do not submit any on-chain data when editing published off chain projects but keep storing everything off-chain

Also fixes: #2177 a bug that I came across while working on this

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Go to https://deploy-preview-2178--regen-marketplace.netlify.app/ and login with a class issuer/project admin.
From https://deploy-preview-2178--regen-marketplace.netlify.app/profile/projects:
1. Create a new project with a credit class and make sure the entire flow still works as before, in particular an on chain project is created at the end of the flow
1. Create a new project without any credit class:
   - no metadata form
   - the project shouldn't be created on chain but after final submission, it should be "published" meaning that if you go to the project page before this step, it will return 404 whereas if you go to the project page after the final review step submission, it will show the project data (use the UUID in the URL to go to the project page: https://deploy-preview-2178--regen-marketplace.netlify.app/project/{someUUID})
1. Edit an on chain project, behavior should be unchanged: on chain actions gets triggered when editing anchored data (basic info, location, roles and metadata)
1. Edit a project without a credit class that hasn't been published or a project with a credit class that is not on chain yet, you should still be redirected to the project create flow
1. Edit a project without any credit class that has been published:
   - no metadata form
   - you should be redirected to the project edit flow and editing shouldn't trigger any on chain actions (contrary to 3.)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
