### PR TITLE
feat: add pinnedIds to useProjectsWithOrders

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -41,7 +41,7 @@
   NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [context.deploy-preview.environment]
-  VITE_SANITY_TAG = "pinned-projects"
+  VITE_SANITY_TAG = "default"
   VITE_SANITY_DATASET = "staging"
   VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
   VITE_API_URI = "https://api-staging.regen.network"

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,7 +41,7 @@
   NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [context.deploy-preview.environment]
-  VITE_SANITY_TAG = "default"
+  VITE_SANITY_TAG = "pinned-projects"
   VITE_SANITY_DATASET = "staging"
   VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
   VITE_API_URI = "https://api-staging.regen.network"

--- a/web-marketplace/sanity-graphql.schema.json
+++ b/web-marketplace/sanity-graphql.schema.json
@@ -26189,7 +26189,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "TitleCustomBody",
+              "name": "HomePageProjectsSection",
               "ofType": null
             },
             "isDeprecated": false,
@@ -26362,7 +26362,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "TitleCustomBodyFilter",
+              "name": "HomePageProjectsSectionFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -26399,6 +26399,163 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "BottomBannerFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "HomePageProjectsSection",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "TitleCustomBody",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projects",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HomePageProjectsSectionFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TitleCustomBodyFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HomePageProjectsSectionSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TitleCustomBodySorting",
               "ofType": null
             },
             "defaultValue": null,
@@ -26517,7 +26674,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "TitleCustomBodySorting",
+              "name": "HomePageProjectsSectionSorting",
               "ofType": null
             },
             "defaultValue": null,
