### PR TITLE
fix: APP-138 long story text width

### DIFF
--- a/web-components/src/components/read-more/index.tsx
+++ b/web-components/src/components/read-more/index.tsx
@@ -102,7 +102,12 @@ const ReadMore: React.FC<React.PropsWithChildren<ReadMoreProps>> = ({
               </Body>
             )}
             {rest.map((text, i) => (
-              <Body component={component} size={size} mobileSize={mobileSize}>
+              <Body
+                component={component}
+                size={size}
+                mobileSize={mobileSize}
+                key={i}
+              >
                 {sentenceBased && rest && i === 0 && expanded && (
                   <>
                     <br />

--- a/web-marketplace/src/components/organisms/ProjectStorySection/ProjectStorySection.tsx
+++ b/web-marketplace/src/components/organisms/ProjectStorySection/ProjectStorySection.tsx
@@ -35,7 +35,7 @@ export function ProjectStorySection({
           <StoryText
             storyTitle={storyTitle}
             story={story}
-            hasMedia={!!storyMedia}
+            hasMedia={!!storyMedia?.['schema:url']}
           />
         )}
         {storyMedia?.['schema:url'] && (


### PR DESCRIPTION
## Description

I've added:

- A missing key prop in ReadMore component.
- Updated the hasMedia prop in StoryText to check for a media url 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

Create a new project with a Long-form project story and no media, then visit the project page and open the Read More

- Marketplace: https://deploy-preview-2392--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
