### PR TITLE
fix: APP-295 set Edit Profile form as dirty on image change

### DIFF
--- a/web-marketplace/src/components/organisms/EditProfileForm/EditProfileForm.tsx
+++ b/web-marketplace/src/components/organisms/EditProfileForm/EditProfileForm.tsx
@@ -93,10 +93,10 @@ const EditProfileForm: React.FC<React.PropsWithChildren<EditProfileFormProps>> =
     /* Setter */
 
     const setProfileImage = ({ value }: { value: string }): void => {
-      form.setValue('profileImage', value);
+      form.setValue('profileImage', value, { shouldDirty: true });
     };
     const setBackgroundImage = ({ value }: { value: string }): void => {
-      form.setValue('backgroundImage', value);
+      form.setValue('backgroundImage', value, { shouldDirty: true });
     };
 
     /* Effect */

--- a/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.tsx
+++ b/web-marketplace/src/components/organisms/RolesForm/components/ProfileModal/ProfileModal.tsx
@@ -65,7 +65,7 @@ function ProfileModal({
   /* Setter */
 
   const setProfileImage = ({ value }: { value: string }): void => {
-    form.setValue('profileImage', value);
+    form.setValue('profileImage', value, { shouldDirty: true });
   };
 
   /* Effect */


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-295

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2459--regen-marketplace.netlify.app/
Log in and go to edit your profile.
Update your profile image or background image (without updating anything else). After successful image upload, the save button should be enabled and you can save the changes.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
