### PR TITLE
fix: APP-316 decoding file URLs

### DIFF
--- a/web-components/src/components/organisms/PostFiles/components/FilePreview.tsx
+++ b/web-components/src/components/organisms/PostFiles/components/FilePreview.tsx
@@ -52,7 +52,7 @@ const FilePreview = ({
       className={className}
       sx={theme => ({
         position: 'relative',
-        background: `${image ? `url(${url})` : `${theme.palette.grey[100]}`}`,
+        background: `${image ? `url("${url}")` : `${theme.palette.grey[100]}`}`,
         backgroundSize: 'contain',
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'center',

--- a/web-marketplace/src/components/organisms/EditFileForm/EditFileForm.tsx
+++ b/web-marketplace/src/components/organisms/EditFileForm/EditFileForm.tsx
@@ -80,7 +80,7 @@ export const EditFileForm = ({
           className="block m-auto pb-40 sm:pb-50"
           width="180px"
           height="100%"
-          src={url}
+          src={decodeURI(url)}
           alt="preview"
         />
       )}

--- a/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
+++ b/web-marketplace/src/components/organisms/PostForm/PostForm.tsx
@@ -137,7 +137,7 @@ export const PostForm = ({
         mimeType: '',
       });
     }
-    if (value) setValue(`files.${fieldIndex}.url`, encodeURI(value));
+    if (value) setValue(`files.${fieldIndex}.url`, decodeURI(value));
     if (mimeType) setValue(`files.${fieldIndex}.mimeType`, mimeType);
     if (name) setValue(`files.${fieldIndex}.name`, name);
     if (iri) setValue(`files.${fieldIndex}.iri`, iri);


### PR DESCRIPTION
## Description

Since I've merged https://github.com/regen-network/regen-server/pull/483, there was an issue when uploading data post file and previewing them on the form because we were not using the decoded URL.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Create a post and upload a file, if that's an image you should see the preview in the "edit file" form, then after submitting you should see the file preview in the list of files on the create post form.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
