### PR TITLE
chore: APP-157 use 'create project' instead of 'list a project'

### DIFF
--- a/web-marketplace/src/components/organisms/ListProject/ListProject.constants.ts
+++ b/web-marketplace/src/components/organisms/ListProject/ListProject.constants.ts
@@ -1,1 +1,1 @@
-export const LIST_PROJECT = '+List a project';
+export const CREATE_PROJECT = '+Create project';

--- a/web-marketplace/src/components/organisms/ListProject/ListProject.tsx
+++ b/web-marketplace/src/components/organisms/ListProject/ListProject.tsx
@@ -16,7 +16,7 @@ import { useQueryIsIssuer } from 'hooks/useQueryIsIssuer';
 import { useWallet } from '../../../lib/wallet/wallet';
 import { useLoginData } from '../LoginButton/hooks/useLoginData';
 import { LoginFlow } from '../LoginFlow/LoginFlow';
-import { LIST_PROJECT } from './ListProject.constants';
+import { CREATE_PROJECT } from './ListProject.constants';
 
 const ListProject = () => {
   const { wallet } = useWallet();
@@ -64,7 +64,7 @@ const ListProject = () => {
               : onButtonClick
           }
         >
-          {LIST_PROJECT}
+          {CREATE_PROJECT}
         </Body>
       )}
       <LoginFlow


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-157?atlOrigin=eyJpIjoiYzU3MTNmMDlhN2Y0NDM4NDg3NTEyYzg3ZjFjY2FhMDIiLCJwIjoiaiJ9

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Check that "create project" is used instead of "list a project" on https://deploy-preview-2421--regen-marketplace.netlify.app/

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
