### PR TITLE
fix: APP-478 remove color override for credibility cards on terrasos

### DIFF
--- a/web-components/src/components/cards/CredibilityCard/CredibilityCard.tsx
+++ b/web-components/src/components/cards/CredibilityCard/CredibilityCard.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@mui/material';
-import { IS_REGEN } from 'lib/env';
 
 import isString from '../../../utils/isString';
 import { BlockContent } from '../../block-content';

--- a/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.tsx
+++ b/web-marketplace/src/components/organisms/DetailsSection/DetailsSection.tsx
@@ -135,7 +135,6 @@ export const DetailsSection: React.FC<
               title={card?.credibilityCard?.title as string}
               descriptionRaw={card?.credibilityCard?.descriptionRaw}
               icon={card?.credibilityCard?.icon?.asset?.url}
-              overrideIconColor={!IS_REGEN}
               claims={
                 card?.claims?.map(claim => ({
                   description: claim?.description as string,


### PR DESCRIPTION
## Description

Closes: APP-478

Remove color override on Terrasos credibility card icon.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
