### PR TITLE
fix: APP-102 truncate profile name/email in user menu

### DIFF
--- a/web-components/src/components/header/components/UserMenuItems.tsx
+++ b/web-components/src/components/header/components/UserMenuItems.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import BreadcrumbIcon from '../../icons/BreadcrumbIcon';
+import { LogOutIcon } from '../../icons/LogOutIcon';
 import { Body } from '../../typography';
 import UserAvatar from '../../user/UserAvatar';
 import { HeaderDropdownItemProps } from './HeaderDropdown/HeaderDropdown.Item';
 import { HeaderMenuItemBase } from './HeaderMenuItem/HeaderMenuItem';
 import { UserMenuItem } from './UserMenuItem';
-import { LogOutIcon } from '../../icons/LogOutIcon';
-import BreadcrumbIcon from '../../icons/BreadcrumbIcon';
 
 interface UserMenuItemsProps extends HeaderMenuItemBase {
   nameOrAddress?: string | null;
@@ -32,7 +32,7 @@ const UserMenuItems: React.FC<React.PropsWithChildren<UserMenuItemsProps>> = ({
       item={{
         renderTitle: () => (
           <div className="flex justify-between items-center text-sm w-[164px] sm:w-[194px]">
-            <div className="flex items-center">
+            <div className="flex items-center truncate">
               <UserAvatar
                 size="small"
                 sx={{
@@ -41,7 +41,7 @@ const UserMenuItems: React.FC<React.PropsWithChildren<UserMenuItemsProps>> = ({
                 alt="default avatar"
                 src={avatar}
               />
-              {nameOrAddress}
+              <span className="truncate">{nameOrAddress}</span>
             </div>
             <BreadcrumbIcon className="w-[12px] h-[12px] text-grey-700 mr-10" />
           </div>


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-102?atlOrigin=eyJpIjoiZTcwMTgxYzNiNTgwNDEyOWIzNmMyNDIxN2JhNDA2NDYiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2368--regen-marketplace.netlify.app/, log in with an account with a long name or a web2 account with no name but somewhat long email. Those should now be truncated in the user menu.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
