### PR TITLE
feat: APP-419 use Montserrat font by default

### DIFF
--- a/web-marketplace/src/clients/terrasos/Terrasos.base.css
+++ b/web-marketplace/src/clients/terrasos/Terrasos.base.css
@@ -1,3 +1,8 @@
 a {
   color: inherit;
 }
+
+body {
+  font-family: 'Montserrat', -apple-system, sans-serif !important;
+  background-color: #ffffff;
+}

--- a/web-marketplace/src/clients/terrasos/Terrasos.muiTheme.ts
+++ b/web-marketplace/src/clients/terrasos/Terrasos.muiTheme.ts
@@ -16,12 +16,17 @@ const defaultTheme = createTheme({
 
 export const { pxToRem } = defaultTheme.typography;
 
-export const headerFontFamily = ['"Muli"', '-apple-system', 'sans-serif'].join(
-  ',',
-);
-export const defaultFontFamily = ['"Lato"', '-apple-system', 'sans-serif'].join(
-  ',',
-);
+export const headerFontFamily = [
+  '"Montserrat"',
+  '-apple-system',
+  'sans-serif',
+].join(',');
+
+export const defaultFontFamily = [
+  '"Montserrat"',
+  '-apple-system',
+  'sans-serif',
+].join(',');
 
 const headerDefaults = {
   fontWeight: 900,

--- a/web-marketplace/src/clients/terrasos/Terrasos.muiTheme.ts
+++ b/web-marketplace/src/clients/terrasos/Terrasos.muiTheme.ts
@@ -29,7 +29,7 @@ export const defaultFontFamily = [
 ].join(',');
 
 const headerDefaults = {
-  fontWeight: 900,
+  fontWeight: 700,
   fontFamily: headerFontFamily,
 };
 


### PR DESCRIPTION
## Description

Closes: APP-419

Change the default font to Montserrat in the base CSS and MUI theme.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