@@ -40942,7 +41099,7 @@
           },
           {
             "name": "projectId",
-            "description": "on-chain project id",
+            "description": "on-chain project id, off-chain uuid or slug",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -66655,6 +66812,57 @@
       }
     ],
     "directives": [
+      {
+        "name": "crossDatasetReference",
+        "description": "Field references one or more document in another dataset",
+        "isRepeatable": false,
+        "locations": [
+          "OBJECT",
+          "FIELD_DEFINITION"
+        ],
+        "args": [
+          {
+            "name": "dataset",
+            "description": "Dataset name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeNames",
+            "description": "Strings of the target types names enabled for this reference",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ]
+      },
       {
         "name": "jsonAlias",
         "description": "Field is a \"raw\" JSON alias for a different field",

--- a/web-marketplace/src/components/organisms/ProjectCardsSection/ProjectCardsSection.tsx
+++ b/web-marketplace/src/components/organisms/ProjectCardsSection/ProjectCardsSection.tsx
@@ -75,7 +75,7 @@ export function ProjectCardsSection({
                   onButtonClick && (() => onButtonClick({ project }))
                 }
                 purchaseInfo={project.purchaseInfo}
-                href={`/project/${project.id}`}
+                href={`/project/${project.slug ?? project.id}`}
                 target={'_self'}
                 imageStorageBaseUrl={IMAGE_STORAGE_BASE_URL}
                 apiServerUrl={API_URI}

--- a/web-marketplace/src/generated/sanity-graphql.tsx
+++ b/web-marketplace/src/generated/sanity-graphql.tsx
@@ -22,6 +22,7 @@ export type Scalars = {
 
 
 
+
 export type ActionCard = {
   __typename?: 'ActionCard';
   _key?: Maybe<Scalars['String']>;
@@ -3011,7 +3012,7 @@ export type HomePage = Document & {
   _key?: Maybe<Scalars['String']>;
   seo?: Maybe<Seo>;
   heroSection?: Maybe<HomePageTopSection>;
-  projectsSection?: Maybe<TitleCustomBody>;
+  projectsSection?: Maybe<HomePageProjectsSection>;
   creditClassesSection?: Maybe<TitleCustomBody>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSection>;
   bottomBanner?: Maybe<BottomBanner>;
@@ -3028,10 +3029,30 @@ export type HomePageFilter = {
   _key?: Maybe<StringFilter>;
   seo?: Maybe<SeoFilter>;
   heroSection?: Maybe<HomePageTopSectionFilter>;
-  projectsSection?: Maybe<TitleCustomBodyFilter>;
+  projectsSection?: Maybe<HomePageProjectsSectionFilter>;
   creditClassesSection?: Maybe<TitleCustomBodyFilter>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSectionFilter>;
   bottomBanner?: Maybe<BottomBannerFilter>;
+};
+
+export type HomePageProjectsSection = {
+  __typename?: 'HomePageProjectsSection';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  titleCustomBody?: Maybe<TitleCustomBody>;
+  projects?: Maybe<Array<Maybe<Project>>>;
+};
+
+export type HomePageProjectsSectionFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  titleCustomBody?: Maybe<TitleCustomBodyFilter>;
+};
+
+export type HomePageProjectsSectionSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  titleCustomBody?: Maybe<TitleCustomBodySorting>;
 };
 
 export type HomePageSorting = {
@@ -3043,7 +3064,7 @@ export type HomePageSorting = {
   _key?: Maybe<SortOrder>;
   seo?: Maybe<SeoSorting>;
   heroSection?: Maybe<HomePageTopSectionSorting>;
-  projectsSection?: Maybe<TitleCustomBodySorting>;
+  projectsSection?: Maybe<HomePageProjectsSectionSorting>;
   creditClassesSection?: Maybe<TitleCustomBodySorting>;
   bottomBanner?: Maybe<BottomBannerSorting>;
 };
@@ -4707,7 +4728,7 @@ export type Project = Document & {
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
   projectName?: Maybe<Scalars['String']>;
-  /** on-chain project id */
+  /** on-chain project id, off-chain uuid or slug */
   projectId?: Maybe<Scalars['String']>;
   image?: Maybe<CustomImage>;
   location?: Maybe<Scalars['String']>;
@@ -8084,8 +8105,14 @@ export type AllHomePageQuery = (
       { __typename?: 'GettingStartedResourcesSection' }
       & GettingStartedResourcesSectionFieldsFragment
     )>, projectsSection?: Maybe<(
-      { __typename?: 'TitleCustomBody' }
-      & TitleCustomBodyFieldsFragment
+      { __typename?: 'HomePageProjectsSection' }
+      & { titleCustomBody?: Maybe<(
+        { __typename?: 'TitleCustomBody' }
+        & TitleCustomBodyFieldsFragment
+      )>, projects?: Maybe<Array<Maybe<(
+        { __typename?: 'Project' }
+        & Pick<Project, 'projectId'>
+      )>>> }
     )>, creditClassesSection?: Maybe<(
       { __typename?: 'TitleCustomBody' }
       & TitleCustomBodyFieldsFragment
@@ -9956,7 +9983,12 @@ export const AllHomePageDocument = gql`
       ...gettingStartedResourcesSectionFields
     }
     projectsSection {
-      ...titleCustomBodyFields
+      titleCustomBody {
+        ...titleCustomBodyFields
+      }
+      projects {
+        projectId
+      }
     }
     creditClassesSection {
       ...titleCustomBodyFields

--- a/web-marketplace/src/graphql/sanity/AllHomePage.graphql
+++ b/web-marketplace/src/graphql/sanity/AllHomePage.graphql
@@ -20,7 +20,12 @@ query allHomePage {
       ...gettingStartedResourcesSectionFields
     }
     projectsSection {
-      ...titleCustomBodyFields
+      titleCustomBody {
+        ...titleCustomBodyFields
+      }
+      projects {
+        projectId
+      }
     }
     creditClassesSection {
       ...titleCustomBodyFields

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -19,7 +19,10 @@ import { useWallet } from 'lib/wallet/wallet';
 
 import { useFetchAllOffChainProjects } from 'pages/Projects/hooks/useOffChainProjects';
 import { ProjectsSellOrders } from 'pages/Projects/hooks/useProjectsSellOrders.types';
-import { sortProjects } from 'pages/Projects/utils/sortProjects';
+import {
+  sortPinnedProject,
+  sortProjects,
+} from 'pages/Projects/utils/sortProjects';
 import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
 
 import { useLastRandomProjects } from './useLastRandomProjects';
@@ -35,6 +38,7 @@ export interface ProjectsWithOrdersProps {
   projectId?: string; // to filter by project
   skippedProjectId?: string; // to discard a specific project
   classId?: string; // to filter by class
+  pinnedIds?: string[]; // list of on-chain id, uuid or slug to pinned at the top
   sort?: string;
   creditClassFilter?: Record<string, boolean>;
 }
@@ -51,6 +55,7 @@ export function useProjectsWithOrders({
   useOffChainProjects = false,
   skippedProjectId,
   classId,
+  pinnedIds,
   sort = '',
   projectId,
   creditClassFilter = {},
@@ -164,16 +169,16 @@ export function useProjectsWithOrders({
   const creditClassSelected = Object.keys(creditClassFilter).filter(
     creditClassId => creditClassFilter[creditClassId],
   );
+
   const projectsFilteredByCreditClass = allProject.filter(project =>
     creditClassSelected.length === 0
       ? true
       : creditClassSelected.includes(project.creditClassId ?? ''),
   );
 
-  const sortedProjects = sortProjects(
-    projectsFilteredByCreditClass,
-    sort,
-  ).slice(offset, limit ? offset + limit : undefined);
+  const sortedProjects = sortProjects(projectsFilteredByCreditClass, sort)
+    .sort((a, b) => sortPinnedProject(a, b, pinnedIds))
+    .slice(offset, limit ? offset + limit : undefined);
 
   /* Metadata queries */
 

--- a/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
+++ b/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
@@ -83,6 +83,7 @@ export const normalizeProjectWithMetadata = ({
     ...projectWithOrderData,
     id: projectId,
     offChainId: offChainProject?.id,
+    slug: offChainProject?.slug,
     name:
       projectMetadata?.['schema:name'] ||
       projectWithOrderData?.name ||

--- a/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
+++ b/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
@@ -83,7 +83,7 @@ export const normalizeProjectWithMetadata = ({
     ...projectWithOrderData,
     id: projectId,
     offChainId: offChainProject?.id,
-    slug: offChainProject?.slug,
+    slug: offChainProject?.slug ?? projectWithOrderData?.slug,
     name:
       projectMetadata?.['schema:name'] ||
       projectWithOrderData?.name ||

--- a/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
+++ b/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
@@ -82,6 +82,7 @@ export const normalizeProjectWithMetadata = ({
   return {
     ...projectWithOrderData,
     id: projectId,
+    offChainId: offChainProject?.id,
     name:
       projectMetadata?.['schema:name'] ||
       projectWithOrderData?.name ||

--- a/web-marketplace/src/pages/Home/Home.FeaturedProjects.tsx
+++ b/web-marketplace/src/pages/Home/Home.FeaturedProjects.tsx
@@ -4,7 +4,11 @@ import { Box } from '@mui/material';
 
 import ContainedButton from 'web-components/lib/components/buttons/ContainedButton';
 
-import { Maybe, Scalars } from 'generated/sanity-graphql';
+import {
+  HomePageProjectsSection,
+  Maybe,
+  Scalars,
+} from 'generated/sanity-graphql';
 
 import { BuySellOrderFlow } from 'features/marketplace/BuySellOrderFlow/BuySellOrderFlow';
 import { ProjectWithOrderData } from 'pages/Projects/Projects.types';
@@ -12,14 +16,21 @@ import { ProjectCardsSection } from 'components/organisms/ProjectCardsSection/Pr
 
 import { useFeaturedProjects } from './hooks/useFeaturedProjects';
 
+type Props = {
+  title: string;
+  body: Maybe<Scalars['JSON']>;
+  sanityFeaturedProjects: HomePageProjectsSection['projects'];
+};
+
 export function FeaturedProjects({
   title,
   body,
-}: {
-  title: string;
-  body: Maybe<Scalars['JSON']>;
-}): JSX.Element {
-  const { featuredProjects, loading } = useFeaturedProjects();
+  sanityFeaturedProjects,
+}: Props): JSX.Element {
+  const pinnedIds = sanityFeaturedProjects?.map(project =>
+    String(project?.projectId),
+  );
+  const { featuredProjects, loading } = useFeaturedProjects({ pinnedIds });
   const [selectedProject, setSelectedProject] =
     useState<ProjectWithOrderData | null>(null);
   const [isBuyFlowStarted, setIsBuyFlowStarted] = useState(false);

--- a/web-marketplace/src/pages/Home/Home.tsx
+++ b/web-marketplace/src/pages/Home/Home.tsx
@@ -153,8 +153,9 @@ const Home: React.FC<React.PropsWithChildren<unknown>> = () => {
       </BackgroundImgSection>
 
       <FeaturedProjects
-        title={projectsSection?.title || 'Featured Projects'}
-        body={projectsSection?.bodyRaw}
+        title={projectsSection?.titleCustomBody?.title || 'Featured Projects'}
+        body={projectsSection?.titleCustomBody?.bodyRaw}
+        sanityFeaturedProjects={projectsSection?.projects}
       />
 
       {creditClasses && (

--- a/web-marketplace/src/pages/Home/hooks/useFeaturedProjects.ts
+++ b/web-marketplace/src/pages/Home/hooks/useFeaturedProjects.ts
@@ -3,7 +3,11 @@ import { useProjectsWithOrders } from 'hooks/projects/useProjectsWithOrders';
 
 import { FEATURE_PROJECTS_COUNT, PROJECTS_SORT } from '../Home.constants';
 
-export function useFeaturedProjects(): {
+type Props = {
+  pinnedIds?: string[];
+};
+
+export function useFeaturedProjects({ pinnedIds }: Props): {
   featuredProjects: ProjectWithOrderData[];
   loading: boolean;
 } {
@@ -12,6 +16,8 @@ export function useFeaturedProjects(): {
     limit: FEATURE_PROJECTS_COUNT,
     metadata: true, // to discard projects without metadata prop
     sort: PROJECTS_SORT,
+    pinnedIds,
+    useOffChainProjects: true,
   });
   return {
     featuredProjects: projectsWithOrderData,

--- a/web-marketplace/src/pages/Projects/Projects.types.ts
+++ b/web-marketplace/src/pages/Projects/Projects.types.ts
@@ -17,6 +17,7 @@ export interface ProjectWithOrderData extends ProjectCardProps {
   offChain?: boolean;
   published?: boolean;
   offChainId?: string;
+  slug?: string;
 }
 
 export type FilterCommunityCreditsEvent = {

--- a/web-marketplace/src/pages/Projects/Projects.types.ts
+++ b/web-marketplace/src/pages/Projects/Projects.types.ts
@@ -16,6 +16,7 @@ export interface ProjectWithOrderData extends ProjectCardProps {
   sanityCreditClassData?: AllCreditClassQuery['allCreditClass'][0];
   offChain?: boolean;
   published?: boolean;
+  offChainId?: string;
 }
 
 export type FilterCommunityCreditsEvent = {

--- a/web-marketplace/src/pages/Projects/utils/sortProjects.ts
+++ b/web-marketplace/src/pages/Projects/utils/sortProjects.ts
@@ -88,26 +88,28 @@ export function sortPinnedProject(
 
   const aIdIndex = pinnedIds?.indexOf(a.id);
   const aOffChainIdIndex = pinnedIds?.indexOf(a.offChainId ?? '');
-  const aNameIndex = pinnedIds?.indexOf(a.name);
+  const aSlugIndex = pinnedIds?.indexOf(a.slug ?? '');
+
   let aIndex = -1;
-  if (aIdIndex > 0) {
+  if (aIdIndex >= 0) {
     aIndex = aIdIndex;
-  } else if (aOffChainIdIndex > 0) {
+  } else if (aOffChainIdIndex >= 0) {
     aIndex = aOffChainIdIndex;
-  } else if (aNameIndex > 0) {
-    aIndex = aNameIndex;
+  } else if (aSlugIndex >= 0) {
+    aIndex = aSlugIndex;
   }
 
   const bIdIndex = pinnedIds?.indexOf(b.id);
   const bOffChainIdIndex = pinnedIds?.indexOf(b.offChainId ?? '');
-  const bNameIndex = pinnedIds?.indexOf(b.name);
+  const bSlugIndex = pinnedIds?.indexOf(b.slug ?? '');
+
   let bIndex = -1;
-  if (bIdIndex > 0) {
+  if (bIdIndex >= 0) {
     bIndex = bIdIndex;
-  } else if (bOffChainIdIndex > 0) {
+  } else if (bOffChainIdIndex >= 0) {
     bIndex = bOffChainIdIndex;
-  } else if (bNameIndex > 0) {
-    bIndex = bNameIndex;
+  } else if (bSlugIndex >= 0) {
+    bIndex = bSlugIndex;
   }
 
   if (aIndex >= 0 && bIndex === -1) return -1;

--- a/web-marketplace/src/pages/Projects/utils/sortProjects.ts
+++ b/web-marketplace/src/pages/Projects/utils/sortProjects.ts
@@ -87,10 +87,28 @@ export function sortPinnedProject(
   if (!pinnedIds) return 0;
 
   const aIdIndex = pinnedIds?.indexOf(a.id);
-  const aIndex = aIdIndex > 0 ? aIdIndex : pinnedIds?.indexOf(a.name);
+  const aOffChainIdIndex = pinnedIds?.indexOf(a.offChainId ?? '');
+  const aNameIndex = pinnedIds?.indexOf(a.name);
+  let aIndex = -1;
+  if (aIdIndex > 0) {
+    aIndex = aIdIndex;
+  } else if (aOffChainIdIndex > 0) {
+    aIndex = aOffChainIdIndex;
+  } else if (aNameIndex > 0) {
+    aIndex = aNameIndex;
+  }
 
   const bIdIndex = pinnedIds?.indexOf(b.id);
-  const bIndex = bIdIndex > 0 ? bIdIndex : pinnedIds?.indexOf(b.name);
+  const bOffChainIdIndex = pinnedIds?.indexOf(b.offChainId ?? '');
+  const bNameIndex = pinnedIds?.indexOf(b.name);
+  let bIndex = -1;
+  if (bIdIndex > 0) {
+    bIndex = bIdIndex;
+  } else if (bOffChainIdIndex > 0) {
+    bIndex = bOffChainIdIndex;
+  } else if (bNameIndex > 0) {
+    bIndex = bNameIndex;
+  }
 
   if (aIndex >= 0 && bIndex === -1) return -1;
   if (aIndex === -1 && bIndex >= 0) return 1;

--- a/web-marketplace/src/pages/Projects/utils/sortProjects.ts
+++ b/web-marketplace/src/pages/Projects/utils/sortProjects.ts
@@ -78,6 +78,29 @@ function compareQuantityDescending(
   return 0;
 }
 
+// Sort pinned project at the beginning
+export function sortPinnedProject(
+  a: ProjectWithOrderData,
+  b: ProjectWithOrderData,
+  pinnedIds?: string[],
+): number {
+  if (!pinnedIds) return 0;
+
+  const aIdIndex = pinnedIds?.indexOf(a.id);
+  const aIndex = aIdIndex > 0 ? aIdIndex : pinnedIds?.indexOf(a.name);
+
+  const bIdIndex = pinnedIds?.indexOf(b.id);
+  const bIndex = bIdIndex > 0 ? bIdIndex : pinnedIds?.indexOf(b.name);
+
+  if (aIndex >= 0 && bIndex === -1) return -1;
+  if (aIndex === -1 && bIndex >= 0) return 1;
+  if (aIndex >= 0 && bIndex >= 0) {
+    return aIndex < bIndex ? -1 : 1;
+  }
+
+  return 0;
+}
+
 function getQuantities(
   a: ProjectWithOrderData,
   b: ProjectWithOrderData,


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1811
Needs: https://github.com/regen-network/regen-sanity/pull/49

Add the possibility to pin projects to the featured projects section on the registry homepage.
`useProjectsWithOrders` now accepts a `pinnedIds` prop to enable this feature.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. https://deploy-preview-2191--regen-marketplace.netlify.app/
2. For devs: Try to change the featured projects in sanity staging (note that off-chain projects will need to be validated and published).

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
