### PR TITLE
fix: APP-294 mobile post map icons

### DIFF
--- a/web-components/src/components/organisms/PostFiles/PostFiles.Cards.Mobile.tsx
+++ b/web-components/src/components/organisms/PostFiles/PostFiles.Cards.Mobile.tsx
@@ -7,6 +7,7 @@ import { FileBody } from './components/FileBody';
 import { FilePreview } from './components/FilePreview';
 import { PostFile } from './PostFiles';
 import { useStyles } from './PostFiles.styles';
+import { FilesPreviews } from './PostFiles.types';
 
 type Props = {
   files: Array<PostFile>;
@@ -15,6 +16,7 @@ type Props = {
   setSelectedLocation: UseStateSetter<Point | undefined>;
   selectedUrl: string;
   setAnimateMarker: UseStateSetter<boolean>;
+  filesPreviews: FilesPreviews;
 };
 
 const PostFilesCardsMobile = ({
@@ -24,6 +26,7 @@ const PostFilesCardsMobile = ({
   setSelectedLocation,
   selectedUrl,
   setAnimateMarker,
+  filesPreviews,
 }: Props) => {
   const { classes: styles } = useStyles();
 
@@ -44,6 +47,7 @@ const PostFilesCardsMobile = ({
           className="relative bg-grey-0 h-[230px] rounded-[10px] border-[3px] border-solid border-grey-0"
         >
           <FilePreview
+            preview={file.url ? filesPreviews[file.url] : undefined}
             pdfPageHeight={183}
             className="rounded-t-[10px] h-[183px] overflow-hidden"
             file={file}

--- a/web-components/src/components/organisms/PostFiles/PostFiles.Public.tsx
+++ b/web-components/src/components/organisms/PostFiles/PostFiles.Public.tsx
@@ -245,6 +245,7 @@ const PostFilesPublic = ({
               }}
               setSelectedLocation={setSelectedLocation}
               setAnimateMarker={setAnimateMarker}
+              filesPreviews={filesPreviews}
             />
           )}
           {isAdmin && (privateLocations || privateFiles) && (

--- a/web-components/src/components/organisms/PostFiles/components/Buttons.tsx
+++ b/web-components/src/components/organisms/PostFiles/components/Buttons.tsx
@@ -10,7 +10,7 @@ const Buttons = ({ onClose, selectedUrl }: Props) => (
   <>
     <div
       onClick={onClose}
-      className="cursor-pointer absolute top-[13px] right-[13px]"
+      className="cursor-pointer absolute top-[13px] right-[13px] z-10"
     >
       <CloseIcon className="h-[24px] w-[24px] rounded-[50%] text-grey-0 bg-grey-700/[.6] p-3" />
     </div>
@@ -18,7 +18,7 @@ const Buttons = ({ onClose, selectedUrl }: Props) => (
       target="_blank"
       rel="noopener noreferrer"
       href={selectedUrl}
-      className="outline-none cursor-pointer absolute top-[13px] right-[47px]"
+      className="outline-none cursor-pointer absolute top-[13px] right-[47px] z-10"
     >
       <OpenInNewIcon className="h-[24px] w-[24px] rounded-[50%] text-grey-0 bg-grey-700/[.6] p-3" />
     </a>

--- a/web-components/src/components/organisms/PostFiles/components/TextOrIconFilePreview.tsx
+++ b/web-components/src/components/organisms/PostFiles/components/TextOrIconFilePreview.tsx
@@ -62,7 +62,7 @@ export const TextOrIconFilePreview = ({
       }
     };
   }, []);
-
+  console.log(preview);
   return (
     <div
       ref={parentRef}

--- a/web-components/src/components/organisms/PostFiles/components/TextOrIconFilePreview.tsx
+++ b/web-components/src/components/organisms/PostFiles/components/TextOrIconFilePreview.tsx
@@ -62,7 +62,7 @@ export const TextOrIconFilePreview = ({
       }
     };
   }, []);
-  console.log(preview);
+
   return (
     <div
       ref={parentRef}


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-294

Also adds file previews to mobile map view, which were missing.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2455--regen-marketplace.netlify.app/post/regen:13toVg51tcwo2J82Jc5JUmjLbKahxVdDgLcmwvTwFMgU2h5L7gc4Ptt.rdf, test the "open file" and "close" icon on mobile (or using desktop, toggling mobile view from the dev tools)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
