### PR TITLE
fix: APP-409 set retiring to true when payment is card

### DIFF
--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -11,6 +11,7 @@ import { useGetProject } from 'components/templates/ProjectDetails/hooks/useGetP
 import { useNavigateToSlug } from 'components/templates/ProjectDetails/hooks/useNavigateToSlug';
 
 import { paymentOptionAtom } from './BuyCredits.atoms';
+import { PAYMENT_OPTIONS } from './BuyCredits.constants';
 import { BuyCreditsForm } from './BuyCredits.Form';
 import { CardDetails } from './BuyCredits.types';
 import { getFormModel } from './BuyCredits.utils';
@@ -76,6 +77,12 @@ export const BuyCredits = () => {
   useEffect(() => {
     if (confirmationTokenId) summarizePayment(confirmationTokenId);
   }, [confirmationTokenId, summarizePayment]);
+
+  useEffect(() => {
+    if (!retiring && paymentOption === PAYMENT_OPTIONS.CARD) {
+      setRetiring(true);
+    }
+  }, [paymentOption, retiring, setRetiring]);
 
   if (noProjectFound) return <NotFoundPage />;
 


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-409

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2545--regen-marketplace.netlify.app/project/mai-ndombe-4/buy
2. Select crypto and then Buy tradable ecocredits
3. Swap back to card and back again to crypto - verify that the Crypto purchase options is set to Retire credits now

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
