### PR TITLE
fix: APP-178 display UTC batch start/end dates

### DIFF
--- a/web-marketplace/src/components/organisms/EcocreditsTable.tsx
+++ b/web-marketplace/src/components/organisms/EcocreditsTable.tsx
@@ -125,8 +125,8 @@ export const EcocreditsTable: React.FC<
           <WithLoader isLoading={!row.denom} variant="skeleton">
             <AccountLink address={row.issuer} />
           </WithLoader>,
-          <GreyText>{formatDate(row.startDate)}</GreyText>,
-          <GreyText>{formatDate(row.endDate)}</GreyText>,
+          <GreyText>{formatDate(row.startDate, undefined, true)}</GreyText>,
+          <GreyText>{formatDate(row.endDate, undefined, true)}</GreyText>,
           <WithLoader isLoading={row.projectLocation === ''} variant="skeleton">
             <Box>{row.projectLocation}</Box>
           </WithLoader>,


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-178?atlOrigin=eyJpIjoiM2Q3M2QyMmZjMTYwNGYyZjliZjhjNTlkYWNlMWNlOTQiLCJwIjoiaiJ9

closes: #2353

We were displaying the batch start/end dates on the portfolio page in local time, instead of UTC, which might result in Jan 1 being displayed as Dec 31 for people in the US.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

https://deploy-preview-2391--regen-marketplace.netlify.app/profiles/regen1cg9l00yfr8ckxc0wnxag6ss96grdzsdmtl97w5/portfolio

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
