### PR TITLE
fix: prevent rendering LedgerProvider until wallet is loaded

### DIFF
--- a/web-marketplace/src/ledger.tsx
+++ b/web-marketplace/src/ledger.tsx
@@ -8,6 +8,8 @@ import { QueryClientImpl as BasketQueryClientImpl } from '@regen-network/api/lib
 import { QueryClientImpl as MarketplaceQueryClientImpl } from '@regen-network/api/lib/generated/regen/ecocredit/marketplace/v1/query';
 import { QueryClientImpl as EcocreditQueryClientImpl } from '@regen-network/api/lib/generated/regen/ecocredit/v1/query';
 
+import { Loading } from 'web-components/src/components/loading';
+
 import { useInitClient } from 'lib/clients/hooks/useInitClient';
 import { EcocreditQueryClient } from 'lib/ecocredit/api';
 import { MarketplaceQueryClient } from 'lib/ecocredit/marketplace/marketplace.types';
@@ -84,6 +86,11 @@ const getApi = async (
 export const LedgerProviderWithWallet: React.FC<React.PropsWithChildren<{}>> =
   ({ children }) => {
     const { wallet, loaded } = useWallet();
+
+    // Prevent rendering until wallet is loaded
+    if (!loaded) {
+      return <Loading className="h-screen" />;
+    }
 
     return (
       <LedgerProvider wallet={wallet} walletLoaded={loaded}>


### PR DESCRIPTION
## Description

Fixing issue when trying to sign transactions
ref: https://github.com/regen-network/regen-web/pull/2489#issuecomment-2385770696

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Try to sign any type of transaction (from profile portfolio or projects, from project cards "buy", create post attest, etc.)

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
