### PR TITLE
fix: APP-296 set published to true after on chain project created

### DIFF
--- a/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
+++ b/web-marketplace/src/pages/ProjectReview/ProjectReview.tsx
@@ -107,6 +107,7 @@ export const ProjectReview: React.FC<React.PropsWithChildren<unknown>> = () => {
             id: projectId,
             projectPatch: {
               onChainId: projectOnChainId,
+              published: true,
               metadata: getUnanchoredProjectMetadata(
                 metadata,
                 projectOnChainId,


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-296

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Log in using a wallet address that is a class issuer and create an on-chain project.
After publishing it, check in the query result or the db that project.published is set to true.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
