### PR TITLE
fix: delete post success banner and redirect

### DIFF
--- a/web-marketplace/src/pages/Post/Post.Header.tsx
+++ b/web-marketplace/src/pages/Post/Post.Header.tsx
@@ -66,6 +66,7 @@ export const PostHeader = ({
   const { deletePost, open, onClose, onOpen } = useDelete({
     iri,
     projectHref,
+    offChainProjectId,
   });
 
   return (

--- a/web-marketplace/src/pages/Post/hooks/useDelete.ts
+++ b/web-marketplace/src/pages/Post/hooks/useDelete.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useLingui } from '@lingui/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { postData } from 'utils/fetch/postData';
@@ -21,6 +22,7 @@ type Params = {
 };
 
 export const useDelete = ({ iri, offChainProjectId, projectHref }: Params) => {
+  const { _ } = useLingui();
   const retryCsrfRequest = useRetryCsrfRequest();
   const { data: token } = useQuery(getCsrfTokenQuery({}));
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
@@ -45,7 +47,7 @@ export const useDelete = ({ iri, offChainProjectId, projectHref }: Params) => {
           token,
           parseTextResponse: true,
           retryCsrfRequest,
-          onSuccess: async _ => {
+          onSuccess: async () => {
             if (offChainProjectId) {
               await reactQueryClient.invalidateQueries({
                 queryKey: getPostsQueryKey({ projectId: offChainProjectId }),
@@ -68,6 +70,7 @@ export const useDelete = ({ iri, offChainProjectId, projectHref }: Params) => {
       }
     }
   }, [
+    _,
     iri,
     navigate,
     offChainProjectId,


### PR DESCRIPTION
## Description

Last minute bug fix: https://github.com/regen-network/regen-web/pull/2469#issuecomment-2343712072

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2471--regen-marketplace.netlify.app/, try to delete a post from the data stream section and the post page itself. It should show a success banner. From the post page, it should redirect to the updated data stream on the project page.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
