### PR TITLE
fix: APP-92 create batch form projects dropdown shows projects by admin instead of class issuers

### DIFF
--- a/web-marketplace/src/features/ecocredit/CreateBatchBySteps/CreateBatchMultiStepForm/CreditBasics.tsx
+++ b/web-marketplace/src/features/ecocredit/CreateBatchBySteps/CreateBatchMultiStepForm/CreditBasics.tsx
@@ -25,6 +25,7 @@ import {
 import { Body } from 'web-components/src/components/typography';
 import { Theme } from 'web-components/src/theme/muiTheme';
 
+import { useAuth } from 'lib/auth/auth';
 import { NameUrl } from 'lib/rdf/types';
 
 import { AddCertificationModal } from 'components/organisms/Modals/AddCertificationModal/AddCertificationModal';
@@ -100,7 +101,10 @@ export default function CreditBasics({
   saveProjectOptionSelected,
 }: Props): React.ReactElement {
   const { wallet } = useWallet();
-  const projects = useQueryProjectsByIssuer(wallet!.address); // TODO: We should not use the typescript bypass! here (should try to avoid using period)
+  const { activeAccount } = useAuth();
+  const projects = useQueryProjectsByIssuer(
+    activeAccount?.addr || wallet?.address,
+  );
 
   const { values, validateForm } = useFormikContext<CreditBasicsFormValues>();
   const { projectId } = values;

--- a/web-marketplace/src/features/ecocredit/CreateBatchBySteps/CreateBatchMultiStepForm/CreditBasics.tsx
+++ b/web-marketplace/src/features/ecocredit/CreateBatchBySteps/CreateBatchMultiStepForm/CreditBasics.tsx
@@ -103,7 +103,7 @@ export default function CreditBasics({
   const { wallet } = useWallet();
   const { activeAccount } = useAuth();
   const projects = useQueryProjectsByIssuer(
-    activeAccount?.addr || wallet?.address,
+    activeAccount?.addr ?? wallet?.address,
   );
 
   const { values, validateForm } = useFormikContext<CreditBasicsFormValues>();

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { ProjectInfo } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 import { useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -29,7 +30,6 @@ import { useClassesWithMetadata } from 'hooks/classes/useClassesWithMetadata';
 
 import { useLastRandomProjects } from './useLastRandomProjects';
 import { selectProjects } from './useProjectsWithOrders.utils';
-import { useMemo } from 'react';
 
 export interface ProjectsWithOrdersProps {
   limit?: number;

--- a/web-marketplace/src/hooks/useQueryProjectsByIssuer.ts
+++ b/web-marketplace/src/hooks/useQueryProjectsByIssuer.ts
@@ -13,7 +13,7 @@ import { getClassesByIssuerQuery } from 'lib/queries/react-query/registry-server
 import { useLedger } from '../ledger';
 import type { ProjectWithMetadataObj as Project } from '../types/ledger/ecocredit';
 
-export default function useQueryProjectsByIssuer(issuer: string): Project[] {
+export default function useQueryProjectsByIssuer(issuer?: string): Project[] {
   const graphqlClient =
     useApolloClient() as ApolloClient<NormalizedCacheObject>;
   const { ecocreditClient, dataClient } = useLedger();

--- a/web-marketplace/src/types/ledger/ecocredit.ts
+++ b/web-marketplace/src/types/ledger/ecocredit.ts
@@ -43,7 +43,7 @@ export type ClassID = 'C01' | 'C02' | 'C03';
 type GenericObject = { [key: string]: any };
 
 export interface ProjectWithMetadataObj extends Omit<ProjectInfo, 'metadata'> {
-  metadata: GenericObject;
+  metadata?: GenericObject;
 }
 
 export type BridgedTxStatus =


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-92?atlOrigin=eyJpIjoiMmEyMDFhNzBkN2Q1NDk3YTk2NTRmOWM0OGMwMWY4Y2MiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

**While testing, please be aware that getting the list of projects you can issue credits to is based on an indexer based query for getting classes by issuer address and the staging indexer database is pruned so you might not see all classes you actually an issuer of on dev / deploy previews (this won't be the case on prod since the indexer db is not pruned there of course)**

From https://deploy-preview-2342--regen-marketplace.netlify.app/ecocredits/create-batch
login with an account that is an issuer and check out the projects you can issue credits to

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
