### PR TITLE
fix: PinIcon on StaticMap (project page)

### DIFF
--- a/web-components/src/components/icons/GreenPinIcon.tsx
+++ b/web-components/src/components/icons/GreenPinIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const GreenPinIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg width="37" height="50" viewBox="0 0 37 50" fill="none" {...props}>
+    <ellipse
+      cx="18.2422"
+      cy="45.5114"
+      rx="9.99124"
+      ry="3.57954"
+      fill="#D2D5D9"
+      fill-opacity="0.3"
+    />
+    <path
+      d="M36.2263 17.9297C36.2263 32.3673 20.7011 43.3452 18.5003 44.8289C18.3383 44.9381 18.1458 44.9381 17.9838 44.8289C15.783 43.3452 0.257812 32.3674 0.257812 17.9297C0.257812 8.02739 8.30962 0 18.242 0C28.1744 0 36.2263 8.02739 36.2263 17.9297Z"
+      fill="#4FB573"
+    />
+    <ellipse cx="18.2419" cy="18.2812" rx="9.68381" ry="9.84375" fill="white" />
+  </svg>
+);

--- a/web-components/src/components/icons/icons.stories.tsx
+++ b/web-components/src/components/icons/icons.stories.tsx
@@ -45,6 +45,7 @@ import ErrorIcon from './ErrorIcon';
 import EyeIcon from './EyeIcon';
 import FarmerIcon from './FarmerIcon';
 import FilterIcon from './FilterIcon';
+import { GreenPinIcon } from './GreenPinIcon';
 import { HorizontalDotsIcon } from './HorizontalDotsIcon';
 import InfoIcon from './InfoIcon';
 import InfoIconOutlined from './InfoIconOutlined';
@@ -253,6 +254,7 @@ export const allIcons = (): JSX.Element => (
       icon={<FilterIcon sx={{ color: 'secondary.dark' }} />}
       label="FilterIcon"
     />
+    <LabeledIcon icon={<GreenPinIcon />} label="GreenPinIcon" />
     <LabeledIcon icon={<GithubIcon color="grey" />} label="GithubIcon" />
     <LabeledIcon icon={<GravUsdcIcon />} label="GravUsdcIcon" />
     <LabeledIcon icon={<HorizontalDotsIcon />} label="HorizontalDotsIcon" />

--- a/web-components/src/components/map/StaticMap.tsx
+++ b/web-components/src/components/map/StaticMap.tsx
@@ -3,6 +3,7 @@ import { CircularProgress } from '@mui/material';
 import bbox from '@turf/bbox';
 import { FeatureCollection } from 'geojson';
 
+import { GreenPinIcon } from '../icons/GreenPinIcon';
 import PinIcon from '../icons/PinIcon';
 
 import 'mapbox-gl/dist/mapbox-gl.css';
@@ -78,7 +79,7 @@ export default function StaticMap({
           longitude={boundary.longitude}
           style={{ cursor: 'default' }}
         >
-          <PinIcon fontSize="large" size={35} />
+          <GreenPinIcon />
         </Marker>
       </Map>
     </Suspense>


### PR DESCRIPTION
## Description

Since last release, the pin icon on the map on the top of the project pages was black instead of green/white.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2293--regen-marketplace.netlify.app/project/wilmot

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
