### PR TITLE
fix: navigate to slug based project url on buy page

### DIFF
--- a/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
+++ b/web-marketplace/src/components/templates/ProjectDetails/ProjectDetails.tsx
@@ -60,6 +60,7 @@ import { GettingStartedResourcesSection } from '../../molecules';
 import { ProjectTopSection } from '../../organisms';
 import useGeojson from './hooks/useGeojson';
 import { useGetProject } from './hooks/useGetProject';
+import { useNavigateToSlug } from './hooks/useNavigateToSlug';
 import useSeo from './hooks/useSeo';
 import { useSortedDocuments } from './hooks/useSortedDocuments';
 import { useStakeholders } from './hooks/useStakeholders';
@@ -151,19 +152,10 @@ function ProjectDetails(): JSX.Element {
     onChainCreditClassId,
     creditClassOnChain,
     cardSellOrders,
+    slug,
   } = useGetProject();
 
-  const slug =
-    offchainProjectByIdData?.data?.projectById?.slug ||
-    projectByOnChainId?.data?.projectByOnChainId?.slug ||
-    projectBySlug?.data.projectBySlug?.slug;
-
-  useEffect(() => {
-    if (!!slug) {
-      const hash = location.hash || '';
-      navigate(`/project/${slug}${hash}`, { replace: true });
-    }
-  }, [slug, navigate, location.hash]);
+  useNavigateToSlug(slug);
 
   const element = document.getElementById(location.hash.substring(1));
   useEffect(() => {

--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
@@ -127,6 +127,11 @@ export const useGetProject = () => {
     [sanityProject?.fiatSellOrders, sellOrders],
   );
 
+  const slug =
+    offchainProjectByIdData?.data?.projectById?.slug ||
+    projectByOnChainId?.data?.projectByOnChainId?.slug ||
+    projectBySlug?.data.projectBySlug?.slug;
+
   return {
     sanityProject,
     loadingSanityProject,
@@ -145,5 +150,6 @@ export const useGetProject = () => {
     loadingBuySellOrders,
     sellOrders,
     cardSellOrders,
+    slug,
   };
 };

--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-export const useNavigateToSlug = (slug?: string | null) => {
+export const useNavigateToSlug = (slug?: string | null, path?: string) => {
   const location = useLocation();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!!slug) {
       const hash = location.hash || '';
-      navigate(`/project/${slug}${hash}`, { replace: true });
+      navigate(`/project/${slug}${path}${hash}`, { replace: true });
     }
-  }, [slug, navigate, location.hash]);
+  }, [slug, navigate, location.hash, path]);
 };

--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export const useNavigateToSlug = (slug?: string | null) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!!slug) {
+      const hash = location.hash || '';
+      navigate(`/project/${slug}${hash}`, { replace: true });
+    }
+  }, [slug, navigate, location.hash]);
+};

--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useNavigateToSlug.ts
@@ -8,7 +8,7 @@ export const useNavigateToSlug = (slug?: string | null, path?: string) => {
   useEffect(() => {
     if (!!slug) {
       const hash = location.hash || '';
-      navigate(`/project/${slug}${path}${hash}`, { replace: true });
+      navigate(`/project/${slug}${path || ''}${hash}`, { replace: true });
     }
   }, [slug, navigate, location.hash, path]);
 };

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -8,6 +8,7 @@ import WithLoader from 'components/atoms/WithLoader';
 import { CardSellOrder } from 'components/organisms/ChooseCreditsForm/ChooseCreditsForm.types';
 import { MultiStepTemplate } from 'components/templates/MultiStepTemplate';
 import { useGetProject } from 'components/templates/ProjectDetails/hooks/useGetProject';
+import { useNavigateToSlug } from 'components/templates/ProjectDetails/hooks/useNavigateToSlug';
 
 import { PAYMENT_OPTIONS } from './BuyCredits.constants';
 import { BuyCreditsForm } from './BuyCredits.Form';
@@ -36,7 +37,10 @@ export const BuyCredits = () => {
     loadingBuySellOrders,
     sellOrders,
     cardSellOrders,
+    slug,
   } = useGetProject();
+
+  useNavigateToSlug(slug);
 
   const [paymentOption, setPaymentOption] = useState<PaymentOptionsType>(
     PAYMENT_OPTIONS.CRYPTO,

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -40,7 +40,7 @@ export const BuyCredits = () => {
     slug,
   } = useGetProject();
 
-  useNavigateToSlug(slug);
+  useNavigateToSlug(slug, '/buy');
 
   const [paymentOption, setPaymentOption] = useState<PaymentOptionsType>(
     PAYMENT_OPTIONS.CRYPTO,


### PR DESCRIPTION
## Description

Redirect to slug based project url if project has a slug.
Doing the same as on the project page so that it retrieves slug-based project on sanity.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2507--regen-marketplace.netlify.app/project/C01-001/buy should redirect to https://deploy-preview-2507--regen-marketplace.netlify.app/project/mai-ndombe-4/buy

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
