### PR TITLE
fix: APP-128 only display 'or, log in with email/social' if wallets available in log in modal

### DIFF
--- a/web-marketplace/src/components/organisms/LoginModal/components/LoginModal.Select.tsx
+++ b/web-marketplace/src/components/organisms/LoginModal/components/LoginModal.Select.tsx
@@ -49,7 +49,7 @@ const LoginModalSelect = ({
               user guide.
             </Link>
           </Body>
-          <LoginModalProviders providers={wallets} />(
+          <LoginModalProviders providers={wallets} />
           <Grid container alignItems="center" pb={7.5} spacing={7.5} pt={5}>
             <Grid item xs={4}>
               <Box sx={{ height: '1px', backgroundColor: 'grey.100' }} />
@@ -63,7 +63,6 @@ const LoginModalSelect = ({
               <Box sx={{ height: '1px', backgroundColor: 'grey.100' }} />
             </Grid>
           </Grid>
-          )
         </>
       )}
       <Body


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-128?atlOrigin=eyJpIjoiNWFiZWRmMThhMTllNDYxNWJhODU4YjlhMWQ3NjU1MzYiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2364--regen-marketplace.netlify.app/, click on "List a project" in the header **while being logged out on mobile**. The section with "learn more about wallets" and "or, log in with email/social" should be hidden. On desktop, it should be unchanged.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
