### PR TITLE
fix: add dropdown items to projects menu item

### DIFF
--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
@@ -32,7 +32,24 @@ export const getMenuItems = (pathname: string): Item[] => [
   },
   {
     title: 'Projects',
-    href: '/projects/1',
+    dropdownItems: [
+      {
+        pathname,
+        href: '/projects/1',
+        label: 'All projects',
+        linkComponent: Link,
+        importCallback: (): Promise<any> =>
+          import('../../../pages/Projects/AllProjects'),
+      },
+      {
+        pathname,
+        href: '/projects/prefinance',
+        label: 'Prefinance projects',
+        linkComponent: Link,
+        importCallback: (): Promise<any> =>
+          import('../../../pages/Projects/PrefinanceProjects'),
+      },
+    ],
   },
   {
     title: 'Trade',


### PR DESCRIPTION
## Description

As part of https://github.com/regen-network/regen-web/pull/2291, we forgot to update the "Projects" menu item to have 2 dropdown items for "All projects" and "Prefinance projects": https://www.figma.com/file/EPSVuGURedvRfO6LxUAQZs/Pre-financing?type=design&node-id=8%3A33002&mode=design&t=SxBVSQMQ7JTU72Py-1

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2307--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
