### PR TITLE
fix: replay http requests with expired CSRF token

### DIFF
--- a/web-marketplace/src/components/organisms/LoginButton/hooks/onLoginPostData.ts
+++ b/web-marketplace/src/components/organisms/LoginButton/hooks/onLoginPostData.ts
@@ -2,6 +2,7 @@ import { postData, PostParams } from 'utils/fetch/postData';
 
 import { UseStateSetter } from 'types/react/use-state';
 import { FailedFnType } from 'lib/atoms/error.atoms';
+import { CSRF_ERROR } from 'lib/errors/apiErrors';
 
 type Params = PostParams & {
   defaultError: string;
@@ -25,11 +26,10 @@ export const onPostData = async ({
       data,
       token,
       retryCsrfRequest,
+      onSuccess,
     });
-    if (response.error) {
+    if (response.error && response.error !== CSRF_ERROR) {
       setEmailModalErrorCode(response.error);
-    } else {
-      onSuccess && onSuccess();
     }
   } catch (e: unknown) {
     setEmailModalErrorCode(defaultError);

--- a/web-marketplace/src/components/organisms/LoginButton/hooks/onLoginPostData.ts
+++ b/web-marketplace/src/components/organisms/LoginButton/hooks/onLoginPostData.ts
@@ -1,11 +1,13 @@
 import { postData, PostParams } from 'utils/fetch/postData';
 
 import { UseStateSetter } from 'types/react/use-state';
+import { FailedFnType } from 'lib/atoms/error.atoms';
 
 type Params = PostParams & {
   defaultError: string;
   setEmailModalErrorCode: UseStateSetter<string>;
   onSuccess?: () => Promise<void>;
+  retryCsrfRequest?: (failedFunction: FailedFnType) => Promise<void>;
 };
 
 export const onPostData = async ({
@@ -15,12 +17,14 @@ export const onPostData = async ({
   defaultError,
   onSuccess,
   setEmailModalErrorCode,
+  retryCsrfRequest,
 }: Params) => {
   try {
     const response: { error?: string } = await postData({
       url: url,
       data,
       token,
+      retryCsrfRequest,
     });
     if (response.error) {
       setEmailModalErrorCode(response.error);

--- a/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
+++ b/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
@@ -23,6 +23,7 @@ import {
   RESEND_SUCCES,
   RESEND_TIMER,
 } from '../../LoginButton/LoginButton.constants';
+import { useRetryCsrfRequest } from 'lib/errors/hooks/useRetryCsrfRequest';
 
 type EmailConfirmationDataParams = {
   emailConfirmationText?: string;
@@ -40,6 +41,7 @@ export const useEmailConfirmationData = ({
   const { privActiveAccount } = useAuth();
   const setBannerText = useSetAtom(bannerTextAtom);
   const { data: token } = useQuery(getCsrfTokenQuery({}));
+  const retryCsrfRequest = useRetryCsrfRequest();
   const {
     timeLeft: resendTimeLeft,
     startTimer,
@@ -62,6 +64,7 @@ export const useEmailConfirmationData = ({
         token,
         defaultError: DEFAULT_RESEND_ERROR,
         setEmailModalErrorCode,
+        retryCsrfRequest,
       });
       setBannerText(RESEND_SUCCES);
     }

--- a/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
+++ b/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
@@ -79,6 +79,7 @@ export const useEmailConfirmationData = ({
         },
         token,
         defaultError: DEFAULT_VALIDATE_ERROR,
+        retryCsrfRequest,
         onSuccess: async () => {
           await reactQueryClient.invalidateQueries([GET_ACCOUNTS_QUERY_KEY]);
           setBannerText(emailConfirmationText ?? EMAIL_CONFIRMATION_SUCCES);
@@ -115,6 +116,7 @@ export const useEmailConfirmationData = ({
             email,
           },
           token,
+          retryCsrfRequest,
         });
         if (response.error) {
           if (response.error === CONNECTED_EMAIL_ERROR_TITLE) {
@@ -146,5 +148,6 @@ export const useEmailConfirmationData = ({
     onEmailSubmit,
     isConnectedEmailErrorModalOpen,
     onConnectedEmailErrorModalClose,
+    retryCsrfRequest,
   };
 };

--- a/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
+++ b/web-marketplace/src/components/organisms/LoginFlow/hooks/useEmailConfirmationData.tsx
@@ -117,17 +117,16 @@ export const useEmailConfirmationData = ({
           },
           token,
           retryCsrfRequest,
+          onSuccess: async () => {
+            callback && callback();
+            startTimer();
+            setIsConfirmationModalOpen(true);
+          },
         });
         if (response.error) {
           if (response.error === CONNECTED_EMAIL_ERROR_TITLE) {
             setIsConnectedEmailErrorModalOpen(true);
-          } else {
-            setErrorBannerTextAtom(response.error);
           }
-        } else {
-          callback && callback();
-          startTimer();
-          setIsConfirmationModalOpen(true);
         }
       } catch (e) {
         setErrorBannerTextAtom(String(e));

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -41,6 +41,7 @@ const RegistryLayoutHeader: React.FC = () => {
     privActiveAccount,
     privAuthenticatedAccounts,
   } = useAuth();
+
   const { wallet, disconnect, isConnected, loginDisabled } = useWallet();
   const { accountOrWallet } = useAuthData();
   const theme = useTheme<Theme>();

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.RetryFailedFunctions.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.RetryFailedFunctions.tsx
@@ -1,0 +1,30 @@
+import { useCallback, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useAtom } from 'jotai';
+
+import { failedFunctionsAtom } from 'lib/atoms/error.atoms';
+import { getCsrfTokenQuery } from 'lib/queries/react-query/registry-server/getCsrfTokenQuery/getCsrfTokenQuery';
+
+export const RetryFailedFunctions = () => {
+  const [failedFunctions, setFailedFunctions] = useAtom(failedFunctionsAtom);
+
+  const { data: csrfToken } = useQuery(getCsrfTokenQuery({}));
+
+  const retryFailedFunctions = useCallback(async () => {
+    if (csrfToken) {
+      const failedFunctionPromises = failedFunctions.map(failedFunction =>
+        failedFunction(csrfToken),
+      );
+      await Promise.all(failedFunctionPromises);
+      setFailedFunctions([]);
+    }
+  }, [csrfToken, failedFunctions, setFailedFunctions]);
+
+  useEffect(() => {
+    if (csrfToken && failedFunctions.length > 0) {
+      retryFailedFunctions();
+    }
+  }, [csrfToken, failedFunctions.length, retryFailedFunctions]);
+
+  return null;
+};

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.tsx
@@ -18,6 +18,7 @@ import { RegistryLayoutFooter } from './RegistryLayout.Footer';
 import { RegistryLayoutHeader } from './RegistryLayout.Header';
 import { RegistryLayoutProcessingModal } from './RegistryLayout.ProcessingModal';
 import { RegistryLayoutSwitchWalletModal } from './RegistryLayout.SwitchWalletModal';
+import { RetryFailedFunctions } from './RegistryLayout.RetryFailedFunctions';
 import { RegistryLayoutTxErrorModal } from './RegistryLayout.TxErrorModal';
 import { RegistryLayoutTxSuccessfulModal } from './RegistryLayout.TxSuccessfulModal';
 
@@ -29,6 +30,7 @@ const RegistryLayout: React.FC = () => {
       <RegistryLayoutFooter />
       <PageViewTracking />
       <ScrollToTop />
+      <RetryFailedFunctions />
       <CookiesTopBanner
         privacyUrl={URL_WEB_PRIVACY}
         TOSUrl={URL_REGISTRY_TERMS_SERVICE}

--- a/web-marketplace/src/components/organisms/RegistryLayout/hooks/useOnProfileClick.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/hooks/useOnProfileClick.tsx
@@ -15,6 +15,7 @@ import { GET_ACCOUNTS_QUERY_KEY } from 'lib/queries/react-query/registry-server/
 import { getCsrfTokenQuery } from 'lib/queries/react-query/registry-server/getCsrfTokenQuery/getCsrfTokenQuery';
 import { useWallet } from 'lib/wallet/wallet';
 import { WalletType } from 'lib/wallet/walletsConfig/walletsConfig.types';
+import { useRetryCsrfRequest } from 'lib/errors/hooks/useRetryCsrfRequest';
 
 export const useOnProfileClick = () => {
   const navigate = useNavigate();
@@ -26,6 +27,7 @@ export const useOnProfileClick = () => {
   const reactQueryClient = useQueryClient();
   const { data: token } = useQuery(getCsrfTokenQuery({}));
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
+  const retryCsrfRequest = useRetryCsrfRequest();
 
   const updateActiveAccount = useCallback(
     async (accountId: string) => {
@@ -36,9 +38,11 @@ export const useOnProfileClick = () => {
             accountId,
           },
           token,
-        });
-        await reactQueryClient.invalidateQueries({
-          queryKey: [GET_ACCOUNTS_QUERY_KEY],
+          retryCsrfRequest,
+          onSuccess: async () =>
+            await reactQueryClient.invalidateQueries({
+              queryKey: [GET_ACCOUNTS_QUERY_KEY],
+            }),
         });
       }
     },

--- a/web-marketplace/src/lib/atoms/error.atoms.ts
+++ b/web-marketplace/src/lib/atoms/error.atoms.ts
@@ -1,4 +1,13 @@
 import { atom } from 'jotai';
 
+type FailedFnType = (csrfToken: string) => Promise<Response>;
+
 export const errorCodeAtom = atom('');
 export const errorBannerTextAtom = atom('');
+export const failedFunctionsAtom = atom<FailedFnType[]>([]);
+export const failedFunctionsWriteAtom = atom(
+  null,
+  (get, set, failedFn: FailedFnType) => {
+    set(failedFunctionsAtom, prev => [...prev, failedFn]);
+  },
+);

--- a/web-marketplace/src/lib/atoms/error.atoms.ts
+++ b/web-marketplace/src/lib/atoms/error.atoms.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 
-type FailedFnType = (csrfToken: string) => Promise<Response>;
+export type FailedFnType = (csrfToken: string) => Promise<Response>;
 
 export const errorCodeAtom = atom('');
 export const errorBannerTextAtom = atom('');

--- a/web-marketplace/src/lib/errors/apiErrors.ts
+++ b/web-marketplace/src/lib/errors/apiErrors.ts
@@ -1,0 +1,1 @@
+export const CSRF_ERROR = 'invalid csrf token';

--- a/web-marketplace/src/lib/errors/hooks/useRetryCsrfRequest.tsx
+++ b/web-marketplace/src/lib/errors/hooks/useRetryCsrfRequest.tsx
@@ -1,0 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+
+import { FailedFnType, failedFunctionsWriteAtom } from 'lib/atoms/error.atoms';
+import { GET_CSRF_QUERY_KEY } from 'lib/queries/react-query/registry-server/getCsrfTokenQuery/getCsrfTokenQuery.constants';
+
+export const useRetryCsrfRequest = () => {
+  const reactQueryClient = useQueryClient();
+  const addFailedFunction = useSetAtom(failedFunctionsWriteAtom);
+
+  const retryCsrfRequest = async (failedFunction: FailedFnType) => {
+    await reactQueryClient.invalidateQueries({
+      queryKey: [GET_CSRF_QUERY_KEY],
+    });
+    addFailedFunction(failedFunction);
+  };
+
+  return retryCsrfRequest;
+};

--- a/web-marketplace/src/lib/wallet/hooks/useLogout.tsx
+++ b/web-marketplace/src/lib/wallet/hooks/useLogout.tsx
@@ -1,10 +1,14 @@
 import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
 
 import { UseStateSetter } from 'types/react/use-state';
 import { apiUri } from 'lib/apiUri';
+import { failedFunctionsWriteAtom } from 'lib/atoms/error.atoms';
+import { CSRF_ERROR } from 'lib/errors/apiErrors';
 import { GET_ACCOUNTS_QUERY_KEY } from 'lib/queries/react-query/registry-server/getAccounts/getAccountsQuery.constants';
 import { getCsrfTokenQuery } from 'lib/queries/react-query/registry-server/getCsrfTokenQuery/getCsrfTokenQuery';
+import { GET_CSRF_QUERY_KEY } from 'lib/queries/react-query/registry-server/getCsrfTokenQuery/getCsrfTokenQuery.constants';
 
 type Params = {
   setError: UseStateSetter<unknown>;
@@ -13,25 +17,45 @@ type Params = {
 export const useLogout = ({ setError }: Params) => {
   const { data: token } = useQuery(getCsrfTokenQuery({}));
   const reactQueryClient = useQueryClient();
+  const addFailedFunction = useSetAtom(failedFunctionsWriteAtom);
 
   const logout = useCallback(async (): Promise<void> => {
     try {
       if (token) {
-        await fetch(`${apiUri}/marketplace/v1/wallet-auth/logout`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'X-CSRF-TOKEN': token,
-          },
-        });
-        reactQueryClient.invalidateQueries({
-          queryKey: [GET_ACCOUNTS_QUERY_KEY],
-        });
+        const logoutFn = async (csrfToken: string) => {
+          const response = await fetch(
+            `${apiUri}/marketplace/v1/wallet-auth/logout`,
+            {
+              method: 'POST',
+              credentials: 'include',
+              headers: {
+                'X-CSRF-TOKEN': csrfToken,
+              },
+            },
+          );
+          const bodyResponse = await response.json();
+          if (!bodyResponse.error) {
+            reactQueryClient.invalidateQueries({
+              queryKey: [GET_ACCOUNTS_QUERY_KEY],
+            });
+          }
+
+          return bodyResponse;
+        };
+
+        const bodyResponse = await logoutFn(token);
+
+        if (bodyResponse.error === CSRF_ERROR) {
+          await reactQueryClient.invalidateQueries({
+            queryKey: [GET_CSRF_QUERY_KEY],
+          });
+          addFailedFunction(logoutFn);
+        }
       }
     } catch (e) {
       setError(e);
     }
-  }, [token, reactQueryClient, setError]);
+  }, [token, reactQueryClient, addFailedFunction, setError]);
 
   return logout;
 };

--- a/web-marketplace/src/lib/wallet/hooks/useOnAccountChange.tsx
+++ b/web-marketplace/src/lib/wallet/hooks/useOnAccountChange.tsx
@@ -18,6 +18,7 @@ import { Wallet } from '../wallet';
 import { getWallet } from '../wallet.utils';
 import { WalletConfig, WalletType } from '../walletsConfig/walletsConfig.types';
 import { ConnectWalletType } from './useConnectWallet';
+import { useRetryCsrfRequest } from 'lib/errors/hooks/useRetryCsrfRequest';
 
 type Props = {
   wallet: Wallet;
@@ -50,6 +51,7 @@ export const useOnAccountChange = ({
   );
   const { data: token } = useQuery(getCsrfTokenQuery({}));
   const reactQueryClient = useQueryClient();
+  const retryCsrfRequest = useRetryCsrfRequest();
 
   // Set new wallet or directly connect it for Keplr mobile browser
   useEffect(() => {
@@ -118,9 +120,11 @@ export const useOnAccountChange = ({
                 accountId: newAccountId,
               },
               token,
-            });
-            await reactQueryClient.invalidateQueries({
-              queryKey: [GET_ACCOUNTS_QUERY_KEY],
+              retryCsrfRequest,
+              onSuccess: async () =>
+                await reactQueryClient.invalidateQueries({
+                  queryKey: [GET_ACCOUNTS_QUERY_KEY],
+                }),
             });
             setAccountChanging(false);
           } else {

--- a/web-marketplace/src/pages/ProfileEdit/hooks/useSocialProviders.tsx
+++ b/web-marketplace/src/pages/ProfileEdit/hooks/useSocialProviders.tsx
@@ -35,7 +35,7 @@ export const useSocialProviders = () => {
           setErrorBannerTextAtom(String(e));
         }
     },
-    [reactQueryClient, setErrorBannerTextAtom, token],
+    [retryCsrfRequest, reactQueryClient, setErrorBannerTextAtom, token],
   );
 
   const socialProviders: SocialProvider[] = [


### PR DESCRIPTION
## Description

Closes: regen-network/regen-web#2235

- add a system to replay failed HTTP requests because of an expired CSRF token

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

Logout:

1. Go to https://deploy-preview-2245--regen-marketplace.netlify.app/
2. Log in to an account
3. Open a second tab
4. Go back to the first tab and try to log out (it should work as expected)

Account change:
1. Go to https://deploy-preview-2245--regen-marketplace.netlify.app/
2. Log in to an account
3. Log in a second account
4. Open a second tab
5. Go back to the first tab and try to change your account in the user menu dropdown (it should work as expected)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
