### PR TITLE
feat: add overrides for credit type and unit information in Sanity for Credit Class pages APP-2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,98 +1,99 @@
 [context.production.environment]
-  VITE_SANITY_TAG = "default"
-  VITE_SANITY_DATASET = "production"
-  VITE_API_URI = "https://api.regen.network"
-  VITE_BLOCK_EXPLORER="https://www.mintscan.io"
-  VITE_LEDGER_CHAIN_ID = "regen-1"
-  VITE_SENTRY_ENABLED="true"
-  VITE_SENTRY_ENVIRONMENT="production"
-  VITE_ANALYTICS_ENABLED="true"
-  VITE_BRIDGE_CREDIT_CLASS_ID = "C03"
-  VITE_GA_MEASUREMENT_ID="G-6ZGJM8JXYN"
-  VITE_TOUCAN_LINK="https://toucan.earth/overview?chainId=137"
-  VITE_SKIPPED_CLASS_ID="C01"
+VITE_SANITY_TAG = "default"
+VITE_SANITY_DATASET = "production"
+VITE_API_URI = "https://api.regen.network"
+VITE_BLOCK_EXPLORER = "https://www.mintscan.io"
+VITE_LEDGER_CHAIN_ID = "regen-1"
+VITE_SENTRY_ENABLED = "true"
+VITE_SENTRY_ENVIRONMENT = "production"
+VITE_ANALYTICS_ENABLED = "true"
+VITE_BRIDGE_CREDIT_CLASS_ID = "C03"
+VITE_GA_MEASUREMENT_ID = "G-6ZGJM8JXYN"
+VITE_TOUCAN_LINK = "https://toucan.earth/overview?chainId=137"
+VITE_SKIPPED_CLASS_ID = "C01"
 
-  # Next.js environment variables
-  NEXT_PUBLIC_SANITY_DATASET = "production"
-  NEXT_PUBLIC_API_URI = "https://api.regen.network"
-  NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LeqBFIaAAAAAPfLave4lUtLBKF2WYXinbaLNFqB"
-  NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
+# Next.js environment variables
+NEXT_PUBLIC_SANITY_DATASET = "production"
+NEXT_PUBLIC_API_URI = "https://api.regen.network"
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LeqBFIaAAAAAPfLave4lUtLBKF2WYXinbaLNFqB"
+NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [context.dev.environment]
-  VITE_SANITY_TAG = "default"
-  VITE_SANITY_DATASET = "staging"
-  VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
-  VITE_API_URI = "https://api-staging.regen.network"
-  VITE_INTERCOM_APP_ID = "kn5di10s"
-  VITE_LEDGER_CHAIN_ID = "regen-redwood-1"
-  VITE_LEDGER_CHAIN_NAME = "Regen - Redwood Testnet"
-  VITE_BLOCK_EXPLORER = "https://redwood.regen.aneka.io"
-  VITE_SENTRY_ENVIRONMENT = "development"
-  VITE_TOUCAN_LINK="https://test.app.toucan.earth/?chainId=137"
-  VITE_BRIDGE_API_URI="https://toucan-bridge-staging.herokuapp.com"
-  VITE_BRIDGE_CREDIT_CLASS_ID = "C56"
-  VITE_BRIDGE="true"
-  VITE_SKIPPED_CLASS_ID=""
+VITE_SANITY_TAG = "default"
+VITE_SANITY_DATASET = "staging"
+VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
+VITE_API_URI = "https://api-staging.regen.network"
+VITE_INTERCOM_APP_ID = "kn5di10s"
+VITE_LEDGER_CHAIN_ID = "regen-redwood-1"
+VITE_LEDGER_CHAIN_NAME = "Regen - Redwood Testnet"
+VITE_BLOCK_EXPLORER = "https://redwood.regen.aneka.io"
+VITE_SENTRY_ENVIRONMENT = "development"
+VITE_TOUCAN_LINK = "https://test.app.toucan.earth/?chainId=137"
+VITE_BRIDGE_API_URI = "https://toucan-bridge-staging.herokuapp.com"
+VITE_BRIDGE_CREDIT_CLASS_ID = "C56"
+VITE_BRIDGE = "true"
+VITE_SKIPPED_CLASS_ID = ""
 
-  # Next.js environment variables
-  NEXT_PUBLIC_SANITY_DATASET = "staging"
-  NEXT_PUBLIC_API_URI = "https://api-staging.regen.network"
-  NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
-  NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
+# Next.js environment variables
+NEXT_PUBLIC_SANITY_DATASET = "staging"
+NEXT_PUBLIC_API_URI = "https://api-staging.regen.network"
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
+NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [context.deploy-preview.environment]
-  VITE_SANITY_TAG = "default"
-  VITE_SANITY_DATASET = "staging"
-  VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
-  VITE_API_URI = "https://api-staging.regen.network"
-  VITE_INTERCOM_APP_ID = "kn5di10s"
-  VITE_LEDGER_CHAIN_ID = "regen-redwood-1"
-  VITE_LEDGER_CHAIN_NAME = "Regen - Redwood Testnet"
-  VITE_BLOCK_EXPLORER = "https://redwood.regen.aneka.io"
-  VITE_SENTRY_ENVIRONMENT = "development"
-  VITE_TOUCAN_LINK="https://test.app.toucan.earth/?chainId=137"
-  VITE_BRIDGE_API_URI="https://toucan-bridge-staging.herokuapp.com"
-  VITE_BRIDGE_CREDIT_CLASS_ID = "C56"
-  VITE_BRIDGE="true"
-  VITE_SKIPPED_CLASS_ID=""
-  VITE_ANALYTICS_ENABLED="true"
+NEXT_PUBLIC_SANITY_TAG = "credit"
+VITE_SANITY_TAG = "credit"
+VITE_SANITY_DATASET = "staging"
+VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
+VITE_API_URI = "https://api-staging.regen.network"
+VITE_INTERCOM_APP_ID = "kn5di10s"
+VITE_LEDGER_CHAIN_ID = "regen-redwood-1"
+VITE_LEDGER_CHAIN_NAME = "Regen - Redwood Testnet"
+VITE_BLOCK_EXPLORER = "https://redwood.regen.aneka.io"
+VITE_SENTRY_ENVIRONMENT = "development"
+VITE_TOUCAN_LINK = "https://test.app.toucan.earth/?chainId=137"
+VITE_BRIDGE_API_URI = "https://toucan-bridge-staging.herokuapp.com"
+VITE_BRIDGE_CREDIT_CLASS_ID = "C56"
+VITE_BRIDGE = "true"
+VITE_SKIPPED_CLASS_ID = ""
+VITE_ANALYTICS_ENABLED = "true"
 
-  # Next.js environment variables
-  NEXT_PUBLIC_SANITY_DATASET = "staging"
-  NEXT_PUBLIC_API_URI = "https://api-staging.regen.network"
-  NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
-  NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
+# Next.js environment variables
+NEXT_PUBLIC_SANITY_DATASET = "staging"
+NEXT_PUBLIC_API_URI = "https://api-staging.regen.network"
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
+NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [build.environment]
-  NODE_OPTIONS = "--max-old-space-size=10216"
+NODE_OPTIONS = "--max-old-space-size=10216"
 
 [[redirects]]
-  from = "https://app.regen.network/create-methodology"
-  to = "https://app.regen.network"
-  force = true
-  status = 302
-  
+from = "https://app.regen.network/create-methodology"
+to = "https://app.regen.network"
+force = true
+status = 302
+
 
 [[redirects]]
-  from = "https://app.regen.network/create-methodology/methodology-review-process"
-  to = "https://app.regen.network"
-  force = true
-  status = 302
+from = "https://app.regen.network/create-methodology/methodology-review-process"
+to = "https://app.regen.network"
+force = true
+status = 302
 
 [[redirects]]
-  from = "https://app.regen.network/buyers/"
-  to = "https://www.regen.network/buyers"
-  force = true
-  status = 302
+from = "https://app.regen.network/buyers/"
+to = "https://www.regen.network/buyers"
+force = true
+status = 302
 
 [[redirects]]
-  from = "https://app.regen.network/ecocredits/*"
-  to = "https://app.regen.network/profile/:splat"
-  force = true
-  status = 302
+from = "https://app.regen.network/ecocredits/*"
+to = "https://app.regen.network/profile/:splat"
+force = true
+status = 302
 
 [[redirects]]
-  from = "https://app.regen.network/ecocredits/accounts/*"
-  to = "https://app.regen.network/profiles/:splat"
-  force = true
-  status = 302
+from = "https://app.regen.network/ecocredits/accounts/*"
+to = "https://app.regen.network/profiles/:splat"
+force = true
+status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,8 +41,7 @@ NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
 NEXT_PUBLIC_INTERCOM_APP_ID = "kn5di10s"
 
 [context.deploy-preview.environment]
