### PR TITLE
fix: redirect project page from off chain UUID to slug based URL

### DIFF
--- a/web-marketplace/src/components/organisms/SettingsForm/SettingsForm.schema.ts
+++ b/web-marketplace/src/components/organisms/SettingsForm/SettingsForm.schema.ts
@@ -1,7 +1,8 @@
+import { getIsUuid } from 'components/templates/ProjectDetails/ProjectDetails.utils';
 import { z } from 'zod';
 
 export const settingsFormSchema = z.object({
-  slug: z.string(),
+  slug: z.string().refine(value => !getIsUuid(value), { message: `Slug can't be set to a UUID` }),
 });
 
 export type SettingsFormSchemaType = z.infer<typeof settingsFormSchema>;

--- a/web-marketplace/src/components/organisms/SettingsForm/SettingsForm.schema.ts
+++ b/web-marketplace/src/components/organisms/SettingsForm/SettingsForm.schema.ts
@@ -1,8 +1,18 @@
-import { getIsUuid } from 'components/templates/ProjectDetails/ProjectDetails.utils';
+import {
+  getIsOnChainId,
+  getIsUuid,
+} from 'components/templates/ProjectDetails/ProjectDetails.utils';
 import { z } from 'zod';
 
 export const settingsFormSchema = z.object({
-  slug: z.string().refine(value => !getIsUuid(value), { message: `Slug can't be set to a UUID` }),
+  slug: z
+    .string()
+    .refine(value => !getIsOnChainId(value), {
+      message: `Slug can't be set to an on-chain project ID`,
+    })
+    .refine(value => !getIsUuid(value), {
+      message: `Slug can't be set to a UUID`,
+    }),
 });
 
 export type SettingsFormSchemaType = z.infer<typeof settingsFormSchema>;

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -169,7 +169,7 @@ function ProjectDetails(): JSX.Element {
   const slug = offchainProjectByIdData?.data?.projectById?.slug;
   useEffect(() => {
     if (!!slug) {
-      navigate(`/project/${slug}`);
+      navigate(`/project/${slug}`, { replace: true });
     }
   }, [slug, navigate]);
 

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useApolloClient } from '@apollo/client';
 import { Box, Skeleton, useMediaQuery, useTheme } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
