### PR TITLE
fix: hide menu items for wc users

### DIFF
--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -41,7 +41,7 @@ const RegistryLayoutHeader: React.FC = () => {
     privActiveAccount,
     privAuthenticatedAccounts,
   } = useAuth();
-  const { wallet, disconnect, isConnected, isWalletConnect } = useWallet();
+  const { wallet, disconnect, isConnected, loginDisabled } = useWallet();
   const { accountOrWallet } = useAuthData();
   const theme = useTheme<Theme>();
   const headerColors = useMemo(() => getHeaderColors(theme), [theme]);
@@ -59,7 +59,7 @@ const RegistryLayoutHeader: React.FC = () => {
         isIssuer,
         showProjects,
         isWalletConnected: isConnected,
-        isWalletConnect,
+        loginDisabled,
       }),
     [
       pathname,
@@ -67,7 +67,7 @@ const RegistryLayoutHeader: React.FC = () => {
       isIssuer,
       showProjects,
       isConnected,
-      isWalletConnect,
+      loginDisabled,
     ],
   );
   const onProfileClick = useOnProfileClick();
@@ -132,7 +132,7 @@ const RegistryLayoutHeader: React.FC = () => {
                   })) || []
                 }
                 onProfileClick={onProfileClick}
-                addAccount={isWalletConnect ? undefined : onButtonClick}
+                addAccount={loginDisabled ? undefined : onButtonClick}
               />
             )}
             <LoginButton />

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -41,7 +41,7 @@ const RegistryLayoutHeader: React.FC = () => {
     privActiveAccount,
     privAuthenticatedAccounts,
   } = useAuth();
-  const { wallet, disconnect, isConnected } = useWallet();
+  const { wallet, disconnect, isConnected, isWalletConnect } = useWallet();
   const { accountOrWallet } = useAuthData();
   const theme = useTheme<Theme>();
   const headerColors = useMemo(() => getHeaderColors(theme), [theme]);
@@ -59,8 +59,16 @@ const RegistryLayoutHeader: React.FC = () => {
         isIssuer,
         showProjects,
         isWalletConnected: isConnected,
+        isWalletConnect,
       }),
-    [pathname, showCreditClasses, isIssuer, showProjects, isConnected],
+    [
+      pathname,
+      showCreditClasses,
+      isIssuer,
+      showProjects,
+      isConnected,
+      isWalletConnect,
+    ],
   );
   const onProfileClick = useOnProfileClick();
 
@@ -124,7 +132,7 @@ const RegistryLayoutHeader: React.FC = () => {
                   })) || []
                 }
                 onProfileClick={onProfileClick}
-                addAccount={onButtonClick}
+                addAccount={isWalletConnect ? undefined : onButtonClick}
               />
             )}
             <LoginButton />

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
@@ -62,6 +62,7 @@ interface GetUserMenuItemsParams {
   isIssuer?: boolean;
   showProjects?: boolean;
   isWalletConnected: boolean;
+  isWalletConnect: boolean;
 }
 
 export const getUserMenuItems = ({
@@ -71,6 +72,7 @@ export const getUserMenuItems = ({
   isIssuer,
   showProjects,
   isWalletConnected,
+  isWalletConnect,
 }: GetUserMenuItemsParams): HeaderDropdownItemProps[] =>
   [
     isWalletConnected && {
@@ -101,15 +103,15 @@ export const getUserMenuItems = ({
         linkComponent,
         ...BRIDGE,
       },
-    {
+    !isWalletConnect && {
       ...SEPARATOR,
     },
-    {
+    !isWalletConnect && {
       pathname,
       linkComponent,
       ...EDIT_PROFILE,
     },
-    {
+    !isWalletConnect && {
       pathname,
       linkComponent,
       ...PROFILE_SETTINGS,

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
@@ -62,7 +62,7 @@ interface GetUserMenuItemsParams {
   isIssuer?: boolean;
   showProjects?: boolean;
   isWalletConnected: boolean;
-  isWalletConnect: boolean;
+  loginDisabled: boolean;
 }
 
 export const getUserMenuItems = ({
@@ -72,7 +72,7 @@ export const getUserMenuItems = ({
   isIssuer,
   showProjects,
   isWalletConnected,
-  isWalletConnect,
+  loginDisabled,
 }: GetUserMenuItemsParams): HeaderDropdownItemProps[] =>
   [
     isWalletConnected && {
@@ -103,15 +103,15 @@ export const getUserMenuItems = ({
         linkComponent,
         ...BRIDGE,
       },
-    !isWalletConnect && {
+    !loginDisabled && {
       ...SEPARATOR,
     },
-    !isWalletConnect && {
+    !loginDisabled && {
       pathname,
       linkComponent,
       ...EDIT_PROFILE,
     },
-    !isWalletConnect && {
+    !loginDisabled && {
       pathname,
       linkComponent,
       ...PROFILE_SETTINGS,

--- a/web-marketplace/src/lib/wallet/wallet.tsx
+++ b/web-marketplace/src/lib/wallet/wallet.tsx
@@ -62,6 +62,7 @@ export type SignArbitraryType = (
 export type WalletContextType = {
   wallet?: Wallet;
   walletConfig?: WalletConfig;
+  isWalletConnect: boolean;
   loaded: boolean;
   connect?: (params: ConnectParams) => Promise<void>;
   connectWallet?: ConnectWalletType;
@@ -82,6 +83,7 @@ const WalletContext = createContext<WalletContextType>({
   isConnected: false,
   accountChanging: false,
   isKeplrMobileWeb: false,
+  isWalletConnect: false,
 });
 
 export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({
@@ -192,6 +194,7 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({
       value={{
         wallet,
         walletConfig: walletConfigRef.current,
+        isWalletConnect: walletConnect,
         loaded: loaded && !isFetching && (loginDisabled || !authLoading),
         connect,
         connectWallet,

--- a/web-marketplace/src/lib/wallet/wallet.tsx
+++ b/web-marketplace/src/lib/wallet/wallet.tsx
@@ -62,7 +62,7 @@ export type SignArbitraryType = (
 export type WalletContextType = {
   wallet?: Wallet;
   walletConfig?: WalletConfig;
-  isWalletConnect: boolean;
+  loginDisabled: boolean;
   loaded: boolean;
   connect?: (params: ConnectParams) => Promise<void>;
   connectWallet?: ConnectWalletType;
@@ -83,7 +83,7 @@ const WalletContext = createContext<WalletContextType>({
   isConnected: false,
   accountChanging: false,
   isKeplrMobileWeb: false,
-  isWalletConnect: false,
+  loginDisabled: false,
 });
 
 export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({
@@ -194,7 +194,7 @@ export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({
       value={{
         wallet,
         walletConfig: walletConfigRef.current,
-        isWalletConnect: walletConnect,
+        loginDisabled,
         loaded: loaded && !isFetching && (loginDisabled || !authLoading),
         connect,
         connectWallet,


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2233

- hide some user menu items (edit profile, settings, add account) for wallet connect users

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
