### PR TITLE
fix APP-193 hide project create modal

### DIFF
--- a/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
+++ b/web-marketplace/src/pages/BasicInfo/BasicInfo.tsx
@@ -37,8 +37,8 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
     }),
     [metadata],
   );
-
-  const { creditClassOnChainId } = useCreateProjectContext();
+  const { creditClassOnChainId, hasModalBeenViewed, setHasModalBeenViewed } =
+    useCreateProjectContext();
   const { data: sanityCreateProjectPageData } = useQuery(
     getAllCreateProjectPageQuery({ sanityClient, enabled: !!sanityClient }),
   );
@@ -52,6 +52,11 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
     [isEdit, creditClassOnChainId, sanityCreateProjectPageData],
   );
 
+  const onClose = () => {
+    setOpen(false);
+    setHasModalBeenViewed(true);
+  };
+
   return (
     <ProjectFormTemplate
       isEdit={isEdit}
@@ -61,11 +66,11 @@ const BasicInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
       loading={loading}
     >
       <BasicInfoForm onSubmit={metadataSubmit} initialValues={initialValues} />
-      {sanityCreateProjectPageData && (
+      {sanityCreateProjectPageData && !hasModalBeenViewed && (
         <CreateProjectPageModal
           sanityCreateProjectPageData={sanityCreateProjectPageData}
           open={open}
-          onClose={() => setOpen(false)}
+          onClose={onClose}
         />
       )}
     </ProjectFormTemplate>

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { GeocodeFeature } from '@mapbox/mapbox-sdk/services/geocoding';
 import { Grid } from '@mui/material';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 
 import { CreateProjectCard } from 'web-components/src/components/cards/CreateCards/CreateProjectCard';
 import ProjectCard from 'web-components/src/components/cards/ProjectCard';
@@ -11,14 +11,20 @@ import { useAuth } from 'lib/auth/auth';
 import { useTracker } from 'lib/tracker/useTracker';
 import { useWallet } from 'lib/wallet/wallet';
 
-import { projectsCurrentStepAtom } from 'pages/ProjectCreate/ProjectCreate.store';
+import {
+  projectsCurrentStepAtom,
+  projectsDraftState,
+} from 'pages/ProjectCreate/ProjectCreate.store';
 import WithLoader from 'components/atoms/WithLoader';
 import { PostFlow } from 'components/organisms/PostFlow/PostFlow';
 
 import { useDashboardContext } from '../Dashboard.context';
 import { useFetchProjectByAdmin } from './hooks/useFetchProjectsByAdmin';
 import { CREATE_POST, DRAFT_ID } from './MyProjects.constants';
-import { getDefaultProject } from './MyProjects.utils';
+import {
+  getDefaultProject,
+  handleProjectsDraftStatus,
+} from './MyProjects.utils';
 
 const MyProjects = (): JSX.Element => {
   const navigate = useNavigate();
@@ -43,6 +49,14 @@ const MyProjects = (): JSX.Element => {
     string | undefined
   >();
   const [postProjectName, setPostProjectName] = useState<string | undefined>();
+
+  const setProjectsDraftState = useSetAtom(projectsDraftState);
+
+  useEffect(() => {
+    setProjectsDraftState(prevState =>
+      handleProjectsDraftStatus(prevState, adminProjects),
+    );
+  }, [adminProjects, setProjectsDraftState]);
 
   return (
     <>

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.utils.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.utils.tsx
@@ -1,7 +1,9 @@
 import { ProjectCardProps } from 'web-components/src/components/cards/ProjectCard';
 import EditIcon from 'web-components/src/components/icons/EditIcon';
 
+import { ProjectsDraftStatus } from 'pages/ProjectCreate/ProjectCreate.store';
 import { EDIT_PROJECT } from 'pages/ProjectEdit/ProjectEdit.constants';
+import { ProjectWithOrderData } from 'pages/Projects/AllProjects/AllProjects.types';
 
 export const getDefaultProject = (disabled: boolean): ProjectCardProps => ({
   name: '',
@@ -19,3 +21,30 @@ export const getDefaultProject = (disabled: boolean): ProjectCardProps => ({
     disabled,
   },
 });
+
+export const handleProjectsDraftStatus = (
+  state: ProjectsDraftStatus,
+  projects: ProjectWithOrderData[],
+): ProjectsDraftStatus => {
+  let newState = [...state];
+
+  projects.forEach(project => {
+    const projectIndex = newState.findIndex(item => item.id === project.id);
+
+    if (projectIndex === -1) {
+      // Project does not exist, add it
+      newState.push({
+        id: project.id,
+        draft: project.offChain && !project.published,
+      });
+    } else {
+      // Project exists, update its 'draft' status
+      newState[projectIndex] = {
+        ...newState[projectIndex],
+        draft: project.offChain && !project.published,
+      };
+    }
+  });
+
+  return newState;
+};

--- a/web-marketplace/src/pages/ProjectCreate/ProjectCreate.store.tsx
+++ b/web-marketplace/src/pages/ProjectCreate/ProjectCreate.store.tsx
@@ -1,10 +1,18 @@
+import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
 type ProjectsCurrentStep = {
   [id: string]: string;
 };
+type ProjectDraftStatus = {
+  id: string;
+  draft: boolean | undefined;
+};
+export type ProjectsDraftStatus = ProjectDraftStatus[] | [];
 
 export const projectsCurrentStepAtom = atomWithStorage(
   'projectsCurrentStep',
   {} as ProjectsCurrentStep,
 );
+
+export const projectsDraftState = atom<ProjectsDraftStatus>([]);

--- a/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
+++ b/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
@@ -1,6 +1,7 @@
 import { createContext, MutableRefObject, useRef, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 import { DeliverTxResponse } from '@cosmjs/stargate';
+
 import { FormRef } from 'components/molecules/Form/Form';
 
 type ContextType = {
@@ -8,11 +9,13 @@ type ContextType = {
   setDeliverTxResponse: (deliverTxResponse?: DeliverTxResponse) => void;
   creditClassId?: string;
   setCreditClassId: (creditClassId?: string) => void;
-  formRef?: FormRef;
   creditClassOnChainId?: string;
   setCreditClassOnChainId: (creditClassId?: string) => void;
+  formRef?: FormRef;
   shouldNavigateRef?: MutableRefObject<boolean>;
   isDraftRef?: MutableRefObject<boolean>;
+  hasModalBeenViewed?: boolean;
+  setHasModalBeenViewed: (state: boolean) => void;
 };
 
 const defaultProjectCreateContext = createContext<ContextType>({
@@ -25,6 +28,8 @@ const defaultProjectCreateContext = createContext<ContextType>({
   formRef: undefined,
   shouldNavigateRef: undefined,
   isDraftRef: undefined,
+  hasModalBeenViewed: false,
+  setHasModalBeenViewed: () => {},
 });
 
 export const ProjectCreate = (): JSX.Element => {
@@ -33,6 +38,7 @@ export const ProjectCreate = (): JSX.Element => {
     useState<DeliverTxResponse>();
   const [creditClassId, setCreditClassId] = useState<string>('');
   const [creditClassOnChainId, setCreditClassOnChainId] = useState<string>('');
+  const [hasModalBeenViewed, setHasModalBeenViewed] = useState(false);
   const formRef = useRef();
   const shouldNavigateRef = useRef(true);
   const isDraftRef = useRef(false);
@@ -49,6 +55,8 @@ export const ProjectCreate = (): JSX.Element => {
         formRef,
         shouldNavigateRef,
         isDraftRef,
+        hasModalBeenViewed,
+        setHasModalBeenViewed,
       }}
     />
   );

--- a/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
+++ b/web-marketplace/src/pages/ProjectCreate/ProjectCreate.tsx
@@ -1,8 +1,11 @@
 import { createContext, MutableRefObject, useRef, useState } from 'react';
-import { Outlet, useOutletContext } from 'react-router-dom';
+import { Outlet, useOutletContext, useParams } from 'react-router-dom';
 import { DeliverTxResponse } from '@cosmjs/stargate';
+import { useAtom } from 'jotai';
 
 import { FormRef } from 'components/molecules/Form/Form';
+
+import { projectsDraftState, ProjectsDraftStatus } from './ProjectCreate.store';
 
 type ContextType = {
   deliverTxResponse?: DeliverTxResponse;
@@ -36,9 +39,13 @@ export const ProjectCreate = (): JSX.Element => {
   // TODO: possibly replace these with `useMsgClient` and pass downstream
   const [deliverTxResponse, setDeliverTxResponse] =
     useState<DeliverTxResponse>();
+  const [projectsState] = useAtom<ProjectsDraftStatus>(projectsDraftState);
+  const { projectId } = useParams();
   const [creditClassId, setCreditClassId] = useState<string>('');
   const [creditClassOnChainId, setCreditClassOnChainId] = useState<string>('');
-  const [hasModalBeenViewed, setHasModalBeenViewed] = useState(false);
+  const [hasModalBeenViewed, setHasModalBeenViewed] = useState(
+    projectsState?.find(project => project.id === projectId)?.draft,
+  );
   const formRef = useRef();
   const shouldNavigateRef = useRef(true);
   const isDraftRef = useRef(false);


### PR DESCRIPTION
## Description

I have added props to the ProjectCreate context to track modal state and then hide the modal when already viewed.
The modal will also be hidden for projects that are in Draft status.

Issue: https://regennetwork.atlassian.net/browse/APP-193

---

### Author Checklist

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. Go to the Marketplace>Projects>Create New Project. Click Continue in the modal window and fill up the form then click "Save and Next". On the Location page click the back button in the footer. 
2. The modal window shouldn't show up again. 

Marketplace:  https://deploy-preview-2399--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
