### PR TITLE
fix: temporarily remove `regen:projectDeveloper` from Project Metadata form omitted keys

### DIFF
--- a/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.config.ts
+++ b/web-marketplace/src/pages/ProjectMetadata/ProjectMetadata.config.ts
@@ -6,6 +6,6 @@ export const OMITTED_METADATA_KEYS = [
   'schema:name',
   'regen:projectSize',
   'schema:location',
-  'regen:projectDeveloper',
+  // 'regen:projectDeveloper', Temporarily remove from omitted key while Roles form is hidden
   ...UNANCHORED_PROJECT_KEYS,
 ];


### PR DESCRIPTION
## Description

ref: https://regennetwork.atlassian.net/browse/APP-207

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2400--regen-marketplace.netlify.app/, create or edit an on chain project and go to the Metadata form, add some value for `regen:projectDeveloper`. This should be saved in the on chain metadata.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
