### PR TITLE
fix: useCallback to define retryCsrfRequest to avoid infinite loop

### DIFF
--- a/web-marketplace/src/lib/errors/hooks/useRetryCsrfRequest.tsx
+++ b/web-marketplace/src/lib/errors/hooks/useRetryCsrfRequest.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 
@@ -8,12 +9,15 @@ export const useRetryCsrfRequest = () => {
   const reactQueryClient = useQueryClient();
   const addFailedFunction = useSetAtom(failedFunctionsWriteAtom);
 
-  const retryCsrfRequest = async (failedFunction: FailedFnType) => {
-    await reactQueryClient.invalidateQueries({
-      queryKey: [GET_CSRF_QUERY_KEY],
-    });
-    addFailedFunction(failedFunction);
-  };
+  const retryCsrfRequest = useCallback(
+    async (failedFunction: FailedFnType) => {
+      await reactQueryClient.invalidateQueries({
+        queryKey: [GET_CSRF_QUERY_KEY],
+      });
+      addFailedFunction(failedFunction);
+    },
+    [addFailedFunction, reactQueryClient],
+  );
 
   return retryCsrfRequest;
 };


### PR DESCRIPTION
## Description

Closes: #2258

As part of https://github.com/regen-network/regen-web/pull/2252 which introduced this bug, `retryCsrfRequest` was added to the dependency array of the `login` callback. Because `retryCsrfRequest` wasn't declared with `useCallback` and always changing, this was causing the `useEffect` in `useAutoConnect` (which indirectly depends on `login` that depends on `retryCsrfRequest`) to trigger indefinitely, eventually causing the app to error.
This issue was reproducible when logging in with an account that has a wallet address (which triggers `tryConnectWallet` in `useAutoConnect`) and then going to another page or reloading the app.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. Log in with an account with a wallet address
2. Navigate the app, reload the app to make sure that the app error doesn't happen anymore

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
