### PR TITLE
fix: add credentials to DELETE /files request

### DIFF
--- a/web-components/src/utils/s3.ts
+++ b/web-components/src/utils/s3.ts
@@ -36,5 +36,8 @@ export async function deleteImage(
   const fileName = imageUrl.split(`${projectId}/`)[1];
   return axios.delete(
     `${apiServerUrl}/marketplace/v1/files/${projectId}/${fileName}`,
+    {
+      withCredentials: true,
+    },
   );
 }


### PR DESCRIPTION
## Description

This is a bug that I encountered while working on something else. I haven't created any issue since it was really quick to fix.
From the project media form, when deleting an existing image, then adding another one and saving, there was an error when trying to delete the existing image (removing it from s3) because the cookies were not passed along with the DELETE request, resulting in some unauthorized error on the server side.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. Go to https://deploy-preview-2318--regen-marketplace.netlify.app/ and login
2. Edit some project and go the the Media form
3. Upload an initial image as main photo for instance then SAVE
4. Delete this initial image, add another one then SAVE, this should not throw any error

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
