### PR TITLE
fix: use activeAccount addr in profile link

### DIFF
--- a/web-marketplace/src/pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/pages/Dashboard/Dashboard.tsx
@@ -88,7 +88,9 @@ const Dashboard = (): JSX.Element => {
     0,
   );
 
-  const profileLink = getProfileLink(wallet?.address || activeAccount?.id);
+  const profileLink = getProfileLink(
+    activeAccount?.addr || activeAccount?.id || wallet?.address,
+  );
   const walletAddress = getWalletAddress({ activeAccount, wallet });
 
   return (


### PR DESCRIPTION
## Description

Closes:  regen-network/rnd-dev-team#1869

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2320--regen-marketplace.netlify.app/
1. Log in with Keplr wallet addr A 
2. Switch to wallet addr B from Keplr, and do not accept the "prove ownership" popup, just close it 
3. Copy link to your profile from your profile page, this should have the right addr in it (addr A)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