-NEXT_PUBLIC_SANITY_TAG = "credit"
-VITE_SANITY_TAG = "credit"
+VITE_SANITY_TAG = "default"
 VITE_SANITY_DATASET = "staging"
 VITE_RECAPTCHA_SITE_KEY = "6LchxlAaAAAAANjtO3w4b5ihVCL87tYfbe0ltzp9"
 VITE_API_URI = "https://api-staging.regen.network"

--- a/web-components/src/components/atoms/CardRibbon/CardRibbon.tsx
+++ b/web-components/src/components/atoms/CardRibbon/CardRibbon.tsx
@@ -38,7 +38,7 @@ const CardRibbon = ({
       ]}
       alignItems="center"
     >
-      {icon && (
+      {icon?.src && (
         <Box
           component="img"
           src={icon?.src}

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.tsx
@@ -18,7 +18,7 @@ export interface EcologicalCreditCardProps extends EcologicalCreditCardType {
 }
 
 const EcologicalCreditCard = ({
-  type,
+  creditCategory,
   title,
   infos,
   description,
@@ -51,8 +51,8 @@ const EcologicalCreditCard = ({
       <Box sx={{ position: 'relative' }}>
         {children}
         <CardRibbon
-          icon={type.icon}
-          label={type.name}
+          icon={creditCategory.icon}
+          label={creditCategory.name}
           sx={{ position: 'absolute', left: 0, top: 48 }}
         />
       </Box>

--- a/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
+++ b/web-components/src/components/molecules/EcologicalCreditCard/EcologicalCreditCard.types.ts
@@ -23,7 +23,7 @@ export type EcologicalCreditCardItemListType = {
 };
 
 export type EcologicalCreditCardType = {
-  type: EcologicalCreditTypeType;
+  creditCategory: EcologicalCreditTypeType;
   image: ImageType;
   title: string;
   infos: EcologicalCreditInfoType;

--- a/web-marketplace/sanity-codegen.yml
+++ b/web-marketplace/sanity-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://jm12rn9t.api.sanity.io/v1/graphql/staging/default'
+schema: 'https://jm12rn9t.api.sanity.io/v1/graphql/staging/credit'
 documents:
   - 'src/graphql/sanity/*.graphql'
 generates:

--- a/web-marketplace/sanity-codegen.yml
+++ b/web-marketplace/sanity-codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://jm12rn9t.api.sanity.io/v1/graphql/staging/credit'
+schema: 'https://jm12rn9t.api.sanity.io/v1/graphql/staging/default'
 documents:
   - 'src/graphql/sanity/*.graphql'
 generates:

--- a/web-marketplace/sanity-graphql.schema.json
+++ b/web-marketplace/sanity-graphql.schema.json
@@ -14805,6 +14805,381 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CreditCategory",
+        "description": null,
+        "fields": [
+          {
+            "name": "_id",
+            "description": "Document ID",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": "Document type",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": "Date the document was created",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": "Date the document was last modified",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": "Current document revision",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Image",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Image",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Document",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreditCategoryFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_",
+            "description": "Apply filters on document level",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Sanity_DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreditCategorySorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CreditCertification",
         "description": null,
         "fields": [
@@ -16463,7 +16838,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "args": [],
             "type": {
@@ -16475,12 +16850,36 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "category",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Image",
+              "name": "CreditCategory",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": "This overrides the on-chain unit",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unitDefinitionRaw",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
               "ofType": null
             },
             "isDeprecated": false,
@@ -16601,7 +17000,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16613,11 +17012,23 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "category",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "ImageFilter",
+              "name": "CreditCategoryFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -16989,7 +17400,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -17001,11 +17412,11 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "unit",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "ImageSorting",
+              "kind": "ENUM",
+              "name": "SortOrder",
               "ofType": null
             },
             "defaultValue": null,
@@ -20232,6 +20643,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "CreditCategory",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "CreditCertification",
             "ofType": null
           },
@@ -21196,12 +21612,12 @@
             "deprecationReason": null
           },
           {
-            "name": "type",
+            "name": "creditCategory",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "CreditType",
+              "name": "CreditCategory",
               "ofType": null
             },
             "isDeprecated": false,
@@ -21426,11 +21842,11 @@
             "deprecationReason": null
           },
           {
-            "name": "type",
+            "name": "creditCategory",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "CreditTypeFilter",
+              "name": "CreditCategoryFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -47704,6 +48120,35 @@
             "deprecationReason": null
           },
           {
+            "name": "CreditCategory",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": "CreditCategory document ID",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CreditCategory",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CreditCertification",
             "description": null,
             "args": [
@@ -50424,6 +50869,87 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "CreateMethodologyPage",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allCreditCategory",
+            "description": null,
+            "args": [
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CreditCategoryFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreditCategorySorting",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "Max documents to return",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Offset at which to start returning documents from",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CreditCategory",
                     "ofType": null
                   }
                 }

--- a/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.Credit.tsx
+++ b/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.Credit.tsx
@@ -1,33 +1,67 @@
 import { Box, Grid } from '@mui/material';
+import { useState } from 'react';
+import {
+  BlockContent,
+  SanityBlockContent,
+} from 'web-components/src/components/block-content';
 
 import { Flex } from 'web-components/src/components/box';
-import { Title } from 'web-components/src/components/typography';
+import { TextButton } from 'web-components/src/components/buttons/TextButton';
+import SmallArrowIcon from 'web-components/src/components/icons/SmallArrowIcon';
+import Modal from 'web-components/src/components/modal';
+import { Body, Title } from 'web-components/src/components/typography';
+import { CREDIT_UNIT_DEFINITION } from './DetailsSection.constants';
 
 type Props = {
   src: string;
   label: string;
+  learnMore?: SanityBlockContent | null;
 };
 
-export const DetailsSectionCredit = ({ src, label }: Props) => (
-  <Grid item width={{ xs: '100%', tablet: 163 }}>
-    <Flex
-      sx={{
-        margin: 'auto',
-        borderRadius: '50%',
-        background:
-          'linear-gradient(219deg, #EEF1F3 0%, #F1F9F6 50%, #F9FBF8 100%)',
-        width: { xs: 90, sm: 104 },
-        height: { xs: 90, sm: 104 },
-      }}
-    >
-      <Box
-        sx={{ margin: 'auto', maxWidth: '100%' }}
-        component="img"
-        src={src}
-      />
-    </Flex>
-    <Title variant="h6" align="center" pt={2.5}>
-      {label}
-    </Title>
-  </Grid>
-);
+export const DetailsSectionCredit = ({ src, label, learnMore }: Props) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Grid item width={{ xs: '100%', tablet: 163 }}>
+        <Flex
+          sx={{
+            margin: 'auto',
+            borderRadius: '50%',
+            background:
+              'linear-gradient(219deg, #EEF1F3 0%, #F1F9F6 50%, #F9FBF8 100%)',
+            width: { xs: 90, sm: 104 },
+            height: { xs: 90, sm: 104 },
+          }}
+        >
+          <Box
+            sx={{ margin: 'auto', maxWidth: '100%' }}
+            component="img"
+            src={src}
+          />
+        </Flex>
+        <Title variant="h6" align="center" pt={2.5}>
+          {label}
+        </Title>
+        {learnMore && (
+          <TextButton
+            className="flex items-center text-[11px] mx-auto mt-[7px]"
+            onClick={() => setOpen(true)}
+          >
+            learn more&nbsp;
+            <SmallArrowIcon />
+          </TextButton>
+        )}
+      </Grid>
+      {learnMore && (
+        <Modal open={open} onClose={() => setOpen(false)}>
+          <Title variant="h4" align="center">
+            {CREDIT_UNIT_DEFINITION}
+          </Title>
+          <Body size="lg" className="pt-20">
+            <BlockContent content={learnMore} />
+          </Body>
+        </Modal>
+      )}
+    </>
+  );
+};

--- a/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.constants.ts
+++ b/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.constants.ts
@@ -1,3 +1,4 @@
 export const VIEW_METHODOLOGY = 'view methodology';
 export const VIEW_CREDIT_CLASS_DOC = 'view credit class doc';
 export const CREDIT = '1 credit';
+export const CREDIT_UNIT_DEFINITION = 'Credit unit definition';

--- a/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.tsx
+++ b/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.tsx
@@ -110,6 +110,7 @@ export const DetailsSection: React.FC<
                     <DetailsSectionCredit
                       src={credit.creditTypeImage}
                       label={credit.creditTypeUnit}
+                      learnMore={credit.creditTypeUnitDefinition}
                     />
                   </Grid>
                 </Grid>

--- a/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.types.ts
+++ b/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.types.ts
@@ -4,6 +4,7 @@ import { Theme } from 'web-components/src/theme/muiTheme';
 
 import { DetailsCard, DetailsSection, Maybe } from 'generated/sanity-graphql';
 import { CompactedNameUrl } from 'lib/rdf/types';
+import { SanityBlockContent } from 'web-components/src/components/block-content';
 
 export interface DetailsSectionProps {
   header?: Maybe<DetailsSection>;
@@ -14,6 +15,7 @@ export interface DetailsSectionProps {
     creditImage?: string | null;
     creditTypeUnit?: string;
     creditTypeImage?: string | null;
+    creditTypeUnitDefinition?: SanityBlockContent | null;
   };
   sx?: SxProps<Theme>;
 }

--- a/web-marketplace/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
+++ b/web-marketplace/src/components/organisms/ProjectTopSection/ProjectTopSection.tsx
@@ -228,8 +228,11 @@ function ProjectTopSection({
             creditClassSanity={creditClassSanity}
             creditClassMetadata={creditClassMetadata as CreditClassMetadataLD}
             onChainCreditClassId={onChainCreditClassId}
-            creditTypeName={creditTypeData?.creditType?.name}
-            creditTypeImage={creditTypeSanity?.image?.asset?.url}
+            creditTypeName={
+              creditTypeSanity?.category?.name ||
+              creditTypeData?.creditType?.name
+            }
+            creditTypeImage={creditTypeSanity?.category?.icon?.asset?.url}
             generationMethods={generationMethods}
             methodology={methodology}
             program={program}

--- a/web-marketplace/src/generated/sanity-graphql.tsx
+++ b/web-marketplace/src/generated/sanity-graphql.tsx
@@ -1705,6 +1705,50 @@ export type CredibilityCardSorting = {
   icon?: Maybe<ImageSorting>;
 };
 
+export type CreditCategory = Document & {
+  __typename?: 'CreditCategory';
+  /** Document ID */
+  _id?: Maybe<Scalars['ID']>;
+  /** Document type */
+  _type?: Maybe<Scalars['String']>;
+  /** Date the document was created */
+  _createdAt?: Maybe<Scalars['DateTime']>;
+  /** Date the document was last modified */
+  _updatedAt?: Maybe<Scalars['DateTime']>;
+  /** Current document revision */
+  _rev?: Maybe<Scalars['String']>;
+  _key?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  icon?: Maybe<Image>;
+  largeImage?: Maybe<Image>;
+};
+
+export type CreditCategoryFilter = {
+  /** Apply filters on document level */
+  _?: Maybe<Sanity_DocumentFilter>;
+  _id?: Maybe<IdFilter>;
+  _type?: Maybe<StringFilter>;
+  _createdAt?: Maybe<DatetimeFilter>;
+  _updatedAt?: Maybe<DatetimeFilter>;
+  _rev?: Maybe<StringFilter>;
+  _key?: Maybe<StringFilter>;
+  name?: Maybe<StringFilter>;
+  icon?: Maybe<ImageFilter>;
+  largeImage?: Maybe<ImageFilter>;
+};
+
+export type CreditCategorySorting = {
+  _id?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  _createdAt?: Maybe<SortOrder>;
+  _updatedAt?: Maybe<SortOrder>;
+  _rev?: Maybe<SortOrder>;
+  _key?: Maybe<SortOrder>;
+  name?: Maybe<SortOrder>;
+  icon?: Maybe<ImageSorting>;
+  largeImage?: Maybe<ImageSorting>;
+};
+
 export type CreditCertification = Document & {
   __typename?: 'CreditCertification';
   /** Document ID */
@@ -1895,8 +1939,11 @@ export type CreditType = Document & {
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
-  image?: Maybe<Image>;
   largeImage?: Maybe<Image>;
+  category?: Maybe<CreditCategory>;
+  /** This overrides the on-chain unit */
+  unit?: Maybe<Scalars['String']>;
+  unitDefinitionRaw?: Maybe<Scalars['JSON']>;
 };
 
 export type CreditTypeFilter = {
@@ -1909,8 +1956,9 @@ export type CreditTypeFilter = {
   _rev?: Maybe<StringFilter>;
   _key?: Maybe<StringFilter>;
   name?: Maybe<StringFilter>;
-  image?: Maybe<ImageFilter>;
   largeImage?: Maybe<ImageFilter>;
+  category?: Maybe<CreditCategoryFilter>;
+  unit?: Maybe<StringFilter>;
 };
 
 export type CreditTypeSection = {
@@ -1950,8 +1998,8 @@ export type CreditTypeSorting = {
   _rev?: Maybe<SortOrder>;
   _key?: Maybe<SortOrder>;
   name?: Maybe<SortOrder>;
-  image?: Maybe<ImageSorting>;
   largeImage?: Maybe<ImageSorting>;
+  unit?: Maybe<SortOrder>;
 };
 
 export type CrossDatasetReference = {
@@ -2419,7 +2467,7 @@ export type EcologicalCreditCard = Document & {
   title?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   image?: Maybe<CustomImage>;
-  type?: Maybe<CreditType>;
+  creditCategory?: Maybe<CreditCategory>;
   creditClass?: Maybe<CreditClass>;
   creditInfos?: Maybe<CreditInfos>;
   offsetMethods?: Maybe<Array<Maybe<OffsetMethod>>>;
@@ -2440,7 +2488,7 @@ export type EcologicalCreditCardFilter = {
   title?: Maybe<StringFilter>;
   description?: Maybe<StringFilter>;
   image?: Maybe<CustomImageFilter>;
-  type?: Maybe<CreditTypeFilter>;
+  creditCategory?: Maybe<CreditCategoryFilter>;
   creditClass?: Maybe<CreditClassFilter>;
   creditInfos?: Maybe<CreditInfosFilter>;
   button?: Maybe<ButtonFilter>;
@@ -5470,6 +5518,7 @@ export type RootQuery = {
   ContactPage?: Maybe<ContactPage>;
   CreateCreditClassPage?: Maybe<CreateCreditClassPage>;
   CreateMethodologyPage?: Maybe<CreateMethodologyPage>;
+  CreditCategory?: Maybe<CreditCategory>;
   CreditCertification?: Maybe<CreditCertification>;
   CreditClass?: Maybe<CreditClass>;
   CreditClassPage?: Maybe<CreditClassPage>;
@@ -5539,6 +5588,7 @@ export type RootQuery = {
   allContactPage: Array<ContactPage>;
   allCreateCreditClassPage: Array<CreateCreditClassPage>;
   allCreateMethodologyPage: Array<CreateMethodologyPage>;
+  allCreditCategory: Array<CreditCategory>;
   allCreditCertification: Array<CreditCertification>;
   allCreditClass: Array<CreditClass>;
   allCreditClassPage: Array<CreditClassPage>;
@@ -5663,6 +5713,11 @@ export type RootQueryCreateCreditClassPageArgs = {
 
 
 export type RootQueryCreateMethodologyPageArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type RootQueryCreditCategoryArgs = {
   id: Scalars['ID'];
 };
 
@@ -6049,6 +6104,14 @@ export type RootQueryAllCreateCreditClassPageArgs = {
 export type RootQueryAllCreateMethodologyPageArgs = {
   where?: Maybe<CreateMethodologyPageFilter>;
   sort?: Maybe<Array<CreateMethodologyPageSorting>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+
+export type RootQueryAllCreditCategoryArgs = {
+  where?: Maybe<CreditCategoryFilter>;
+  sort?: Maybe<Array<CreditCategorySorting>>;
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
 };
@@ -8331,13 +8394,20 @@ export type AllCreditTypeQuery = (
   { __typename?: 'RootQuery' }
   & { allCreditType: Array<(
     { __typename?: 'CreditType' }
-    & Pick<CreditType, 'name'>
-    & { image?: Maybe<(
+    & Pick<CreditType, 'name' | 'unit' | 'unitDefinitionRaw'>
+    & { largeImage?: Maybe<(
       { __typename?: 'Image' }
       & ImageFieldsFragment
-    )>, largeImage?: Maybe<(
-      { __typename?: 'Image' }
-      & ImageFieldsFragment
+    )>, category?: Maybe<(
+      { __typename?: 'CreditCategory' }
+      & Pick<CreditCategory, 'name'>
+      & { icon?: Maybe<(
+        { __typename?: 'Image' }
+        & ImageFieldsFragment
+      )>, largeImage?: Maybe<(
+        { __typename?: 'Image' }
+        & ImageFieldsFragment
+      )> }
     )> }
   )> }
 );
@@ -8722,10 +8792,10 @@ export type EcologicalCreditCardFieldsFragment = (
         & Pick<SanityImageAsset, 'url'>
       )> }
     )> }
-  )>, type?: Maybe<(
-    { __typename?: 'CreditType' }
-    & Pick<CreditType, 'name'>
-    & { image?: Maybe<(
+  )>, creditCategory?: Maybe<(
+    { __typename?: 'CreditCategory' }
+    & Pick<CreditCategory, 'name'>
+    & { icon?: Maybe<(
       { __typename?: 'Image' }
       & { asset?: Maybe<(
         { __typename?: 'SanityImageAsset' }
@@ -9327,9 +9397,9 @@ export const EcologicalCreditCardFieldsFragmentDoc = gql`
       }
     }
   }
-  type {
+  creditCategory {
     name
-    image {
+    icon {
       asset {
         url
       }
@@ -10236,11 +10306,19 @@ export const AllCreditTypeDocument = gql`
     query allCreditType {
   allCreditType {
     name
-    image {
-      ...imageFields
-    }
     largeImage {
       ...imageFields
+    }
+    unit
+    unitDefinitionRaw
+    category {
+      name
+      icon {
+        ...imageFields
+      }
+      largeImage {
+        ...imageFields
+      }
     }
   }
 }

--- a/web-marketplace/src/graphql/sanity/AllCreditType.graphql
+++ b/web-marketplace/src/graphql/sanity/AllCreditType.graphql
@@ -1,11 +1,19 @@
 query allCreditType {
   allCreditType {
     name
-    image {
-      ...imageFields
-    }
     largeImage {
       ...imageFields
+    }
+    unit
+    unitDefinitionRaw
+    category {
+      name
+      icon {
+        ...imageFields
+      }
+      largeImage {
+        ...imageFields
+      }
     }
   }
 }

--- a/web-marketplace/src/graphql/sanity/EcologicalCreditCardFragment.graphql
+++ b/web-marketplace/src/graphql/sanity/EcologicalCreditCardFragment.graphql
@@ -10,9 +10,9 @@ fragment ecologicalCreditCardFields on EcologicalCreditCard {
       }
     }
   }
-  type {
+  creditCategory {
     name
-    image {
+    icon {
       asset {
         url
       }

--- a/web-marketplace/src/pages/Buyers/normalizers/normalizeEcologicalCreditCards.ts
+++ b/web-marketplace/src/pages/Buyers/normalizers/normalizeEcologicalCreditCards.ts
@@ -42,11 +42,11 @@ export const normalizeEcologicalCreditCards = ({
           country: card?.creditInfos?.country ?? '',
           price: card?.creditInfos?.price ?? '',
         },
-        type: {
-          name: card?.type?.name ?? '',
+        creditCategory: {
+          name: card?.creditCategory?.name ?? '',
           icon: {
-            src: card?.type?.image?.asset?.url ?? '',
-            alt: card?.type?.name ?? '',
+            src: card?.creditCategory?.icon?.asset?.url ?? '',
+            alt: card?.creditCategory?.name ?? '',
           },
         },
         program: creditClassProgram,

--- a/web-marketplace/src/pages/CreditClassDetails/CreditClassDetailsSimple/CreditClassDetailsSimple.tsx
+++ b/web-marketplace/src/pages/CreditClassDetails/CreditClassDetailsSimple/CreditClassDetailsSimple.tsx
@@ -128,8 +128,14 @@ const CreditClassDetailsSimple: React.FC<
                   }}
                 >
                   <CardRibbon
-                    icon={{ src: creditTypeSanity?.image?.asset?.url ?? '' }}
-                    label={creditTypeSanity?.name ?? ''}
+                    icon={{
+                      src: creditTypeSanity?.category?.icon?.asset?.url ?? '',
+                    }}
+                    label={
+                      (creditTypeSanity?.category?.name ||
+                        creditTypeSanity?.name) ??
+                      ''
+                    }
                     labelSize="xs"
                     labelMobileSize="xxs"
                     sx={{
@@ -211,8 +217,12 @@ const CreditClassDetailsSimple: React.FC<
         methodology={methodology}
         credit={{
           creditImage: sanityCreditClassPage?.creditImage?.asset?.url,
-          creditTypeUnit: creditTypeData?.creditType?.unit,
-          creditTypeImage: creditTypeSanity?.largeImage?.asset?.url,
+          creditTypeUnit:
+            creditTypeSanity?.unit || creditTypeData?.creditType?.unit,
+          creditTypeImage:
+            creditTypeSanity?.largeImage?.asset?.url ||
+            creditTypeSanity?.category?.largeImage?.asset?.url,
+          creditTypeUnitDefinition: creditTypeSanity?.unitDefinitionRaw,
         }}
       >
         <CreditClassDetailsStakeholders

--- a/web-www/generated/sanity-graphql.tsx
+++ b/web-www/generated/sanity-graphql.tsx
@@ -114,7 +114,8 @@ export type Block = {
   _type?: Maybe<Scalars['String']>;
   children?: Maybe<Array<Maybe<Span>>>;
   style?: Maybe<Scalars['String']>;
-  list?: Maybe<Scalars['String']>;
+  listItem?: Maybe<Scalars['String']>;
+  level?: Maybe<Scalars['Float']>;
 };
 
 export type BlogPost = {
@@ -196,6 +197,8 @@ export type BooleanFilter = {
   eq?: Maybe<Scalars['Boolean']>;
   /** Checks if the value is not equal to the given input. */
   neq?: Maybe<Scalars['Boolean']>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 export type BottomBanner = {
@@ -1154,6 +1157,68 @@ export type ClaimSorting = {
   description?: Maybe<SortOrder>;
 };
 
+export type ClassPrefinanceTimelineItem = {
+  __typename?: 'ClassPrefinanceTimelineItem';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  status?: Maybe<ClassPrefinanceTimelineStatus>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItem>;
+};
+
+export type ClassPrefinanceTimelineItemFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  status?: Maybe<ClassPrefinanceTimelineStatusFilter>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItemFilter>;
+};
+
+export type ClassPrefinanceTimelineItemSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItemSorting>;
+};
+
+export type ClassPrefinanceTimelineStatus = Document & {
+  __typename?: 'ClassPrefinanceTimelineStatus';
+  /** Document ID */
+  _id?: Maybe<Scalars['ID']>;
+  /** Document type */
+  _type?: Maybe<Scalars['String']>;
+  /** Date the document was created */
+  _createdAt?: Maybe<Scalars['DateTime']>;
+  /** Date the document was last modified */
+  _updatedAt?: Maybe<Scalars['DateTime']>;
+  /** Current document revision */
+  _rev?: Maybe<Scalars['String']>;
+  _key?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  icon?: Maybe<CustomImage>;
+};
+
+export type ClassPrefinanceTimelineStatusFilter = {
+  /** Apply filters on document level */
+  _?: Maybe<Sanity_DocumentFilter>;
+  _id?: Maybe<IdFilter>;
+  _type?: Maybe<StringFilter>;
+  _createdAt?: Maybe<DatetimeFilter>;
+  _updatedAt?: Maybe<DatetimeFilter>;
+  _rev?: Maybe<StringFilter>;
+  _key?: Maybe<StringFilter>;
+  description?: Maybe<StringFilter>;
+  icon?: Maybe<CustomImageFilter>;
+};
+
+export type ClassPrefinanceTimelineStatusSorting = {
+  _id?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  _createdAt?: Maybe<SortOrder>;
+  _updatedAt?: Maybe<SortOrder>;
+  _rev?: Maybe<SortOrder>;
+  _key?: Maybe<SortOrder>;
+  description?: Maybe<SortOrder>;
+  icon?: Maybe<CustomImageSorting>;
+};
+
 export type ClimateSection = {
   __typename?: 'ClimateSection';
   _key?: Maybe<Scalars['String']>;
@@ -1640,6 +1705,50 @@ export type CredibilityCardSorting = {
   icon?: Maybe<ImageSorting>;
 };
 
+export type CreditCategory = Document & {
+  __typename?: 'CreditCategory';
+  /** Document ID */
+  _id?: Maybe<Scalars['ID']>;
+  /** Document type */
+  _type?: Maybe<Scalars['String']>;
+  /** Date the document was created */
+  _createdAt?: Maybe<Scalars['DateTime']>;
+  /** Date the document was last modified */
+  _updatedAt?: Maybe<Scalars['DateTime']>;
+  /** Current document revision */
+  _rev?: Maybe<Scalars['String']>;
+  _key?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  icon?: Maybe<Image>;
+  largeImage?: Maybe<Image>;
+};
+
+export type CreditCategoryFilter = {
+  /** Apply filters on document level */
+  _?: Maybe<Sanity_DocumentFilter>;
+  _id?: Maybe<IdFilter>;
+  _type?: Maybe<StringFilter>;
+  _createdAt?: Maybe<DatetimeFilter>;
+  _updatedAt?: Maybe<DatetimeFilter>;
+  _rev?: Maybe<StringFilter>;
+  _key?: Maybe<StringFilter>;
+  name?: Maybe<StringFilter>;
+  icon?: Maybe<ImageFilter>;
+  largeImage?: Maybe<ImageFilter>;
+};
+
+export type CreditCategorySorting = {
+  _id?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  _createdAt?: Maybe<SortOrder>;
+  _updatedAt?: Maybe<SortOrder>;
+  _rev?: Maybe<SortOrder>;
+  _key?: Maybe<SortOrder>;
+  name?: Maybe<SortOrder>;
+  icon?: Maybe<ImageSorting>;
+  largeImage?: Maybe<ImageSorting>;
+};
+
 export type CreditCertification = Document & {
   __typename?: 'CreditCertification';
   /** Document ID */
@@ -1830,8 +1939,11 @@ export type CreditType = Document & {
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
-  image?: Maybe<Image>;
   largeImage?: Maybe<Image>;
+  category?: Maybe<CreditCategory>;
+  /** This overrides the on-chain unit */
+  unit?: Maybe<Scalars['String']>;
+  unitDefinitionRaw?: Maybe<Scalars['JSON']>;
 };
 
 export type CreditTypeFilter = {
@@ -1844,8 +1956,9 @@ export type CreditTypeFilter = {
   _rev?: Maybe<StringFilter>;
   _key?: Maybe<StringFilter>;
   name?: Maybe<StringFilter>;
-  image?: Maybe<ImageFilter>;
   largeImage?: Maybe<ImageFilter>;
+  category?: Maybe<CreditCategoryFilter>;
+  unit?: Maybe<StringFilter>;
 };
 
 export type CreditTypeSection = {
@@ -1885,8 +1998,8 @@ export type CreditTypeSorting = {
   _rev?: Maybe<SortOrder>;
   _key?: Maybe<SortOrder>;
   name?: Maybe<SortOrder>;
-  image?: Maybe<ImageSorting>;
   largeImage?: Maybe<ImageSorting>;
+  unit?: Maybe<SortOrder>;
 };
 
 export type CrossDatasetReference = {
@@ -1956,6 +2069,8 @@ export type DateFilter = {
   lt?: Maybe<Scalars['Date']>;
   /** Checks if the value is lesser than or equal to the given input. */
   lte?: Maybe<Scalars['Date']>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1972,6 +2087,8 @@ export type DatetimeFilter = {
   lt?: Maybe<Scalars['DateTime']>;
   /** Checks if the value is lesser than or equal to the given input. */
   lte?: Maybe<Scalars['DateTime']>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 export type DetailsCard = {
@@ -2350,7 +2467,7 @@ export type EcologicalCreditCard = Document & {
   title?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   image?: Maybe<CustomImage>;
-  type?: Maybe<CreditType>;
+  creditCategory?: Maybe<CreditCategory>;
   creditClass?: Maybe<CreditClass>;
   creditInfos?: Maybe<CreditInfos>;
   offsetMethods?: Maybe<Array<Maybe<OffsetMethod>>>;
@@ -2371,7 +2488,7 @@ export type EcologicalCreditCardFilter = {
   title?: Maybe<StringFilter>;
   description?: Maybe<StringFilter>;
   image?: Maybe<CustomImageFilter>;
-  type?: Maybe<CreditTypeFilter>;
+  creditCategory?: Maybe<CreditCategoryFilter>;
   creditClass?: Maybe<CreditClassFilter>;
   creditInfos?: Maybe<CreditInfosFilter>;
   button?: Maybe<ButtonFilter>;
@@ -2738,6 +2855,8 @@ export type FloatFilter = {
   lt?: Maybe<Scalars['Float']>;
   /** Checks if the value is lesser than or equal to the given input. */
   lte?: Maybe<Scalars['Float']>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 export type FullStepCardSection = {
@@ -3497,6 +3616,8 @@ export type IntFilter = {
   lt?: Maybe<Scalars['Int']>;
   /** Checks if the value is lesser than or equal to the given input. */
   lte?: Maybe<Scalars['Int']>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -4449,6 +4570,54 @@ export type PracticesOutcomesSectionSorting = {
   note?: Maybe<SortOrder>;
 };
 
+export type PrefinanceProjects = {
+  __typename?: 'PrefinanceProjects';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  descriptionRaw?: Maybe<Scalars['JSON']>;
+  learnMore?: Maybe<Scalars['String']>;
+};
+
+export type PrefinanceProjectsFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  learnMore?: Maybe<StringFilter>;
+};
+
+export type PrefinanceProjectsSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  learnMore?: Maybe<SortOrder>;
+};
+
+export type PrefinanceTimelineItem = {
+  __typename?: 'PrefinanceTimelineItem';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  /** optional */
+  date?: Maybe<Scalars['Date']>;
+  /** optional if single date */
+  endDate?: Maybe<Scalars['Date']>;
+  /** Timeline items that are done will be written in black text on the timeline while projected items are greyed out. The most recent done item will show up as the current status on the project page. */
+  currentStatus?: Maybe<Scalars['String']>;
+};
+
+export type PrefinanceTimelineItemFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  date?: Maybe<DateFilter>;
+  endDate?: Maybe<DateFilter>;
+  currentStatus?: Maybe<StringFilter>;
+};
+
+export type PrefinanceTimelineItemSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  date?: Maybe<SortOrder>;
+  endDate?: Maybe<SortOrder>;
+  currentStatus?: Maybe<SortOrder>;
+};
+
 export type PresskitAwardsSection = {
   __typename?: 'PresskitAwardsSection';
   _key?: Maybe<Scalars['String']>;
@@ -4730,14 +4899,15 @@ export type Project = Document & {
   /** Current document revision */
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
-  projectName?: Maybe<Scalars['String']>;
   /** on-chain project id, off-chain uuid or slug */
   projectId?: Maybe<Scalars['String']>;
+  projectPrefinancing?: Maybe<ProjectPrefinancing>;
+  credibilityCards?: Maybe<Array<Maybe<DetailsCard>>>;
+  projectName?: Maybe<Scalars['String']>;
   image?: Maybe<CustomImage>;
   location?: Maybe<Scalars['String']>;
   area?: Maybe<Scalars['Float']>;
   areaUnit?: Maybe<Scalars['String']>;
-  credibilityCards?: Maybe<Array<Maybe<DetailsCard>>>;
 };
 
 export type ProjectActivity = Document & {
@@ -4831,8 +5001,9 @@ export type ProjectFilter = {
   _updatedAt?: Maybe<DatetimeFilter>;
   _rev?: Maybe<StringFilter>;
   _key?: Maybe<StringFilter>;
-  projectName?: Maybe<StringFilter>;
   projectId?: Maybe<StringFilter>;
+  projectPrefinancing?: Maybe<ProjectPrefinancingFilter>;
+  projectName?: Maybe<StringFilter>;
   image?: Maybe<CustomImageFilter>;
   location?: Maybe<StringFilter>;
   area?: Maybe<FloatFilter>;
@@ -4883,6 +5054,108 @@ export type ProjectPageSorting = {
   otcCard?: Maybe<ActionCardSorting>;
 };
 
+export type ProjectPrefinanceTimelineItem = {
+  __typename?: 'ProjectPrefinanceTimelineItem';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  status?: Maybe<ProjectPrefinanceTimelineStatus>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItem>;
+};
+
+export type ProjectPrefinanceTimelineItemFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  status?: Maybe<ProjectPrefinanceTimelineStatusFilter>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItemFilter>;
+};
+
+export type ProjectPrefinanceTimelineItemSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  prefinanceTimelineItem?: Maybe<PrefinanceTimelineItemSorting>;
+};
+
+export type ProjectPrefinanceTimelineStatus = Document & {
+  __typename?: 'ProjectPrefinanceTimelineStatus';
+  /** Document ID */
+  _id?: Maybe<Scalars['ID']>;
+  /** Document type */
+  _type?: Maybe<Scalars['String']>;
+  /** Date the document was created */
+  _createdAt?: Maybe<Scalars['DateTime']>;
+  /** Date the document was last modified */
+  _updatedAt?: Maybe<Scalars['DateTime']>;
+  /** Current document revision */
+  _rev?: Maybe<Scalars['String']>;
+  _key?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  icon?: Maybe<CustomImage>;
+};
+
+export type ProjectPrefinanceTimelineStatusFilter = {
+  /** Apply filters on document level */
+  _?: Maybe<Sanity_DocumentFilter>;
+  _id?: Maybe<IdFilter>;
+  _type?: Maybe<StringFilter>;
+  _createdAt?: Maybe<DatetimeFilter>;
+  _updatedAt?: Maybe<DatetimeFilter>;
+  _rev?: Maybe<StringFilter>;
+  _key?: Maybe<StringFilter>;
+  description?: Maybe<StringFilter>;
+  icon?: Maybe<CustomImageFilter>;
+};
+
+export type ProjectPrefinanceTimelineStatusSorting = {
+  _id?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  _createdAt?: Maybe<SortOrder>;
+  _updatedAt?: Maybe<SortOrder>;
+  _rev?: Maybe<SortOrder>;
+  _key?: Maybe<SortOrder>;
+  description?: Maybe<SortOrder>;
+  icon?: Maybe<CustomImageSorting>;
+};
+
+export type ProjectPrefinancing = {
+  __typename?: 'ProjectPrefinancing';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  isPrefinanceProject?: Maybe<Scalars['Boolean']>;
+  /** in USD */
+  price?: Maybe<Scalars['Float']>;
+  /** estimated number of credits that will be issued */
+  estimatedIssuance?: Maybe<Scalars['Float']>;
+  stripePaymentLink?: Maybe<Scalars['String']>;
+  prefinanceTermsRaw?: Maybe<Scalars['JSON']>;
+  purchaseAgreementLink?: Maybe<Scalars['String']>;
+  projectedCreditDeliveryDate?: Maybe<Scalars['Date']>;
+  projectTimeline?: Maybe<Array<Maybe<ProjectPrefinanceTimelineItem>>>;
+  classTimeline?: Maybe<Array<Maybe<ClassPrefinanceTimelineItem>>>;
+  supportEnables?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+export type ProjectPrefinancingFilter = {
+  _key?: Maybe<StringFilter>;
+  _type?: Maybe<StringFilter>;
+  isPrefinanceProject?: Maybe<BooleanFilter>;
+  price?: Maybe<FloatFilter>;
+  estimatedIssuance?: Maybe<FloatFilter>;
+  stripePaymentLink?: Maybe<StringFilter>;
+  purchaseAgreementLink?: Maybe<StringFilter>;
+  projectedCreditDeliveryDate?: Maybe<DateFilter>;
+};
+
+export type ProjectPrefinancingSorting = {
+  _key?: Maybe<SortOrder>;
+  _type?: Maybe<SortOrder>;
+  isPrefinanceProject?: Maybe<SortOrder>;
+  price?: Maybe<SortOrder>;
+  estimatedIssuance?: Maybe<SortOrder>;
+  stripePaymentLink?: Maybe<SortOrder>;
+  purchaseAgreementLink?: Maybe<SortOrder>;
+  projectedCreditDeliveryDate?: Maybe<SortOrder>;
+};
+
 export type ProjectRating = Document & {
   __typename?: 'ProjectRating';
   /** Document ID */
@@ -4931,8 +5204,9 @@ export type ProjectSorting = {
   _updatedAt?: Maybe<SortOrder>;
   _rev?: Maybe<SortOrder>;
   _key?: Maybe<SortOrder>;
-  projectName?: Maybe<SortOrder>;
   projectId?: Maybe<SortOrder>;
+  projectPrefinancing?: Maybe<ProjectPrefinancingSorting>;
+  projectName?: Maybe<SortOrder>;
   image?: Maybe<CustomImageSorting>;
   location?: Maybe<SortOrder>;
   area?: Maybe<SortOrder>;
@@ -4953,6 +5227,7 @@ export type ProjectsPage = Document & {
   _rev?: Maybe<Scalars['String']>;
   _key?: Maybe<Scalars['String']>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSection>;
+  prefinanceProjects?: Maybe<PrefinanceProjects>;
 };
 
 export type ProjectsPageFilter = {
@@ -4965,6 +5240,7 @@ export type ProjectsPageFilter = {
   _rev?: Maybe<StringFilter>;
   _key?: Maybe<StringFilter>;
   gettingStartedResourcesSection?: Maybe<GettingStartedResourcesSectionFilter>;
+  prefinanceProjects?: Maybe<PrefinanceProjectsFilter>;
 };
 
 export type ProjectsPageSorting = {
@@ -4974,6 +5250,7 @@ export type ProjectsPageSorting = {
   _updatedAt?: Maybe<SortOrder>;
   _rev?: Maybe<SortOrder>;
   _key?: Maybe<SortOrder>;
+  prefinanceProjects?: Maybe<PrefinanceProjectsSorting>;
 };
 
 export type RegenTeamMember = Document & {
@@ -5235,11 +5512,13 @@ export type RootQuery = {
   CaseStudiesPage?: Maybe<CaseStudiesPage>;
   CaseStudyPage?: Maybe<CaseStudyPage>;
   Claim?: Maybe<Claim>;
+  ClassPrefinanceTimelineStatus?: Maybe<ClassPrefinanceTimelineStatus>;
   CredibilityCard?: Maybe<CredibilityCard>;
   CommunityPage?: Maybe<CommunityPage>;
   ContactPage?: Maybe<ContactPage>;
   CreateCreditClassPage?: Maybe<CreateCreditClassPage>;
   CreateMethodologyPage?: Maybe<CreateMethodologyPage>;
+  CreditCategory?: Maybe<CreditCategory>;
   CreditCertification?: Maybe<CreditCertification>;
   CreditClass?: Maybe<CreditClass>;
   CreditClassPage?: Maybe<CreditClassPage>;
@@ -5275,6 +5554,7 @@ export type RootQuery = {
   Project?: Maybe<Project>;
   ProjectActivity?: Maybe<ProjectActivity>;
   ProjectEcosystem?: Maybe<ProjectEcosystem>;
+  ProjectPrefinanceTimelineStatus?: Maybe<ProjectPrefinanceTimelineStatus>;
   ProjectPage?: Maybe<ProjectPage>;
   ProjectRating?: Maybe<ProjectRating>;
   ProjectsPage?: Maybe<ProjectsPage>;
@@ -5302,11 +5582,13 @@ export type RootQuery = {
   allCaseStudiesPage: Array<CaseStudiesPage>;
   allCaseStudyPage: Array<CaseStudyPage>;
   allClaim: Array<Claim>;
+  allClassPrefinanceTimelineStatus: Array<ClassPrefinanceTimelineStatus>;
   allCredibilityCard: Array<CredibilityCard>;
   allCommunityPage: Array<CommunityPage>;
   allContactPage: Array<ContactPage>;
   allCreateCreditClassPage: Array<CreateCreditClassPage>;
   allCreateMethodologyPage: Array<CreateMethodologyPage>;
+  allCreditCategory: Array<CreditCategory>;
   allCreditCertification: Array<CreditCertification>;
   allCreditClass: Array<CreditClass>;
   allCreditClassPage: Array<CreditClassPage>;
@@ -5342,6 +5624,7 @@ export type RootQuery = {
   allProject: Array<Project>;
   allProjectActivity: Array<ProjectActivity>;
   allProjectEcosystem: Array<ProjectEcosystem>;
+  allProjectPrefinanceTimelineStatus: Array<ProjectPrefinanceTimelineStatus>;
   allProjectPage: Array<ProjectPage>;
   allProjectRating: Array<ProjectRating>;
   allProjectsPage: Array<ProjectsPage>;
@@ -5404,6 +5687,11 @@ export type RootQueryClaimArgs = {
 };
 
 
+export type RootQueryClassPrefinanceTimelineStatusArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type RootQueryCredibilityCardArgs = {
   id: Scalars['ID'];
 };
@@ -5425,6 +5713,11 @@ export type RootQueryCreateCreditClassPageArgs = {
 
 
 export type RootQueryCreateMethodologyPageArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type RootQueryCreditCategoryArgs = {
   id: Scalars['ID'];
 };
 
@@ -5604,6 +5897,11 @@ export type RootQueryProjectEcosystemArgs = {
 };
 
 
+export type RootQueryProjectPrefinanceTimelineStatusArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type RootQueryProjectPageArgs = {
   id: Scalars['ID'];
 };
@@ -5763,6 +6061,14 @@ export type RootQueryAllClaimArgs = {
 };
 
 
+export type RootQueryAllClassPrefinanceTimelineStatusArgs = {
+  where?: Maybe<ClassPrefinanceTimelineStatusFilter>;
+  sort?: Maybe<Array<ClassPrefinanceTimelineStatusSorting>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+
 export type RootQueryAllCredibilityCardArgs = {
   where?: Maybe<CredibilityCardFilter>;
   sort?: Maybe<Array<CredibilityCardSorting>>;
@@ -5798,6 +6104,14 @@ export type RootQueryAllCreateCreditClassPageArgs = {
 export type RootQueryAllCreateMethodologyPageArgs = {
   where?: Maybe<CreateMethodologyPageFilter>;
   sort?: Maybe<Array<CreateMethodologyPageSorting>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+
+export type RootQueryAllCreditCategoryArgs = {
+  where?: Maybe<CreditCategoryFilter>;
+  sort?: Maybe<Array<CreditCategorySorting>>;
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
 };
@@ -6078,6 +6392,14 @@ export type RootQueryAllProjectActivityArgs = {
 export type RootQueryAllProjectEcosystemArgs = {
   where?: Maybe<ProjectEcosystemFilter>;
   sort?: Maybe<Array<ProjectEcosystemSorting>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+};
+
+
+export type RootQueryAllProjectPrefinanceTimelineStatusArgs = {
+  where?: Maybe<ProjectPrefinanceTimelineStatusFilter>;
+  sort?: Maybe<Array<ProjectPrefinanceTimelineStatusSorting>>;
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
 };
@@ -7067,6 +7389,8 @@ export type StringFilter = {
   matches?: Maybe<Scalars['String']>;
   in?: Maybe<Array<Scalars['String']>>;
   nin?: Maybe<Array<Scalars['String']>>;
+  /** Checks if the value is defined. */
+  is_defined?: Maybe<Scalars['Boolean']>;
 };
 
 export type Tag = Document & {
@@ -8055,6 +8379,58 @@ export type ResourcesTopSectionFieldsFragment = (
   )> }
 );
 
+export type CallToActionFieldsFragment = (
+  { __typename?: 'CallToAction' }
+  & Pick<CallToAction, 'caption' | 'header' | 'description' | 'linkText' | 'linkUrl'>
+  & { image?: Maybe<(
+    { __typename?: 'Image' }
+    & ImageFieldsFragment
+  )> }
+);
+
+export type CustomImageFieldsFragment = (
+  { __typename?: 'CustomImage' }
+  & Pick<CustomImage, 'imageAlt' | 'imageHref'>
+  & { image?: Maybe<(
+    { __typename?: 'Image' }
+    & { asset?: Maybe<(
+      { __typename?: 'SanityImageAsset' }
+      & Pick<SanityImageAsset, 'altText' | 'url'>
+      & { metadata?: Maybe<(
+        { __typename?: 'SanityImageMetadata' }
+        & { dimensions?: Maybe<(
+          { __typename?: 'SanityImageDimensions' }
+          & Pick<SanityImageDimensions, 'height' | 'width'>
+        )> }
+      )> }
+    )> }
+  )> }
+);
+
+export type ImageFieldsFragment = (
+  { __typename?: 'Image' }
+  & { asset?: Maybe<(
+    { __typename?: 'SanityImageAsset' }
+    & Pick<SanityImageAsset, 'altText' | 'url'>
+    & { metadata?: Maybe<(
+      { __typename?: 'SanityImageMetadata' }
+      & { dimensions?: Maybe<(
+        { __typename?: 'SanityImageDimensions' }
+        & Pick<SanityImageDimensions, 'height' | 'width'>
+      )> }
+    )> }
+  )> }
+);
+
+export type MediaFieldsFragment = (
+  { __typename?: 'Media' }
+  & Pick<Media, 'title' | 'author' | 'date' | 'href' | 'type'>
+  & { image?: Maybe<(
+    { __typename?: 'CustomImage' }
+    & CustomImageFieldsFragment
+  )> }
+);
+
 export type BottomBannerFieldsFragment = (
   { __typename?: 'BottomBanner' }
   & Pick<BottomBanner, 'title' | 'descriptionRaw'>
@@ -8079,15 +8455,6 @@ export type ButtonFieldsFragment = (
   )> }
 );
 
-export type CallToActionFieldsFragment = (
-  { __typename?: 'CallToAction' }
-  & Pick<CallToAction, 'caption' | 'header' | 'description' | 'linkText' | 'linkUrl'>
-  & { image?: Maybe<(
-    { __typename?: 'Image' }
-    & ImageFieldsFragment
-  )> }
-);
-
 export type CardFieldsFragment = (
   { __typename?: 'Card' }
   & Pick<Card, 'title' | 'descriptionRaw'>
@@ -8096,25 +8463,6 @@ export type CardFieldsFragment = (
     & { asset?: Maybe<(
       { __typename?: 'SanityImageAsset' }
       & Pick<SanityImageAsset, 'url'>
-    )> }
-  )> }
-);
-
-export type CustomImageFieldsFragment = (
-  { __typename?: 'CustomImage' }
-  & Pick<CustomImage, 'imageAlt' | 'imageHref'>
-  & { image?: Maybe<(
-    { __typename?: 'Image' }
-    & { asset?: Maybe<(
-      { __typename?: 'SanityImageAsset' }
-      & Pick<SanityImageAsset, 'altText' | 'url'>
-      & { metadata?: Maybe<(
-        { __typename?: 'SanityImageMetadata' }
-        & { dimensions?: Maybe<(
-          { __typename?: 'SanityImageDimensions' }
-          & Pick<SanityImageDimensions, 'height' | 'width'>
-        )> }
-      )> }
     )> }
   )> }
 );
@@ -8132,10 +8480,10 @@ export type EcologicalCreditCardFieldsFragment = (
         & Pick<SanityImageAsset, 'url'>
       )> }
     )> }
-  )>, type?: Maybe<(
-    { __typename?: 'CreditType' }
-    & Pick<CreditType, 'name'>
-    & { image?: Maybe<(
+  )>, creditCategory?: Maybe<(
+    { __typename?: 'CreditCategory' }
+    & Pick<CreditCategory, 'name'>
+    & { icon?: Maybe<(
       { __typename?: 'Image' }
       & { asset?: Maybe<(
         { __typename?: 'SanityImageAsset' }
@@ -8200,21 +8548,6 @@ export type HeroSectionFieldsFragment = (
   )> }
 );
 
-export type ImageFieldsFragment = (
-  { __typename?: 'Image' }
-  & { asset?: Maybe<(
-    { __typename?: 'SanityImageAsset' }
-    & Pick<SanityImageAsset, 'altText' | 'url'>
-    & { metadata?: Maybe<(
-      { __typename?: 'SanityImageMetadata' }
-      & { dimensions?: Maybe<(
-        { __typename?: 'SanityImageDimensions' }
-        & Pick<SanityImageDimensions, 'height' | 'width'>
-      )> }
-    )> }
-  )> }
-);
-
 export type ImageGridItemFieldsFragment = (
   { __typename?: 'ImageGridItem' }
   & Pick<ImageGridItem, 'header' | 'descriptionRaw'>
@@ -8253,15 +8586,6 @@ export type LinkFieldsFragment = (
   & { buttonDoc?: Maybe<(
     { __typename?: 'Doc' }
     & Pick<Doc, 'href'>
-  )> }
-);
-
-export type MediaFieldsFragment = (
-  { __typename?: 'Media' }
-  & Pick<Media, 'title' | 'author' | 'date' | 'href' | 'type'>
-  & { image?: Maybe<(
-    { __typename?: 'CustomImage' }
-    & CustomImageFieldsFragment
   )> }
 );
 
@@ -8785,9 +9109,9 @@ export const EcologicalCreditCardFieldsFragmentDoc = gql`
       }
     }
   }
-  type {
+  creditCategory {
     name
-    image {
+    icon {
       asset {
         url
       }

--- a/web-www/graphql/sanity/fragments/shared/ecologicalCreditCardFragment.graphql
+++ b/web-www/graphql/sanity/fragments/shared/ecologicalCreditCardFragment.graphql
@@ -10,9 +10,9 @@ fragment ecologicalCreditCardFields on EcologicalCreditCard {
       }
     }
   }
-  type {
+  creditCategory {
     name
-    image {
+    icon {
       asset {
         url
       }

--- a/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
+++ b/web-www/lib/utils/normalizers/normalizeEcologicalCreditCards.ts
@@ -29,11 +29,11 @@ export const normalizeEcologicalCreditCards = ({
         country: card?.creditInfos?.country ?? '',
         price: card?.creditInfos?.price ?? '',
       },
-      type: {
-        name: card?.type?.name ?? '',
+      creditCategory: {
+        name: card?.creditCategory?.name ?? '',
         icon: {
-          src: card?.type?.image?.asset?.url ?? '',
-          alt: card?.type?.name ?? '',
+          src: card?.creditCategory?.icon?.asset?.url ?? '',
+          alt: card?.creditCategory?.name ?? '',
         },
       },
       button: {

--- a/web-www/sanity-graphql.schema.json
+++ b/web-www/sanity-graphql.schema.json
@@ -769,7 +769,7 @@
             "deprecationReason": null
           },
           {
-            "name": "list",
+            "name": "listItem",
             "description": null,
             "args": [],
             "type": {
@@ -779,10 +779,32 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "level",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Float",
+        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1438,6 +1460,18 @@
           {
             "name": "neq",
             "description": "Checks if the value is not equal to the given input.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
@@ -9864,6 +9898,510 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ClassPrefinanceTimelineItem",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ClassPrefinanceTimelineStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PrefinanceTimelineItem",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ClassPrefinanceTimelineItemFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ClassPrefinanceTimelineStatusFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceTimelineItemFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ClassPrefinanceTimelineItemSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceTimelineItemSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ClassPrefinanceTimelineStatus",
+        "description": null,
+        "fields": [
+          {
+            "name": "_id",
+            "description": "Document ID",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": "Document type",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": "Date the document was created",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": "Date the document was last modified",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": "Current document revision",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomImage",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Document",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ClassPrefinanceTimelineStatusFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_",
+            "description": "Apply filters on document level",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Sanity_DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ClassPrefinanceTimelineStatusSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ClimateSection",
         "description": null,
         "fields": [
@@ -14267,6 +14805,381 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CreditCategory",
+        "description": null,
+        "fields": [
+          {
+            "name": "_id",
+            "description": "Document ID",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": "Document type",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": "Date the document was created",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": "Date the document was last modified",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": "Current document revision",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Image",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Image",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Document",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreditCategoryFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_",
+            "description": "Apply filters on document level",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Sanity_DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreditCategorySorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "largeImage",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CreditCertification",
         "description": null,
         "fields": [
@@ -15925,7 +16838,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "args": [],
             "type": {
@@ -15937,12 +16850,36 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "category",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Image",
+              "name": "CreditCategory",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": "This overrides the on-chain unit",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unitDefinitionRaw",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
               "ofType": null
             },
             "isDeprecated": false,
@@ -16063,7 +17000,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16075,11 +17012,23 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "category",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "ImageFilter",
+              "name": "CreditCategoryFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -16451,7 +17400,7 @@
             "deprecationReason": null
           },
           {
-            "name": "image",
+            "name": "largeImage",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -16463,11 +17412,11 @@
             "deprecationReason": null
           },
           {
-            "name": "largeImage",
+            "name": "unit",
             "description": null,
             "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "ImageSorting",
+              "kind": "ENUM",
+              "name": "SortOrder",
               "ofType": null
             },
             "defaultValue": null,
@@ -17028,6 +17977,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -17116,6 +18077,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -19640,6 +20613,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ClassPrefinanceTimelineStatus",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "CommunityPage",
             "ofType": null
           },
@@ -19661,6 +20639,11 @@
           {
             "kind": "OBJECT",
             "name": "CredibilityCard",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CreditCategory",
             "ofType": null
           },
           {
@@ -19841,6 +20824,11 @@
           {
             "kind": "OBJECT",
             "name": "ProjectPage",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectPrefinanceTimelineStatus",
             "ofType": null
           },
           {
@@ -20624,12 +21612,12 @@
             "deprecationReason": null
           },
           {
-            "name": "type",
+            "name": "creditCategory",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "CreditType",
+              "name": "CreditCategory",
               "ofType": null
             },
             "isDeprecated": false,
@@ -20854,11 +21842,11 @@
             "deprecationReason": null
           },
           {
-            "name": "type",
+            "name": "creditCategory",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
-              "name": "CreditTypeFilter",
+              "name": "CreditCategoryFilter",
               "ofType": null
             },
             "defaultValue": null,
@@ -23872,18 +24860,20 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Float",
-        "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
-        "fields": null,
-        "inputFields": null,
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -30304,6 +31294,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -38725,6 +39727,372 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PrefinanceProjects",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionRaw",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "learnMore",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PrefinanceProjectsFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "learnMore",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PrefinanceProjectsSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "learnMore",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PrefinanceTimelineItem",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "date",
+            "description": "optional",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endDate",
+            "description": "optional if single date",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentStatus",
+            "description": "Timeline items that are done will be written in black text on the timeline while projected items are greyed out. The most recent done item will show up as the current status on the project page.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PrefinanceTimelineItemFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "date",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endDate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentStatus",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "PrefinanceTimelineItemSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "date",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endDate",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentStatus",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PresskitAwardsSection",
         "description": null,
         "fields": [
@@ -41122,8 +42490,8 @@
             "deprecationReason": null
           },
           {
-            "name": "projectName",
-            "description": null,
+            "name": "projectId",
+            "description": "on-chain project id, off-chain uuid or slug",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -41134,8 +42502,36 @@
             "deprecationReason": null
           },
           {
-            "name": "projectId",
-            "description": "on-chain project id, off-chain uuid or slug",
+            "name": "projectPrefinancing",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectPrefinancing",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "credibilityCards",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DetailsCard",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectName",
+            "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -41189,22 +42585,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "credibilityCards",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DetailsCard",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -41990,7 +43370,7 @@
             "deprecationReason": null
           },
           {
-            "name": "projectName",
+            "name": "projectId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -42002,7 +43382,19 @@
             "deprecationReason": null
           },
           {
-            "name": "projectId",
+            "name": "projectPrefinancing",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectPrefinancingFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectName",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
@@ -42418,6 +43810,891 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "ActionCardSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectPrefinanceTimelineItem",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectPrefinanceTimelineStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PrefinanceTimelineItem",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinanceTimelineItemFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectPrefinanceTimelineStatusFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceTimelineItemFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinanceTimelineItemSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTimelineItem",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceTimelineItemSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectPrefinanceTimelineStatus",
+        "description": null,
+        "fields": [
+          {
+            "name": "_id",
+            "description": "Document ID",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": "Document type",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": "Date the document was created",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": "Date the document was last modified",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": "Current document revision",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomImage",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Document",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinanceTimelineStatusFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_",
+            "description": "Apply filters on document level",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Sanity_DocumentFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IDFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomImageFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinanceTimelineStatusSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_updatedAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_rev",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "icon",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomImageSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectPrefinancing",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrefinanceProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": "in USD",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimatedIssuance",
+            "description": "estimated number of credits that will be issued",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stripePaymentLink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceTermsRaw",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "purchaseAgreementLink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectedCreditDeliveryDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTimeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProjectPrefinanceTimelineItem",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "classTimeline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ClassPrefinanceTimelineItem",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportEnables",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinancingFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrefinanceProject",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BooleanFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimatedIssuance",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stripePaymentLink",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "purchaseAgreementLink",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectedCreditDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DateFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectPrefinancingSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isPrefinanceProject",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "estimatedIssuance",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stripePaymentLink",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "purchaseAgreementLink",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectedCreditDeliveryDate",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
               "ofType": null
             },
             "defaultValue": null,
@@ -42847,7 +45124,7 @@
             "deprecationReason": null
           },
           {
-            "name": "projectName",
+            "name": "projectId",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -42859,7 +45136,19 @@
             "deprecationReason": null
           },
           {
-            "name": "projectId",
+            "name": "projectPrefinancing",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectPrefinancingSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectName",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -43011,6 +45300,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "prefinanceProjects",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PrefinanceProjects",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -43125,6 +45426,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "prefinanceProjects",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceProjectsFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -43203,6 +45516,18 @@
             "type": {
               "kind": "ENUM",
               "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefinanceProjects",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PrefinanceProjectsSorting",
               "ofType": null
             },
             "defaultValue": null,
@@ -45621,6 +47946,35 @@
             "deprecationReason": null
           },
           {
+            "name": "ClassPrefinanceTimelineStatus",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": "ClassPrefinanceTimelineStatus document ID",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ClassPrefinanceTimelineStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CredibilityCard",
             "description": null,
             "args": [
@@ -45760,6 +48114,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "CreateMethodologyPage",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CreditCategory",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": "CreditCategory document ID",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CreditCategory",
               "ofType": null
             },
             "isDeprecated": false,
@@ -46775,6 +49158,35 @@
             "type": {
               "kind": "OBJECT",
               "name": "ProjectEcosystem",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ProjectPrefinanceTimelineStatus",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": "ProjectPrefinanceTimelineStatus document ID",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProjectPrefinanceTimelineStatus",
               "ofType": null
             },
             "isDeprecated": false,
@@ -47980,6 +50392,87 @@
             "deprecationReason": null
           },
           {
+            "name": "allClassPrefinanceTimelineStatus",
+            "description": null,
+            "args": [
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ClassPrefinanceTimelineStatusFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ClassPrefinanceTimelineStatusSorting",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "Max documents to return",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Offset at which to start returning documents from",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ClassPrefinanceTimelineStatus",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "allCredibilityCard",
             "description": null,
             "args": [
@@ -48376,6 +50869,87 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "CreateMethodologyPage",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allCreditCategory",
+            "description": null,
+            "args": [
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CreditCategoryFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreditCategorySorting",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "Max documents to return",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Offset at which to start returning documents from",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CreditCategory",
                     "ofType": null
                   }
                 }
@@ -51211,6 +53785,87 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "ProjectEcosystem",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allProjectPrefinanceTimelineStatus",
+            "description": null,
+            "args": [
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProjectPrefinanceTimelineStatusFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sort",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ProjectPrefinanceTimelineStatusSorting",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "Max documents to return",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Offset at which to start returning documents from",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProjectPrefinanceTimelineStatus",
                     "ofType": null
                   }
                 }
@@ -60115,6 +62770,18 @@
                   "ofType": null
                 }
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_defined",
+            "description": "Checks if the value is defined.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,


### PR DESCRIPTION
## Description

Closes: regen-network/rnd-dev-team#1907
Depends on: https://github.com/regen-network/regen-sanity/pull/58

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

**Marketplace**
Credit class page: https://deploy-preview-2324--regen-marketplace.netlify.app/credit-classes/USP01
Project page: https://deploy-preview-2324--regen-marketplace.netlify.app/project/USP01-001

**Website**
Updated the green tag on the featured credits cards to use credit category instead of credit type too (although that doesn't change anything visually):
https://deploy-preview-2324--regen-website.netlify.app
https://deploy-preview-2324--regen-website.netlify.app/buyers


### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
