### PR TITLE
fix: APP-310 create post draft disabled

### DIFF
--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -229,10 +229,14 @@ function ProjectDetails(): JSX.Element {
   const publishedOffchainProjectById = offChainProjectById?.published
     ? offChainProjectById
     : undefined;
+  const publishedOffchainProjectBySlug = projectBySlug?.data?.projectBySlug
+    ?.published
+    ? projectBySlug?.data?.projectBySlug
+    : undefined;
 
   const offChainProject = isOnChainId
     ? projectByOnChainId?.data.projectByOnChainId
-    : publishedOffchainProjectById ?? projectBySlug?.data.projectBySlug;
+    : publishedOffchainProjectById ?? publishedOffchainProjectBySlug;
 
   /* Credit class */
 

--- a/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
+++ b/web-marketplace/src/lib/normalizers/projects/normalizeProjectsWithMetadata.ts
@@ -77,7 +77,7 @@ export const normalizeProjectsWithMetadata = ({
 };
 
 interface NormalizeProjectWithMetadataParams {
-  offChainProject?: Maybe<Pick<Project, 'id' | 'slug'>>;
+  offChainProject?: Maybe<Pick<Project, 'id' | 'slug' | 'published'>>;
   projectWithOrderData?: ProjectWithOrderData;
   projectMetadata?: AnchoredProjectMetadataBaseLD | undefined;
   projectPageMetadata?: ProjectPageMetadataLD;
@@ -134,6 +134,7 @@ export const normalizeProjectWithMetadata = ({
     id: projectId,
     offChainId: offChainProject?.id,
     slug: offChainProject?.slug ?? projectWithOrderData?.slug,
+    draft: !projectWithOrderData && !offChainProject?.published,
     name:
       projectMetadata?.['schema:name'] ||
       projectWithOrderData?.name ||

--- a/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
+++ b/web-marketplace/src/pages/Dashboard/MyProjects/MyProjects.tsx
@@ -100,7 +100,6 @@ const MyProjects = (): JSX.Element => {
                     }
                     {...getDefaultProject(!activeAccountId, _)}
                     {...project}
-                    draft={project.offChain && !project.published}
                     button={{
                       text: _(CREATE_POST),
                       disabled:


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-310

Also showing 404 page when accessing a draft project by **slug** (it was showing the full project page instead)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2457--regen-marketplace.netlify.app/profile/projects
Log in and on your projects page, check out that "create post" is disabled for any draft projects, even if they have a location.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
