### PR TITLE
fix: hide credit class entry if no credit class

### DIFF
--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -48,7 +48,9 @@ const RegistryLayoutHeader: React.FC = () => {
   const isTransparent = useMemo(() => getIsTransparent(pathname), [pathname]);
   const borderBottom = useMemo(() => getBorderBottom(pathname), [pathname]);
 
-  const { showCreditClasses, showProjects, isIssuer } = useProfileItems({});
+  const { showProjects, showCreditClasses, isIssuer } = useProfileItems({
+    address: wallet?.address,
+  });
   const menuItems = useMemo(() => getMenuItems(pathname), [pathname]);
   const userMenuItems = useMemo(
     () =>

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -48,9 +48,7 @@ const RegistryLayoutHeader: React.FC = () => {
   const isTransparent = useMemo(() => getIsTransparent(pathname), [pathname]);
   const borderBottom = useMemo(() => getBorderBottom(pathname), [pathname]);
 
-  const { showProjects, showCreditClasses, isIssuer } = useProfileItems({
-    address: wallet?.address,
-  });
+  const { showProjects, showCreditClasses, isIssuer } = useProfileItems({});
   const menuItems = useMemo(() => getMenuItems(pathname), [pathname]);
   const userMenuItems = useMemo(
     () =>

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -21,7 +21,6 @@ import {
   profileVariantMapping,
 } from 'pages/ProfileEdit/ProfileEdit.constants';
 import { Link } from 'components/atoms';
-import { useFetchCreditClassesWithOrder } from 'hooks/classes/useFetchCreditClassesWithOrder';
 
 import {
   BRIDGE,
@@ -51,9 +50,6 @@ const Dashboard = (): JSX.Element => {
   const { avatarImage, backgroundImage } = getUserImages({
     account,
   });
-  const { creditClasses } = useFetchCreditClassesWithOrder({
-    admin: wallet?.address,
-  });
 
   const socialsLinks: SocialLink[] = useMemo(
     () => getSocialsLinks({ account }),
@@ -65,7 +61,7 @@ const Dashboard = (): JSX.Element => {
       { hidden: !isConnected, ...PORTFOLIO },
       { hidden: !showProjects, ...PROJECTS },
       {
-        hidden: !showCreditClasses || creditClasses.length === 0,
+        hidden: !showCreditClasses,
         ...CREDIT_CLASSES,
       },
       {
@@ -77,6 +73,7 @@ const Dashboard = (): JSX.Element => {
         ...BRIDGE,
       },
     ],
+<<<<<<< HEAD
     [
       isConnected,
       showProjects,
@@ -84,6 +81,9 @@ const Dashboard = (): JSX.Element => {
       creditClasses.length,
       isIssuer,
     ],
+=======
+    [isIssuer, showCreditClasses, showProjects],
+>>>>>>> f358ec360 (fix: hide credit class entry if no credit class)
   );
 
   const activeTab = Math.max(

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -41,7 +41,7 @@ const Dashboard = (): JSX.Element => {
     isProjectAdmin,
     isIssuer,
     showProjects,
-  } = useProfileItems({ address: wallet?.address });
+  } = useProfileItems({});
   const location = useLocation();
 
   const { activeAccount } = useAuth();

--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -34,16 +34,17 @@ import { getSocialsLinks, getUserImages } from './Dashboard.utils';
 import { useProfileItems } from './hooks/useProfileItems';
 
 const Dashboard = (): JSX.Element => {
+  const { wallet, accountByAddr, isConnected } = useWallet();
   const {
     showCreditClasses,
     isCreditClassCreator,
     isProjectAdmin,
     isIssuer,
     showProjects,
-  } = useProfileItems({});
-  const { activeAccount } = useAuth();
-  const { wallet, isConnected, accountByAddr } = useWallet();
+  } = useProfileItems({ address: wallet?.address });
   const location = useLocation();
+
+  const { activeAccount } = useAuth();
 
   const account = activeAccount ?? accountByAddr;
 
@@ -73,17 +74,7 @@ const Dashboard = (): JSX.Element => {
         ...BRIDGE,
       },
     ],
-<<<<<<< HEAD
-    [
-      isConnected,
-      showProjects,
-      showCreditClasses,
-      creditClasses.length,
-      isIssuer,
-    ],
-=======
-    [isIssuer, showCreditClasses, showProjects],
->>>>>>> f358ec360 (fix: hide credit class entry if no credit class)
+    [isConnected, isIssuer, showCreditClasses, showProjects],
   );
 
   const activeTab = Math.max(

--- a/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
+++ b/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from 'lib/auth/auth';
 
+import { useFetchCreditClassesWithOrder } from 'hooks/classes/useFetchCreditClassesWithOrder';
 import { useQueryIfCreditClassCreator } from 'hooks/useQueryIfCreditClassCreator';
 import { useQueryIsClassAdmin } from 'hooks/useQueryIsClassAdmin';
 import { useQueryIsIssuer } from 'hooks/useQueryIsIssuer';
@@ -17,9 +18,15 @@ export const useProfileItems = ({ address, accountId }: Props) => {
   const { isProjectAdmin } = useQueryIsProjectAdmin({ address, accountId });
   const isCreditClassAdmin = useQueryIsClassAdmin({ address });
 
+  const { creditClasses } = useFetchCreditClassesWithOrder({
+    admin: address,
+  });
+
   const activeAccountProfile = !!activeAccountId && !accountId && !address;
   const showProjects = isProjectAdmin || activeAccountProfile;
-  const showCreditClasses = isCreditClassCreator || isCreditClassAdmin;
+
+  const showCreditClasses =
+    (isCreditClassCreator || isCreditClassAdmin) && creditClasses.length > 0;
 
   return {
     showProjects,

--- a/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
+++ b/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
@@ -30,7 +30,7 @@ export const useProfileItems = ({ address, accountId }: Props) => {
 
   return {
     showProjects,
-    showCreditClasses: showCreditClasses,
+    showCreditClasses,
     isCreditClassCreator: false && isCreditClassCreator,
     isProjectAdmin: isProjectAdmin,
     isIssuer: isIssuer,

--- a/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
+++ b/web-marketplace/src/pages/Dashboard/hooks/useProfileItems.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from 'lib/auth/auth';
+import { useWallet } from 'lib/wallet/wallet';
 
 import { useFetchCreditClassesWithOrder } from 'hooks/classes/useFetchCreditClassesWithOrder';
 import { useQueryIfCreditClassCreator } from 'hooks/useQueryIfCreditClassCreator';
@@ -13,13 +14,15 @@ type Props = {
 
 export const useProfileItems = ({ address, accountId }: Props) => {
   const { activeAccountId } = useAuth();
+  const { wallet } = useWallet();
+  const walletAddress = wallet?.address;
+  const activeAddress = address ?? walletAddress;
   const { isIssuer } = useQueryIsIssuer({ address });
   const isCreditClassCreator = useQueryIfCreditClassCreator({ address });
   const { isProjectAdmin } = useQueryIsProjectAdmin({ address, accountId });
   const isCreditClassAdmin = useQueryIsClassAdmin({ address });
-
   const { creditClasses } = useFetchCreditClassesWithOrder({
-    admin: address,
+    admin: activeAddress,
   });
 
   const activeAccountProfile = !!activeAccountId && !accountId && !address;


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2205

Hide credit class entry in the user dropdown menu if the user has no credit class.

The credit class item was displayed in the user menu because if the allowed list param is not activated on the current chain, we display it by default. See [this hook](https://github.com/regen-network/regen-web/blob/dev/web-marketplace/src/hooks/useQueryIfCreditClassCreator.ts#L32) for more info.

The tab was not displayed in the user profile because we also checked the number of credit classes created there. This PR adds the same check for the user menu entry.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. https://deploy-preview-2214--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
