### PR TITLE
feat: use offchain credit class to get primary impact/project benefits

### DIFF
--- a/web-marketplace/src/components/organisms/ProjectTopSection/ProjectTopSection.CreditClassCard.tsx
+++ b/web-marketplace/src/components/organisms/ProjectTopSection/ProjectTopSection.CreditClassCard.tsx
@@ -34,7 +34,8 @@ export const ProjectTopSectionCreditClassCard: React.FC<Props> = ({
   methodology,
   program,
 }) =>
-  creditClassSanity || creditClassMetadata ? (
+  (creditClassSanity || creditClassMetadata) &&
+  (creditClassSanity?.path || onChainCreditClassId) ? (
     <Link
       href={`/credit-classes/${
         creditClassSanity?.path || onChainCreditClassId

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -440,7 +440,11 @@ function ProjectDetails(): JSX.Element {
         }}
         otcCard={otcCard}
         creditClassOnChain={creditClassOnChain}
-        creditClassMetadata={creditClassMetadata}
+        creditClassMetadata={
+          creditClassMetadata ||
+          offChainProject?.creditClassByCreditClassId?.creditClassVersionsById
+            ?.nodes?.[0]?.metadata
+        }
         onChainCreditClassId={onChainCreditClassId}
         program={program}
         projectPrefinancing={projectPrefinancing}


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1856

As part of this issue, I've also added some temporary off chain credit classes for the 2 prefinance projects on production with the appropriate primary impact/project benefits data. Those will appear correctly only once the code change in this PR is deployed to prod.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2294--regen-marketplace.netlify.app/project/prefinance-project

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
