### PR TITLE
fix: max button for create sell order

### DIFF
--- a/web-components/src/components/inputs/new/AmountField/AmountField.tsx
+++ b/web-components/src/components/inputs/new/AmountField/AmountField.tsx
@@ -34,7 +34,10 @@ const AmountField = forwardRef<HTMLDivElement, AmountFieldProps>(
     return (
       <>
         <AmountTextField
-          {...props}
+          customInputProps={{
+            step: 'any',
+            max: availableAmount,
+          }}
           ref={ref}
           name={name}
           type="number"
@@ -49,6 +52,7 @@ const AmountField = forwardRef<HTMLDivElement, AmountFieldProps>(
               denom={denom}
             />
           }
+          {...props}
         />
         <AuxiliaryLabel
           availableAmount={availableAmount}

--- a/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
+++ b/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
@@ -69,6 +69,11 @@ const CreateSellOrderForm: React.FC<Props> = ({
     control: form.control,
   });
   const batchDenom = useWatch({ control: form.control, name: 'batchDenom' });
+  const { setValue } = form;
+  const onMaxClick = () =>
+    setValue('amount', availableAmountByBatch[batchDenom ?? ''], {
+      shouldDirty: true,
+    });
 
   useEffect(() => {
     setOptions(batchDenoms);
@@ -143,7 +148,11 @@ const CreateSellOrderForm: React.FC<Props> = ({
         error={!!errors['amount']}
         helperText={errors['amount']?.message}
         denom={batchDenom ?? ''}
-        customInputProps={{ step: 'any' }}
+        customInputProps={{
+          step: 'any',
+          max: availableAmountByBatch[batchDenom ?? ''],
+        }}
+        onMaxClick={onMaxClick}
         {...form.register('amount')}
       />
       <CheckboxLabel

--- a/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
+++ b/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
@@ -72,7 +72,7 @@ const CreateSellOrderForm: React.FC<Props> = ({
   const availableAmount = availableAmountByBatch[batchDenom ?? ''];
   const { setValue } = form;
   const onMaxClick = () =>
-    setValue('amount', availableAmountByBatch[batchDenom ?? ''], {
+    setValue('amount', availableAmount, {
       shouldDirty: true,
     });
 
@@ -149,10 +149,6 @@ const CreateSellOrderForm: React.FC<Props> = ({
         error={!!errors['amount']}
         helperText={errors['amount']?.message}
         denom={batchDenom ?? ''}
-        customInputProps={{
-          step: 'any',
-          max: availableAmount,
-        }}
         onMaxClick={onMaxClick}
         {...form.register('amount')}
       />

--- a/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
+++ b/web-marketplace/src/components/organisms/CreateSellOrderForm/CreateSellOrderForm.tsx
@@ -69,6 +69,7 @@ const CreateSellOrderForm: React.FC<Props> = ({
     control: form.control,
   });
   const batchDenom = useWatch({ control: form.control, name: 'batchDenom' });
+  const availableAmount = availableAmountByBatch[batchDenom ?? ''];
   const { setValue } = form;
   const onMaxClick = () =>
     setValue('amount', availableAmountByBatch[batchDenom ?? ''], {
@@ -144,13 +145,13 @@ const CreateSellOrderForm: React.FC<Props> = ({
       </Box>
       <AmountField
         label="Amount to sell"
-        availableAmount={availableAmountByBatch[batchDenom ?? '']}
+        availableAmount={availableAmount}
         error={!!errors['amount']}
         helperText={errors['amount']?.message}
         denom={batchDenom ?? ''}
         customInputProps={{
           step: 'any',
-          max: availableAmountByBatch[batchDenom ?? ''],
+          max: availableAmount,
         }}
         onMaxClick={onMaxClick}
         {...form.register('amount')}


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2179

- defined onClick handler for max button in `CretaeSellOrderForm`
- set max value for `<AmountField />`

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. https://deploy-preview-2184--regen-marketplace.netlify.app/profile/portfolio

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