@@ -73,7 +73,7 @@ import { getMediaBoxStyles } from './ProjectDetails.styles';
 import {
   findSanityCreditClass,
   formatOtcCardData,
-  getIsOffChainUuid,
+  getIsUuid,
   getIsOnChainId,
   getProjectGalleryPhotos,
   parseMedia,
@@ -93,6 +93,7 @@ function ProjectDetails(): JSX.Element {
   const { track } = useTracker();
   const location = useLocation();
   const { isKeplrMobileWeb } = useWallet();
+  const navigate = useNavigate();
 
   const { data: sanityProjectPageData } = useQuery(
     getAllProjectPageQuery({ sanityClient, enabled: !!sanityClient }),
@@ -121,7 +122,7 @@ function ProjectDetails(): JSX.Element {
   // or an chain project id
   // or and off-chain project with an UUID
   const isOnChainId = getIsOnChainId(projectId);
-  const isOffChainUuid = getIsOffChainUuid(projectId);
+  const isOffChainUuid = getIsUuid(projectId);
 
   const { data: sanityProjectData } = useQuery(
     getProjectByIdQuery({
@@ -164,6 +165,13 @@ function ProjectDetails(): JSX.Element {
       id: projectId,
     }),
   );
+
+  const slug = offchainProjectByIdData?.data?.projectById?.slug;
+  useEffect(() => {
+    if (!!slug) {
+      navigate(`/project/${slug}`);
+    }
+  }, [slug, navigate]);
 
   const projectBySlugOnChainId =
     projectBySlug?.data.projectBySlug?.onChainId ?? undefined;

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -166,7 +166,9 @@ function ProjectDetails(): JSX.Element {
     }),
   );
 
-  const slug = offchainProjectByIdData?.data?.projectById?.slug;
+  const slug =
+    offchainProjectByIdData?.data?.projectById?.slug ||
+    projectByOnChainId?.data?.projectByOnChainId?.slug;
   useEffect(() => {
     if (!!slug) {
       navigate(`/project/${slug}`, { replace: true });

--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.utils.tsx
@@ -67,11 +67,9 @@ export const findSanityCreditClass = ({
 export const getIsOnChainId = (projectId?: string): boolean =>
   !!projectId && /([A-Z]{1}[\d]+)([-])([\d{3,}])\w+/.test(projectId);
 
-export const getIsOffChainUuid = (projectId?: string): boolean =>
-  !!projectId &&
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-    projectId,
-  );
+export const getIsUuid = (str?: string): boolean =>
+  !!str &&
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(str);
 
 type ParseOffChainProjectReturn = {
   offChainProjectMetadata?: ProjectPageMetadataLD & LegacyProjectMetadataLD;
@@ -284,4 +282,6 @@ export const formatOtcCardData = ({
 };
 
 export const formatTimelineDates = (item: PrefinanceTimelineItem) =>
-  `${formatDate(item.date, 'MMM YYYY')}${item.endDate ? ` - ${formatDate(item.endDate, 'MMM YYYY')}` : ''}`;
+  `${formatDate(item.date, 'MMM YYYY')}${
+    item.endDate ? ` - ${formatDate(item.endDate, 'MMM YYYY')}` : ''
+  }`;

--- a/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
+++ b/web-marketplace/src/hooks/projects/useProjectWithMetadata.ts
@@ -24,7 +24,7 @@ import { DescriptionSchemaType } from 'components/organisms/DescriptionForm/Desc
 import { SimplifiedLocationFormSchemaType } from 'components/organisms/LocationForm/LocationForm.schema';
 import { MediaFormSchemaType } from 'components/organisms/MediaForm/MediaForm.schema';
 import {
-  getIsOffChainUuid,
+  getIsUuid,
   getIsOnChainId,
 } from 'components/templates/ProjectDetails/ProjectDetails.utils';
 
@@ -82,7 +82,7 @@ export const useProjectWithMetadata = ({
 
   const { createOrUpdateProject } = useCreateOrUpdateProject();
   const isOnChainId = getIsOnChainId(projectId);
-  const isOffChainUuid = getIsOffChainUuid(projectId);
+  const isOffChainUuid = getIsUuid(projectId);
 
   // In project creation mode or off-chain project edit mode,
   // we query the off-chain project since there's no on-chain project yet.

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
@@ -35,7 +35,7 @@ import NotFoundPage from 'pages/NotFound';
 import { usePathSection } from 'pages/ProfileEdit/hooks/usePathSection';
 import WithLoader from 'components/atoms/WithLoader';
 import {
-  getIsOffChainUuid,
+  getIsUuid,
   getIsOnChainId,
 } from 'components/templates/ProjectDetails/ProjectDetails.utils';
 import { useMsgClient } from 'hooks';
@@ -113,7 +113,7 @@ function ProjectEdit(): JSX.Element {
 
   const { signAndBroadcast } = useMsgClient();
   const isOnChainId = getIsOnChainId(projectId);
-  const isOffChainUUid = getIsOffChainUuid(projectId);
+  const isOffChainUUid = getIsUuid(projectId);
   const { data: projectRes, isFetching: isFetchingProject } = useQuery(
     getProjectQuery({
       request: {


### PR DESCRIPTION

## Description

Closes:  regen-network/rnd-dev-team#1896

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2317--regen-marketplace.netlify.app/
1. Log in and edit one of your project slug. If you input some UUID, it will display an error.
2. Go to https://deploy-preview-2317--regen-marketplace.netlify.app/project/a1fbc990-60fd-11ee-b6eb-0267c2be097b, it should redirect to https://deploy-preview-2317--regen-marketplace.netlify.app/project/prefinance-project and display prefinance related info.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
