### PR TITLE
feat: add secondary button to EcologicalCreditCard

### DIFF
--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.mock.ts
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.mock.ts
@@ -31,7 +31,7 @@ export const EcologicalCreditCardMock: EcologicalCreditCardProps = {
       },
     ],
   },
-  projectActivitesList: {
+  projectActivitiesList: {
     label: 'offset generation method',
     items: [
       {

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
@@ -2,6 +2,7 @@ import { Box, Card, SxProps } from '@mui/material';
 
 import { Flex } from '../../../components/box';
 import ContainedButton from '../../../components/buttons/ContainedButton';
+import OutlinedButton from '../../../components/buttons/OutlinedButton';
 import { LinkComponentProp } from '../../../components/tabs/IconTabs';
 import { Body, Title } from '../../../components/typography';
 import { pxToRem, Theme } from '../../../theme/muiTheme';
@@ -24,10 +25,14 @@ const EcologicalCreditCard = ({
   offsetMethodList,
   projectActivitesList,
   button,
+  secondaryButton,
   linkComponent,
   children,
   sx = [],
 }: EcologicalCreditCardProps): JSX.Element => {
+  const hasItems =
+    offsetMethodList.items.length > 0 || projectActivitesList.items.length > 0;
+
   return (
     <Card
       sx={[
@@ -70,30 +75,49 @@ const EcologicalCreditCard = ({
         <Body sx={{ mb: { xs: 3.5, sm: 5 }, fontSize: pxToRem(18) }}>
           {description}
         </Body>
-        <Flex
-          sx={{ mb: { xs: 4, sm: 9 } }}
-          flexDirection={{ xs: 'column', sm: 'row' }}
-        >
-          <EcologicalCreditCardItemList
-            label={offsetMethodList.label}
-            items={offsetMethodList.items}
-            sx={{ width: 318, mr: 5, mb: { xs: 5, sm: 0 } }}
-          />
-          <EcologicalCreditCardItemList
-            label={projectActivitesList.label}
-            items={projectActivitesList.items}
-            sx={{ width: 318 }}
-          />
-        </Flex>
-        {button?.text && (
-          <ContainedButton
-            href={button.href}
-            LinkComponent={linkComponent}
-            sx={{ width: 'fit-content' }}
+        {hasItems && (
+          <Flex
+            sx={{ mb: { xs: 4, sm: 9 } }}
+            flexDirection={{ xs: 'column', sm: 'row' }}
           >
-            {button.text}
-          </ContainedButton>
+            <EcologicalCreditCardItemList
+              label={offsetMethodList.label}
+              items={offsetMethodList.items}
+              sx={{ width: 318, mr: 5, mb: { xs: 5, sm: 0 } }}
+            />
+            <EcologicalCreditCardItemList
+              label={projectActivitesList.label}
+              items={projectActivitesList.items}
+              sx={{ width: 318 }}
+            />
+          </Flex>
         )}
+        <div className="flex flex-col sm:flex-row">
+          {button?.text && (
+            <ContainedButton
+              href={button.href}
+              LinkComponent={linkComponent}
+              sx={{
+                width: { xs: 'w-full', sm: 'fit-content' },
+                mb: { xs: 5, sm: 0 },
+              }}
+            >
+              {button.text}
+            </ContainedButton>
+          )}
+          {secondaryButton?.text && (
+            <OutlinedButton
+              href={secondaryButton.href}
+              LinkComponent={linkComponent}
+              sx={{
+                width: { xs: 'w-full', sm: 'fit-content' },
+                ml: { xs: 0, sm: 5 },
+              }}
+            >
+              {secondaryButton.text}
+            </OutlinedButton>
+          )}
+        </div>
       </Box>
     </Card>
   );

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
@@ -23,7 +23,7 @@ const EcologicalCreditCard = ({
   infos,
   description,
   offsetMethodList,
-  projectActivitesList,
+  projectActivitiesList,
   button,
   secondaryButton,
   linkComponent,
@@ -31,7 +31,7 @@ const EcologicalCreditCard = ({
   sx = [],
 }: EcologicalCreditCardProps): JSX.Element => {
   const hasItems =
-    offsetMethodList.items.length > 0 || projectActivitesList.items.length > 0;
+    offsetMethodList.items.length > 0 || projectActivitiesList.items.length > 0;
 
   return (
     <Card
@@ -86,8 +86,8 @@ const EcologicalCreditCard = ({
               sx={{ width: 318, mr: 5, mb: { xs: 5, sm: 0 } }}
             />
             <EcologicalCreditCardItemList
-              label={projectActivitesList.label}
-              items={projectActivitesList.items}
+              label={projectActivitiesList.label}
+              items={projectActivitiesList.items}
               sx={{ width: 318 }}
             />
           </Flex>

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
@@ -29,7 +29,7 @@ export type EcologicalCreditCardType = {
   infos: EcologicalCreditInfoType;
   description: string;
   offsetMethodList: EcologicalCreditCardItemListType;
-  projectActivitesList: EcologicalCreditCardItemListType;
+  projectActivitiesList: EcologicalCreditCardItemListType;
   program?: Account;
   button: {
     text?: string;

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
@@ -32,7 +32,11 @@ export type EcologicalCreditCardType = {
   projectActivitesList: EcologicalCreditCardItemListType;
   program?: Account;
   button: {
-    text: string;
-    href: string;
+    text?: string;
+    href?: string;
+  };
+  secondaryButton?: {
+    text?: string;
+    href?: string;
   };
 };

--- a/web-marketplace/src/pages/Buyers/normalizers/normalizeEcologicalCreditCards.ts
+++ b/web-marketplace/src/pages/Buyers/normalizers/normalizeEcologicalCreditCards.ts
@@ -65,7 +65,7 @@ export const normalizeEcologicalCreditCards = ({
               },
             })) ?? [],
         },
-        projectActivitesList: {
+        projectActivitiesList: {
           label: PROJECT_ACTIVITIES,
           items:
             card?.projectActivities?.map(projectActivity => ({

--- a/web-www/generated/sanity-graphql.tsx
+++ b/web-www/generated/sanity-graphql.tsx
@@ -22,6 +22,7 @@ export type Scalars = {
 
 
 
+
 export type ActionCard = {
   __typename?: 'ActionCard';
   _key?: Maybe<Scalars['String']>;
@@ -1708,6 +1709,8 @@ export type CreditClass = Document & {
   landSteward?: Maybe<LandSteward>;
   icon?: Maybe<Image>;
   program?: Maybe<Program>;
+  retirementLabel?: Maybe<Scalars['String']>;
+  retirementIcon?: Maybe<Image>;
 };
 
 export type CreditClassFilter = {
@@ -1726,6 +1729,8 @@ export type CreditClassFilter = {
   landSteward?: Maybe<LandStewardFilter>;
   icon?: Maybe<ImageFilter>;
   program?: Maybe<ProgramFilter>;
+  retirementLabel?: Maybe<StringFilter>;
+  retirementIcon?: Maybe<ImageFilter>;
 };
 
 export type CreditClassPage = Document & {
@@ -1782,6 +1787,8 @@ export type CreditClassSorting = {
   buyer?: Maybe<BuyerSorting>;
   landSteward?: Maybe<LandStewardSorting>;
   icon?: Maybe<ImageSorting>;
+  retirementLabel?: Maybe<SortOrder>;
+  retirementIcon?: Maybe<ImageSorting>;
 };
 
 export type CreditInfos = {
@@ -2349,6 +2356,7 @@ export type EcologicalCreditCard = Document & {
   offsetMethods?: Maybe<Array<Maybe<OffsetMethod>>>;
   projectActivities?: Maybe<Array<Maybe<ProjectActivity>>>;
   button?: Maybe<Button>;
+  secondaryButton?: Maybe<Button>;
 };
 
 export type EcologicalCreditCardFilter = {
@@ -2367,6 +2375,7 @@ export type EcologicalCreditCardFilter = {
   creditClass?: Maybe<CreditClassFilter>;
   creditInfos?: Maybe<CreditInfosFilter>;
   button?: Maybe<ButtonFilter>;
+  secondaryButton?: Maybe<ButtonFilter>;
 };
 
 export type EcologicalCreditCardSorting = {
@@ -2381,6 +2390,7 @@ export type EcologicalCreditCardSorting = {
   image?: Maybe<CustomImageSorting>;
   creditInfos?: Maybe<CreditInfosSorting>;
   button?: Maybe<ButtonSorting>;
+  secondaryButton?: Maybe<ButtonSorting>;
 };
 
 export type EcologicalCreditCardsSection = {
@@ -3005,7 +3015,7 @@ export type HomePage = Document & {
   _key?: Maybe<Scalars['String']>;
   seo?: Maybe<Seo>;
   heroSection?: Maybe<HomePageTopSection>;
-  projectsSection?: Maybe<TitleCustomBody>;
+  projectsSection?: Maybe<HomePageProjectsSection>;
   creditClassesSection?: Maybe<TitleCustomBody>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSection>;
   bottomBanner?: Maybe<BottomBanner>;
@@ -3022,10 +3032,30 @@ export type HomePageFilter = {
   _key?: Maybe<StringFilter>;
   seo?: Maybe<SeoFilter>;
   heroSection?: Maybe<HomePageTopSectionFilter>;
-  projectsSection?: Maybe<TitleCustomBodyFilter>;
+  projectsSection?: Maybe<HomePageProjectsSectionFilter>;
   creditClassesSection?: Maybe<TitleCustomBodyFilter>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSectionFilter>;
   bottomBanner?: Maybe<BottomBannerFilter>;
+};
+
+export type HomePageProjectsSection = {
+  __typename?: 'HomePageProjectsSection';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  titleCustomBody?: Maybe<TitleCustomBody>;
+  projects?: Maybe<Array<Maybe<Project>>>;
+};
+
+export type HomePageProjectsSectionFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  titleCustomBody?: Maybe<TitleCustomBodyFilter>;
+};
+
+export type HomePageProjectsSectionSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  titleCustomBody?: Maybe<TitleCustomBodySorting>;
 };
 
 export type HomePageSorting = {
@@ -3037,7 +3067,7 @@ export type HomePageSorting = {
   _key?: Maybe<SortOrder>;
   seo?: Maybe<SeoSorting>;
   heroSection?: Maybe<HomePageTopSectionSorting>;
-  projectsSection?: Maybe<TitleCustomBodySorting>;
+  projectsSection?: Maybe<HomePageProjectsSectionSorting>;
   creditClassesSection?: Maybe<TitleCustomBodySorting>;
   bottomBanner?: Maybe<BottomBannerSorting>;
 };
@@ -4701,7 +4731,7 @@ export type Project = Document & {
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
   projectName?: Maybe<Scalars['String']>;
-  /** on-chain project id */
+  /** on-chain project id, off-chain uuid or slug */
   projectId?: Maybe<Scalars['String']>;
   image?: Maybe<CustomImage>;
   location?: Maybe<Scalars['String']>;
@@ -8142,6 +8172,13 @@ export type EcologicalCreditCardFieldsFragment = (
       { __typename?: 'Link' }
       & Pick<Link, 'buttonHref'>
     )> }
+  )>, secondaryButton?: Maybe<(
+    { __typename?: 'Button' }
+    & Pick<Button, 'buttonText'>
+    & { buttonLink?: Maybe<(
+      { __typename?: 'Link' }
+      & Pick<Link, 'buttonHref'>
+    )> }
   )> }
 );
 
@@ -8778,6 +8815,12 @@ export const EcologicalCreditCardFieldsFragmentDoc = gql`
     }
   }
   button {
+    buttonText
+    buttonLink {
+      buttonHref
+    }
+  }
+  secondaryButton {
     buttonText
     buttonLink {
       buttonHref

--- a/web-www/graphql/sanity/fragments/shared/ecologicalCreditCardFragment.graphql
+++ b/web-www/graphql/sanity/fragments/shared/ecologicalCreditCardFragment.graphql
@@ -45,4 +45,10 @@ fragment ecologicalCreditCardFields on EcologicalCreditCard {
       buttonHref
     }
   }
+  secondaryButton {
+    buttonText
+    buttonLink {
+      buttonHref
+    }
+  }
 }

--- a/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
+++ b/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
@@ -40,6 +40,10 @@ export const normalizeEcologicalCreditCards = ({
         text: card?.button?.buttonText ?? '',
         href: card?.button?.buttonLink?.buttonHref ?? '',
       },
+      secondaryButton: {
+        text: card?.secondaryButton?.buttonText ?? '',
+        href: card?.secondaryButton?.buttonLink?.buttonHref ?? '',
+      },
       offsetMethodList: {
         label: OFFSET_GENERATION_METHOD,
         items:

--- a/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
+++ b/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
@@ -55,7 +55,7 @@ export const normalizeEcologicalCreditCards = ({
             },
           })) ?? [],
       },
-      projectActivitesList: {
+      projectActivitiesList: {
         label: PROJECT_ACTIVITIES,
         items:
           card?.projectActivities?.map(projectActivity => ({

--- a/web-www/sanity-graphql.schema.json
+++ b/web-www/sanity-graphql.schema.json
@@ -14864,6 +14864,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "retirementLabel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retirementIcon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Image",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -15045,6 +15069,30 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ProgramFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retirementLabel",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retirementIcon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -15535,6 +15583,30 @@
           },
           {
             "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retirementLabel",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retirementIcon",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -20630,6 +20702,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "secondaryButton",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Button",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -20816,6 +20900,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "secondaryButton",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ButtonFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -20950,6 +21046,18 @@
           },
           {
             "name": "button",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ButtonSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "secondaryButton",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -26117,7 +26225,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "TitleCustomBody",
+              "name": "HomePageProjectsSection",
               "ofType": null
             },
             "isDeprecated": false,
@@ -26290,7 +26398,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "TitleCustomBodyFilter",
+              "name": "HomePageProjectsSectionFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -26327,6 +26435,163 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "BottomBannerFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "HomePageProjectsSection",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "TitleCustomBody",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projects",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HomePageProjectsSectionFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TitleCustomBodyFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "HomePageProjectsSectionSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "titleCustomBody",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "TitleCustomBodySorting",
               "ofType": null
             },
             "defaultValue": null,
@@ -26445,7 +26710,7 @@
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "TitleCustomBodySorting",
+              "name": "HomePageProjectsSectionSorting",
               "ofType": null
             },
             "defaultValue": null,
@@ -40870,7 +41135,7 @@
           },
           {
             "name": "projectId",
-            "description": "on-chain project id",
+            "description": "on-chain project id, off-chain uuid or slug",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -66583,6 +66848,57 @@
       }
     ],
     "directives": [
+      {
+        "name": "crossDatasetReference",
+        "description": "Field references one or more document in another dataset",
+        "isRepeatable": false,
+        "locations": [
+          "OBJECT",
+          "FIELD_DEFINITION"
+        ],
+        "args": [
+          {
+            "name": "dataset",
+            "description": "Dataset name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeNames",
+            "description": "Strings of the target types names enabled for this reference",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ]
+      },
       {
         "name": "jsonAlias",
         "description": "Field is a \"raw\" JSON alias for a different field",

--- a/web-www/tailwind.config.js
+++ b/web-www/tailwind.config.js
@@ -5,5 +5,6 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
+    '../web-components/src/**/*.{js,ts,jsx,tsx}',
   ],
 };


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1829
Needs: https://github.com/regen-network/regen-sanity/pull/52

- handle optional offset generation methods for ecological cards
- handle secondary button to ecological cards

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
