### PR TITLE
fix: APP-95 projects from a Keplr wallet login show up when logged in via a new account

### DIFF
--- a/patches/@ledgerhq+live-network+1.1.7.patch
+++ b/patches/@ledgerhq+live-network+1.1.7.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/@ledgerhq/live-network/lib-es/network.js b/node_modules/@ledgerhq/live-network/lib-es/network.js
+index 41aa14e..f710a9e 100644
+--- a/node_modules/@ledgerhq/live-network/lib-es/network.js
++++ b/node_modules/@ledgerhq/live-network/lib-es/network.js
+@@ -4,6 +4,7 @@ import { retry } from "@ledgerhq/live-promise";
+ import { log } from "@ledgerhq/logs";
+ import axios from "axios";
+ import invariant from "invariant";
++import { HttpsAgent } from 'agentkeepalive';
+ export const requestInterceptor = (request) => {
+     if (!getEnv("ENABLE_NETWORK_LOGS")) {
+         return request;
+@@ -72,8 +73,7 @@ if (!(typeof navigator !== "undefined" && navigator.product === "ReactNative"))
+     // the keepAlive is necessary when we make a lot of request in in parallel, especially for bitcoin sync. Otherwise, it may raise "connect ETIMEDOUT" error
+     // refer to https://stackoverflow.com/questions/63064393/getting-axios-error-connect-etimedout-when-making-high-volume-of-calls
+     // eslint-disable-next-line global-require,@typescript-eslint/no-var-requires
+-    const https = require("https");
+-    axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });
++    axios.defaults.httpsAgent = new HttpsAgent({ keepAlive: true });
+ }
+ const makeError = (msg, status, url, method) => {
+     const obj = {
+diff --git a/node_modules/@ledgerhq/live-network/src/network.ts b/node_modules/@ledgerhq/live-network/src/network.ts
+index de91e00..9fa132f 100644
+--- a/node_modules/@ledgerhq/live-network/src/network.ts
++++ b/node_modules/@ledgerhq/live-network/src/network.ts
+@@ -5,6 +5,7 @@ import { log } from "@ledgerhq/logs";
+ import type { AxiosError, AxiosRequestConfig, Method } from "axios";
+ import axios, { AxiosPromise, AxiosResponse } from "axios";
+ import invariant from "invariant";
++import { HttpsAgent } from 'agentkeepalive';
+ 
+ type Metadata = { startTime: number };
+ type ExtendedXHRConfig = AxiosRequestConfig & { metadata?: Metadata };
+@@ -104,8 +105,7 @@ if (!(typeof navigator !== "undefined" && navigator.product === "ReactNative"))
+   // the keepAlive is necessary when we make a lot of request in in parallel, especially for bitcoin sync. Otherwise, it may raise "connect ETIMEDOUT" error
+   // refer to https://stackoverflow.com/questions/63064393/getting-axios-error-connect-etimedout-when-making-high-volume-of-calls
+   // eslint-disable-next-line global-require,@typescript-eslint/no-var-requires
+-  const https = require("https");
+-  axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });
++  axios.defaults.httpsAgent = new HttpsAgent({ keepAlive: true });
+ }
+ 
+ const makeError = (msg: string, status: number, url: string | undefined, method: Method | "") => {

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
@@ -23,12 +23,12 @@ const MyProjects = (): JSX.Element => {
   const { isIssuer, isProjectAdmin } = useDashboardContext();
   const { track } = useTracker();
   const [projectsCurrentStep] = useAtom(projectsCurrentStepAtom);
-  const { wallet } = useWallet();
+  const { wallet, loginDisabled } = useWallet();
   const { activeAccountId, activeAccount } = useAuth();
 
   const { adminProjects, isLoadingAdminProjects } = useFetchProjectByAdmin({
     adminAccountId: activeAccountId,
-    adminAddress: activeAccount?.addr ?? wallet?.address,
+    adminAddress: loginDisabled ? wallet?.address : activeAccount?.addr,
     keepUnpublished: true,
   });
 


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-95?atlOrigin=eyJpIjoiMTNlOTgxY2YwOWIyNDZhMThmNDgzNGNhZDY2Njc2YjAiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2345--regen-marketplace.netlify.app/
This can be tested if you login with a web3 account, then wait enough for the login session to expire (24 hours) or for testing purposes in order to mimic that, you can just open the dev tool, go to "Application" tab, then cookies and delete the two cookies with name session and session.sig and reload. You'll get logged out.
Finally, log back in with another web2 account. You should only see the projects from this web2 account, while if you do the same on dev.app.regen.network, you'll also get the projects from the web3 account.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
