### PR TITLE
fix: APP-147 project size always displayed as hectares in BasicInfoForm

### DIFF
--- a/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/BasicInfoForm/BasicInfoForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useFormState } from 'react-hook-form';
+import { useFormState, useWatch } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { Box } from '@mui/material';
 import { ERRORS, errorsMapping } from 'config/errors';
@@ -62,6 +62,10 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
   });
   const { isValid, isSubmitting, isDirty, errors } = useFormState({
     control: form.control,
+  });
+  const unit = useWatch({
+    control: form.control,
+    name: 'regen:projectSize.qudt:unit',
   });
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
   const { confirmSave, isEdit, isDirtyRef } = useProjectEditContext();
@@ -177,6 +181,7 @@ const BasicInfoForm: React.FC<BasicInfoFormProps> = ({
               ]}
               defaultStyle={false}
               native={false}
+              value={unit}
               {...form.register('regen:projectSize.qudt:unit')}
             />
           </Box>


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-147?atlOrigin=eyJpIjoiNmM4NzUwMzQzODVhNDM5MWI4NjAwNDY5MWU4N2I3Y2EiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2386--regen-marketplace.netlify.app/, create or edit a new project.
Update the project size to use "acres" and save.
Going back to the basic info form, it should show the right size unit.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
