### PR TITLE
feat: APP-200 create post close confirmation modal

### DIFF
--- a/web-components/src/components/modal/SaveChangesWarningModal/SaveChangesWarningModal.tsx
+++ b/web-components/src/components/modal/SaveChangesWarningModal/SaveChangesWarningModal.tsx
@@ -7,7 +7,7 @@ interface Props extends RegenModalProps {
   navigate: () => void;
 }
 
-export const WarningModal = ({ open, onClose, navigate }: Props) => {
+export const SaveChangesWarningModal = ({ open, onClose, navigate }: Props) => {
   return (
     <SadBeeModal open={open} onClose={onClose}>
       <Title variant="h4" align="center" sx={{ my: 5 }}>

--- a/web-components/src/components/modal/modal.stories.tsx
+++ b/web-components/src/components/modal/modal.stories.tsx
@@ -8,6 +8,7 @@ import { BasketTakeModal } from './BasketTakeModal';
 import { ConfirmModal } from './ConfirmModal';
 import CropImageModal from './CropImageModal';
 import { ProcessingModal } from './ProcessingModal';
+import { SaveChangesWarningModal } from './SaveChangesWarningModal/SaveChangesWarningModal';
 import { TxErrorModal } from './TxErrorModal';
 import { TxSuccessfulModal } from './TxSuccessfulModal';
 
@@ -204,5 +205,13 @@ export const basketTakeModal = (): JSX.Element => (
     mapboxToken={MAPBOX_TOKEN}
     onClose={() => null}
     onSubmit={() => alert('submit')}
+  />
+);
+
+export const saveChangesWarningModal = (): JSX.Element => (
+  <SaveChangesWarningModal
+    open={true}
+    onClose={() => null}
+    navigate={() => null}
   />
 );

--- a/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
+++ b/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
@@ -1,5 +1,10 @@
 import { MutableRefObject, useEffect, useState } from 'react';
-import { SubmitHandler, useFieldArray, useWatch } from 'react-hook-form';
+import {
+  SubmitHandler,
+  useFieldArray,
+  useFormState,
+  useWatch,
+} from 'react-hook-form';
 import { GeocodeFeature } from '@mapbox/mapbox-sdk/services/geocoding';
 import { MAPBOX_TOKEN } from 'config/globals';
 import { Feature, Point } from 'geojson';
@@ -59,6 +64,7 @@ export interface Props {
       }
     | undefined
   >;
+  onUpdateDirtyState?: (isDirty: boolean) => void;
 }
 
 export const PostForm = ({
@@ -70,6 +76,7 @@ export const PostForm = ({
   onSubmit,
   fileNamesToDeleteRef,
   handleUpload,
+  onUpdateDirtyState,
 }: Props): JSX.Element => {
   const form = useZodForm({
     schema: postFormSchema,
@@ -181,6 +188,24 @@ export const PostForm = ({
       });
     }
   }, [append, fields, projectLocation]);
+
+  const { dirtyFields } = useFormState({
+    control: form.control,
+  });
+
+  const isFormDirty = (
+    Object.keys(dirtyFields) as Array<keyof PostFormSchemaType>
+  ).some(key =>
+    key === 'files'
+      ? dirtyFields.files && dirtyFields.files.length > 1
+      : dirtyFields[key] === true,
+  );
+
+  useEffect(() => {
+    if (onUpdateDirtyState) {
+      onUpdateDirtyState(isFormDirty);
+    }
+  }, [isFormDirty, onUpdateDirtyState]);
 
   return (
     <Form

--- a/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
+++ b/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
@@ -1,10 +1,5 @@
 import { MutableRefObject, useEffect, useState } from 'react';
-import {
-  SubmitHandler,
-  useFieldArray,
-  useFormState,
-  useWatch,
-} from 'react-hook-form';
+import { SubmitHandler, useFieldArray, useWatch } from 'react-hook-form';
 import { GeocodeFeature } from '@mapbox/mapbox-sdk/services/geocoding';
 import { MAPBOX_TOKEN } from 'config/globals';
 import { Feature, Point } from 'geojson';
@@ -87,7 +82,7 @@ export const PostForm = ({
   });
   const { classes } = useMediaFormStyles();
   const { classes: textAreaClasses } = useMetadataFormStyles();
-  const { errors, isValid } = form.formState;
+  const { errors, isValid, dirtyFields } = form.formState;
   const { setValue } = form;
 
   const imageDropCommonProps: Partial<FileDropProps> = {
@@ -188,10 +183,6 @@ export const PostForm = ({
       });
     }
   }, [append, fields, projectLocation]);
-
-  const { dirtyFields } = useFormState({
-    control: form.control,
-  });
 
   const isFormDirty = (
     Object.keys(dirtyFields) as Array<keyof PostFormSchemaType>

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
@@ -147,6 +147,12 @@ const MyProjects = (): JSX.Element => {
           offChainProjectId={postOffChainProjectId}
           projectName={postProjectName}
           projectSlug={postProjectSlug}
+          initialValues={{
+            title: '',
+            comment: '',
+            files: [],
+            privacyType: 'public',
+          }}
         />
       )}
     </>

--- a/web-marketplace/src/pages/ProfileEdit/ProfileEdit.tsx
+++ b/web-marketplace/src/pages/ProfileEdit/ProfileEdit.tsx
@@ -6,6 +6,7 @@ import { startCase } from 'lodash';
 
 import { Flex } from 'web-components/src/components/box';
 import ArrowDownIcon from 'web-components/src/components/icons/ArrowDownIcon';
+import { SaveChangesWarningModal } from 'web-components/src/components/modal/SaveChangesWarningModal/SaveChangesWarningModal';
 import { Title } from 'web-components/src/components/typography';
 import { cn } from 'web-components/src/utils/styles/cn';
 
@@ -13,7 +14,6 @@ import { isProfileEditDirtyRef } from 'lib/atoms/ref.atoms';
 import { useAuth } from 'lib/auth/auth';
 import { useWallet } from 'lib/wallet/wallet';
 
-import { WarningModal } from 'pages/ProjectEdit/ProjectEdit.WarningModal';
 import WithLoader from 'components/atoms/WithLoader';
 
 import { usePathSection } from './hooks/usePathSection';
@@ -114,7 +114,7 @@ export const ProfileEdit = () => {
           </WithLoader>
         </Flex>
       </div>
-      <WarningModal
+      <SaveChangesWarningModal
         open={!!isWarningModalOpen}
         navigate={() => {
           if (isWarningModalOpen) navigate(isWarningModalOpen);

--- a/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
+++ b/web-marketplace/src/pages/ProjectEdit/ProjectEdit.tsx
@@ -16,6 +16,7 @@ import { startCase } from 'lodash';
 
 import Banner from 'web-components/src/components/banner';
 import ArrowDownIcon from 'web-components/src/components/icons/ArrowDownIcon';
+import { SaveChangesWarningModal } from 'web-components/src/components/modal/SaveChangesWarningModal/SaveChangesWarningModal';
 import { Label, Title } from 'web-components/src/components/typography';
 import type { Theme } from 'web-components/src/theme/muiTheme';
 
@@ -48,7 +49,6 @@ import useProjectEditSubmit, {
 import { EDIT_PROJECT } from './ProjectEdit.constants';
 import { ProjectEditNav } from './ProjectEdit.Nav';
 import { useProjectEditStyles } from './ProjectEdit.styles';
-import { WarningModal } from './ProjectEdit.WarningModal';
 
 type ContextType = {
   confirmSave?: () => void;
@@ -268,7 +268,7 @@ function ProjectEdit(): JSX.Element {
             </div>
           </div>
           {saved && <Banner text="Changes have been saved" />}
-          <WarningModal
+          <SaveChangesWarningModal
             open={!!isWarningModalOpen}
             navigate={() => {
               if (isWarningModalOpen) navigate(isWarningModalOpen);


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-200

- Added a confirmation modal to prevent accidental post deletion when creating a new post.
- Refactored the confirmation modal used in Edit Profile and Edit Project into a new component to improve reusability.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. On the `Dashboard>Projects` create a new post. If any information is added to the new post form and then click on Close X button or Cancel button a confirmation modal should popup .
2. Please also verify that confirmation modals are still working as expected in the Edit Profile and Edit Project forms.

Marketplace: https://deploy-preview-2405--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
