### PR TITLE
fix: APP-410 save buy flow on last user interaction

### DIFF
--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.constants.ts
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.constants.ts
@@ -5,6 +5,7 @@ export const CURRENCY_AMOUNT = 'currencyAmount';
 export const CURRENCY = 'currency';
 export const CREDIT_VINTAGE_OPTIONS = 'creditVintageOptions';
 export const SELL_ORDERS = 'sellOrders';
+export const MIN_USD_CURRENCY_AMOUNT = 0.5;
 
 export const cryptoOptions = [
   {

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
@@ -153,13 +153,11 @@ export const CreditsAmount = ({
       if (currentCreditsAmount > _creditsAvailable) {
         setValue(CREDITS_AMOUNT, _creditsAvailable);
         setValue(CURRENCY_AMOUNT, _spendingCap);
-        setValue(
-          SELL_ORDERS,
-          orderedSellOrders.map(order => {
-            const price = getSellOrderPrice({ order, card });
-            return formatSellOrder({ order, card, price });
-          }),
-        );
+        const sellOrders = orderedSellOrders.map(order => {
+          const price = getSellOrderPrice({ order, card });
+          return formatSellOrder({ order, card, price });
+        });
+        setValue(SELL_ORDERS, sellOrders);
         setWarningBannerTextAtom(
           getCreditsAvailableBannerText(_creditsAvailable, displayDenom),
         );
@@ -169,7 +167,7 @@ export const CreditsAmount = ({
             ...data,
             creditsAmount: _creditsAvailable,
             currencyAmount: _spendingCap,
-            sellOrders: orderedSellOrders,
+            sellOrders,
           },
           activeStep,
         );

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
@@ -273,10 +273,15 @@ export const CreditsAmount = ({
         activeStep,
       );
     },
-    // Intentionally omit `updateMultiStepData` and `data` from the dependency array
-    // because including them trigger unnecessary renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [card, orderedSellOrders, creditTypePrecision, setValue, activeStep],
+    [
+      card,
+      orderedSellOrders,
+      creditTypePrecision,
+      setValue,
+      updateMultiStepData,
+      data,
+      activeStep,
+    ],
   );
 
   const handleCurrencyAmountChange = useCallback(

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.tsx
@@ -331,12 +331,16 @@ export const CreditsAmount = ({
             cryptoCurrencies={cryptoCurrencies}
             displayDenom={displayDenom}
             allowedDenoms={allowedDenoms}
+            orderedSellOrders={orderedSellOrders}
+            creditTypePrecision={creditTypePrecision}
           />
         )}
         <span className="p-10 sm:p-20 text-xl">=</span>
         <CreditsInput
           creditsAvailable={creditsAvailable}
           handleCreditsAmountChange={handleCreditsAmountChange}
+          orderedSellOrders={orderedSellOrders}
+          creditTypePrecision={creditTypePrecision}
         />
       </div>
       {paymentOption === PAYMENT_OPTIONS.CRYPTO && (

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.types.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.types.tsx
@@ -27,6 +27,8 @@ export interface CreditsAmountProps {
 export interface CreditsInputProps {
   creditsAvailable: number;
   handleCreditsAmountChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  orderedSellOrders: UISellOrderInfo[];
+  creditTypePrecision?: number | null;
 }
 
 export interface CurrencyInputProps {
@@ -37,4 +39,6 @@ export interface CurrencyInputProps {
   cryptoCurrencies: Currency[];
   allowedDenoms?: AllowedDenoms;
   displayDenom: string;
+  orderedSellOrders: UISellOrderInfo[];
+  creditTypePrecision?: number | null;
 }

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
@@ -10,6 +10,8 @@ import TextField from 'web-components/src/components/inputs/new/TextField/TextFi
 
 import { paymentOptionAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
+import { BuyCreditsSchemaTypes } from 'pages/BuyCredits/BuyCredits.types';
+import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
 import {
   CREDITS_AMOUNT,
@@ -34,6 +36,11 @@ export const CreditsInput = ({
   } = useFormContext<ChooseCreditsFormSchemaType>();
   const { onChange } = register(CREDITS_AMOUNT);
   const paymentOption = useAtomValue(paymentOptionAtom);
+  const {
+    data,
+    handleSave: updateMultiStepData,
+    activeStep,
+  } = useMultiStep<BuyCreditsSchemaTypes>();
 
   const onHandleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(event);
@@ -63,7 +70,8 @@ export const CreditsInput = ({
 
   const handleOnBlur = useCallback(
     (event: FocusEvent<HTMLInputElement>): void => {
-      // If the value is empty, set it to 0
+      // If the value is empty or 0, set it to 1 and update
+      // form state and multiStep data.
       const value = event.target.value;
       if (value === '' || parseFloat(value) === 0) {
         const { currencyAmount, sellOrders } = getCurrencyAmount({
@@ -72,18 +80,29 @@ export const CreditsInput = ({
           orderedSellOrders,
           creditTypePrecision,
         });
-        setValue(CREDITS_AMOUNT, 1, { shouldValidate: true });
+        const NEW_CREDITS_AMOUNT = 1;
+        setValue(CREDITS_AMOUNT, NEW_CREDITS_AMOUNT, { shouldValidate: true });
         setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
         setValue(SELL_ORDERS, sellOrders);
-        onHandleChange(event);
+        updateMultiStepData(
+          {
+            ...data,
+            creditsAmount: NEW_CREDITS_AMOUNT,
+            currencyAmount,
+            sellOrders,
+          },
+          activeStep,
+        );
       }
     },
     [
+      activeStep,
       creditTypePrecision,
-      onHandleChange,
+      data,
       orderedSellOrders,
       paymentOption,
       setValue,
+      updateMultiStepData,
     ],
   );
 

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
@@ -9,17 +9,12 @@ import { LeafIcon } from 'web-components/src/components/icons/LeafIcon';
 import TextField from 'web-components/src/components/inputs/new/TextField/TextField';
 
 import { paymentOptionAtom } from 'pages/BuyCredits/BuyCredits.atoms';
-import { PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
 import { BuyCreditsSchemaTypes } from 'pages/BuyCredits/BuyCredits.types';
+import { resetCurrencyAndCredits } from 'pages/BuyCredits/BuyCredits.utils';
 import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
-import {
-  CREDITS_AMOUNT,
-  CURRENCY_AMOUNT,
-  SELL_ORDERS,
-} from './CreditsAmount.constants';
+import { CREDITS_AMOUNT } from './CreditsAmount.constants';
 import { CreditsInputProps } from './CreditsAmount.types';
-import { getCurrencyAmount } from './CreditsAmount.utils';
 
 export const CreditsInput = ({
   creditsAvailable,
@@ -70,27 +65,16 @@ export const CreditsInput = ({
 
   const handleOnBlur = useCallback(
     (event: FocusEvent<HTMLInputElement>): void => {
-      // If the value is empty or 0, set it to 1 and update
-      // form state and multiStep data.
+      // If the value is empty or 0 reset the currency and credit fields.
       const value = event.target.value;
       if (value === '' || parseFloat(value) === 0) {
-        const { currencyAmount, sellOrders } = getCurrencyAmount({
-          currentCreditsAmount: 1,
-          card: paymentOption === PAYMENT_OPTIONS.CARD,
+        resetCurrencyAndCredits(
+          paymentOption,
           orderedSellOrders,
           creditTypePrecision,
-        });
-        const NEW_CREDITS_AMOUNT = 1;
-        setValue(CREDITS_AMOUNT, NEW_CREDITS_AMOUNT, { shouldValidate: true });
-        setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
-        setValue(SELL_ORDERS, sellOrders);
-        updateMultiStepData(
-          {
-            ...data,
-            creditsAmount: NEW_CREDITS_AMOUNT,
-            currencyAmount,
-            sellOrders,
-          },
+          setValue,
+          updateMultiStepData,
+          data,
           activeStep,
         );
       }

--- a/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CreditsInput.tsx
@@ -11,7 +11,11 @@ import TextField from 'web-components/src/components/inputs/new/TextField/TextFi
 import { paymentOptionAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
 
-import { CREDITS_AMOUNT, CURRENCY_AMOUNT } from './CreditsAmount.constants';
+import {
+  CREDITS_AMOUNT,
+  CURRENCY_AMOUNT,
+  SELL_ORDERS,
+} from './CreditsAmount.constants';
 import { CreditsInputProps } from './CreditsAmount.types';
 import { getCurrencyAmount } from './CreditsAmount.utils';
 
@@ -62,7 +66,7 @@ export const CreditsInput = ({
       // If the value is empty, set it to 0
       const value = event.target.value;
       if (value === '' || parseFloat(value) === 0) {
-        const { currencyAmount } = getCurrencyAmount({
+        const { currencyAmount, sellOrders } = getCurrencyAmount({
           currentCreditsAmount: 1,
           card: paymentOption === PAYMENT_OPTIONS.CARD,
           orderedSellOrders,
@@ -70,18 +74,17 @@ export const CreditsInput = ({
         });
         setValue(CREDITS_AMOUNT, 1, { shouldValidate: true });
         setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
+        setValue(SELL_ORDERS, sellOrders);
+        onHandleChange(event);
       }
     },
-    [creditTypePrecision, orderedSellOrders, paymentOption, setValue],
-  );
-  const handleOnFocus = useCallback(
-    (event: FocusEvent<HTMLInputElement>): void => {
-      const value = event.target.value;
-      if (value === '0') {
-        setValue(CREDITS_AMOUNT, 0, { shouldValidate: true });
-      }
-    },
-    [setValue],
+    [
+      creditTypePrecision,
+      onHandleChange,
+      orderedSellOrders,
+      paymentOption,
+      setValue,
+    ],
   );
 
   return (
@@ -99,7 +102,6 @@ export const CreditsInput = ({
         onChange={onHandleChange}
         onInput={handleInput}
         onBlur={handleOnBlur}
-        onFocus={handleOnFocus}
         placeholder="0"
         sx={{
           '& .MuiInputBase-root': {

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -106,8 +106,9 @@ export const CurrencyInput = ({
 
   const handleOnBlur = useCallback(
     (event: FocusEvent<HTMLInputElement>): void => {
-      // If the value is empty, set it to 0
       const value = event.target.value;
+      // If the value is empty or 0, set it to 1 and update the
+      // form state and multiStep data.
       if (value === '' || parseFloat(value) === 0) {
         const { currencyAmount, sellOrders } = getCurrencyAmount({
           currentCreditsAmount: 1,
@@ -115,18 +116,29 @@ export const CurrencyInput = ({
           orderedSellOrders,
           creditTypePrecision,
         });
+        const NEW_CREDITS_AMOUNT = 1;
         setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
-        setValue(CREDITS_AMOUNT, 1, { shouldValidate: true });
+        setValue(CREDITS_AMOUNT, NEW_CREDITS_AMOUNT, { shouldValidate: true });
         setValue(SELL_ORDERS, sellOrders);
-        handleOnChange(event);
+        updateMultiStepData(
+          {
+            ...data,
+            creditsAmount: NEW_CREDITS_AMOUNT,
+            currencyAmount,
+            sellOrders,
+          },
+          activeStep,
+        );
       }
     },
     [
+      activeStep,
       creditTypePrecision,
-      handleOnChange,
+      data,
       orderedSellOrders,
       paymentOption,
       setValue,
+      updateMultiStepData,
     ],
   );
 

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -11,7 +11,6 @@ import TextField from 'web-components/src/components/inputs/new/TextField/TextFi
 import { paymentOptionAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
 import { BuyCreditsSchemaTypes } from 'pages/BuyCredits/BuyCredits.types';
-import { updateMultiStepCurrencyAndPaymentOption } from 'pages/BuyCredits/BuyCredits.utils';
 import { DenomIconWithCurrency } from 'components/molecules/DenomIconWithCurrency/DenomIconWithCurrency';
 import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
@@ -43,8 +42,11 @@ export const CurrencyInput = ({
     control,
   } = useFormContext<ChooseCreditsFormSchemaType>();
   const { _ } = useLingui();
-  const { data, handleSave, activeStep } =
-    useMultiStep<BuyCreditsSchemaTypes>();
+  const {
+    data,
+    handleSave: updateMultiStepData,
+    activeStep,
+  } = useMultiStep<BuyCreditsSchemaTypes>();
   const paymentOption = useAtomValue(paymentOptionAtom);
   const card = paymentOption === PAYMENT_OPTIONS.CARD;
   const { onChange } = register(CURRENCY_AMOUNT);
@@ -97,9 +99,18 @@ export const CurrencyInput = ({
       const value = event.target.value;
       if (value === '') {
         setValue(CURRENCY_AMOUNT, 0, { shouldValidate: true });
+        updateMultiStepData(
+          {
+            ...data,
+            currency,
+            paymentOption,
+            currencyAmount: 0,
+          },
+          activeStep,
+        );
       }
     },
-    [setValue],
+    [activeStep, currency, data, paymentOption, setValue, updateMultiStepData],
   );
 
   const onHandleCurrencyChange = useCallback(
@@ -114,15 +125,23 @@ export const CurrencyInput = ({
               )?.[0].askBaseDenom,
             };
       setValue(CURRENCY, currency);
-      updateMultiStepCurrencyAndPaymentOption(
-        handleSave,
-        data,
-        currency,
+      updateMultiStepData(
+        {
+          ...data,
+          currency,
+          paymentOption,
+        },
         activeStep,
-        paymentOption,
       );
     },
-    [activeStep, cryptoCurrencies, data, handleSave, paymentOption, setValue],
+    [
+      cryptoCurrencies,
+      setValue,
+      updateMultiStepData,
+      data,
+      paymentOption,
+      activeStep,
+    ],
   );
 
   return (

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -99,18 +99,9 @@ export const CurrencyInput = ({
       const value = event.target.value;
       if (value === '') {
         setValue(CURRENCY_AMOUNT, 0, { shouldValidate: true });
-        updateMultiStepData(
-          {
-            ...data,
-            currency,
-            paymentOption,
-            currencyAmount: 0,
-          },
-          activeStep,
-        );
       }
     },
-    [activeStep, currency, data, paymentOption, setValue, updateMultiStepData],
+    [setValue],
   );
 
   const onHandleCurrencyChange = useCallback(

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -15,9 +15,17 @@ import { DenomIconWithCurrency } from 'components/molecules/DenomIconWithCurrenc
 import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
 import { findDisplayDenom } from '../DenomLabel/DenomLabel.utils';
-import { CURRENCY, CURRENCY_AMOUNT } from './CreditsAmount.constants';
+import {
+  CREDITS_AMOUNT,
+  CURRENCY,
+  CURRENCY_AMOUNT,
+} from './CreditsAmount.constants';
 import { CurrencyInputProps } from './CreditsAmount.types';
-import { formatCurrencyAmount, shouldFormatValue } from './CreditsAmount.utils';
+import {
+  formatCurrencyAmount,
+  getCurrencyAmount,
+  shouldFormatValue,
+} from './CreditsAmount.utils';
 
 const CustomSelect = lazy(
   () =>
@@ -34,6 +42,8 @@ export const CurrencyInput = ({
   cryptoCurrencies,
   displayDenom,
   allowedDenoms,
+  orderedSellOrders,
+  creditTypePrecision,
 }: CurrencyInputProps) => {
   const {
     register,
@@ -97,11 +107,18 @@ export const CurrencyInput = ({
     (event: FocusEvent<HTMLInputElement>): void => {
       // If the value is empty, set it to 0
       const value = event.target.value;
-      if (value === '') {
-        setValue(CURRENCY_AMOUNT, 0, { shouldValidate: true });
+      if (value === '' || parseFloat(value) === 0) {
+        const { currencyAmount } = getCurrencyAmount({
+          currentCreditsAmount: 1,
+          card: paymentOption === PAYMENT_OPTIONS.CARD,
+          orderedSellOrders,
+          creditTypePrecision,
+        });
+        setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
+        setValue(CREDITS_AMOUNT, 1, { shouldValidate: true });
       }
     },
-    [setValue],
+    [creditTypePrecision, orderedSellOrders, paymentOption, setValue],
   );
 
   const onHandleCurrencyChange = useCallback(

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -11,22 +11,18 @@ import TextField from 'web-components/src/components/inputs/new/TextField/TextFi
 import { paymentOptionAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
 import { BuyCreditsSchemaTypes } from 'pages/BuyCredits/BuyCredits.types';
+import { resetCurrencyAndCredits } from 'pages/BuyCredits/BuyCredits.utils';
 import { DenomIconWithCurrency } from 'components/molecules/DenomIconWithCurrency/DenomIconWithCurrency';
 import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
 import { findDisplayDenom } from '../DenomLabel/DenomLabel.utils';
 import {
-  CREDITS_AMOUNT,
   CURRENCY,
   CURRENCY_AMOUNT,
-  SELL_ORDERS,
+  MIN_USD_CURRENCY_AMOUNT,
 } from './CreditsAmount.constants';
 import { CurrencyInputProps } from './CreditsAmount.types';
-import {
-  formatCurrencyAmount,
-  getCurrencyAmount,
-  shouldFormatValue,
-} from './CreditsAmount.utils';
+import { formatCurrencyAmount, shouldFormatValue } from './CreditsAmount.utils';
 
 const CustomSelect = lazy(
   () =>
@@ -107,26 +103,15 @@ export const CurrencyInput = ({
   const handleOnBlur = useCallback(
     (event: FocusEvent<HTMLInputElement>): void => {
       const value = event.target.value;
-      // If the value is empty or 0, set it to 1 and update the
-      // form state and multiStep data.
+      // If the value is empty or 0 reset the currency and credit fields.
       if (value === '' || parseFloat(value) === 0) {
-        const { currencyAmount, sellOrders } = getCurrencyAmount({
-          currentCreditsAmount: 1,
-          card: paymentOption === PAYMENT_OPTIONS.CARD,
+        resetCurrencyAndCredits(
+          paymentOption,
           orderedSellOrders,
           creditTypePrecision,
-        });
-        const NEW_CREDITS_AMOUNT = 1;
-        setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
-        setValue(CREDITS_AMOUNT, NEW_CREDITS_AMOUNT, { shouldValidate: true });
-        setValue(SELL_ORDERS, sellOrders);
-        updateMultiStepData(
-          {
-            ...data,
-            creditsAmount: NEW_CREDITS_AMOUNT,
-            currencyAmount,
-            sellOrders,
-          },
+          setValue,
+          updateMultiStepData,
+          data,
           activeStep,
         );
       }
@@ -192,7 +177,7 @@ export const CurrencyInput = ({
         } w-full sm:w-auto flex justify-start relative sm:h-60 rounded-sm items-center`}
         customInputProps={{
           max: maxCurrencyAmount,
-          min: card ? 0.5 : 0,
+          min: card ? MIN_USD_CURRENCY_AMOUNT : 0,
           step: card ? '0.01' : '0.000001',
           'aria-label': _(msg`Currency Input`),
         }}

--- a/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
+++ b/web-marketplace/src/components/molecules/CreditsAmount/CurrencyInput.tsx
@@ -19,6 +19,7 @@ import {
   CREDITS_AMOUNT,
   CURRENCY,
   CURRENCY_AMOUNT,
+  SELL_ORDERS,
 } from './CreditsAmount.constants';
 import { CurrencyInputProps } from './CreditsAmount.types';
 import {
@@ -108,7 +109,7 @@ export const CurrencyInput = ({
       // If the value is empty, set it to 0
       const value = event.target.value;
       if (value === '' || parseFloat(value) === 0) {
-        const { currencyAmount } = getCurrencyAmount({
+        const { currencyAmount, sellOrders } = getCurrencyAmount({
           currentCreditsAmount: 1,
           card: paymentOption === PAYMENT_OPTIONS.CARD,
           orderedSellOrders,
@@ -116,9 +117,17 @@ export const CurrencyInput = ({
         });
         setValue(CURRENCY_AMOUNT, currencyAmount, { shouldValidate: true });
         setValue(CREDITS_AMOUNT, 1, { shouldValidate: true });
+        setValue(SELL_ORDERS, sellOrders);
+        handleOnChange(event);
       }
     },
-    [creditTypePrecision, orderedSellOrders, paymentOption, setValue],
+    [
+      creditTypePrecision,
+      handleOnChange,
+      orderedSellOrders,
+      paymentOption,
+      setValue,
+    ],
   );
 
   const onHandleCurrencyChange = useCallback(

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Retirement.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Retirement.tsx
@@ -1,14 +1,14 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { msg, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
+import { debounce } from 'lodash';
 
 import Card from 'web-components/src/components/cards/Card';
-import CheckboxLabel from 'web-components/src/components/inputs/new/CheckboxLabel/CheckboxLabel';
 import SelectTextField from 'web-components/src/components/inputs/new/SelectTextField/SelectTextField';
 import TextField from 'web-components/src/components/inputs/new/TextField/TextField';
 import QuestionMarkTooltip from 'web-components/src/components/tooltip/QuestionMarkTooltip';
-import { Body, Title } from 'web-components/src/components/typography';
+import { Title } from 'web-components/src/components/typography';
 
 import {
   COUNTRY_LABEL,
@@ -17,6 +17,9 @@ import {
   LOCATION_STATE_PLACEHOLDER_LABEL,
   STATE_LABEL,
 } from 'lib/constants/shared.constants';
+
+import { BuyCreditsSchemaTypes } from 'pages/BuyCredits/BuyCredits.types';
+import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
 import { AgreePurchaseFormSchemaType } from './AgreePurchaseForm.schema';
 
@@ -38,13 +41,18 @@ type Props = { retiring: boolean };
 export const Retirement = ({ retiring }: Props) => {
   const { _ } = useLingui();
   const ctx = useFormContext<AgreePurchaseFormSchemaType>();
-  const { register, formState, control } = ctx;
+  const { register, formState, control, getValues } = ctx;
   const { errors } = formState;
+  const {
+    data,
+    handleSave: updateMultiStepData,
+    activeStep,
+  } = useMultiStep<BuyCreditsSchemaTypes>();
 
-  const anonymousPurchase = useWatch({
-    control: control,
-    name: 'anonymousPurchase',
-  });
+  // const anonymousPurchase = useWatch({
+  //   control: control,
+  //   name: 'anonymousPurchase',
+  // });
   const country = useWatch({
     control: control,
     name: 'country',
@@ -53,6 +61,59 @@ export const Retirement = ({ retiring }: Props) => {
     control: control,
     name: 'stateProvince',
   });
+  const retirementReason = useWatch({
+    control: control,
+    name: 'retirementReason',
+  });
+  const postalCode = useWatch({
+    control: control,
+    name: 'postalCode',
+  });
+
+  const { anonymousPurchase, followProject, subscribeNewsletter, agreeErpa } =
+    getValues();
+
+  useEffect(() => {
+    debounce(() => {
+      updateMultiStepData(
+        {
+          ...data,
+          retirementReason,
+          postalCode,
+        },
+        activeStep,
+      );
+    }, 500)();
+    // Intentionally omit `updateMultiStepData` and `data` from the dependency array
+    // because including them trigger unnecessary renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [retirementReason, postalCode, activeStep]);
+
+  useEffect(() => {
+    updateMultiStepData(
+      {
+        ...data,
+        country,
+        stateProvince,
+        anonymousPurchase,
+        followProject,
+        subscribeNewsletter,
+        agreeErpa,
+      },
+      activeStep,
+    );
+    // Intentionally omit `updateMultiStepData` and `data` from the dependency array
+    // because including them trigger unnecessary renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    country,
+    stateProvince,
+    anonymousPurchase,
+    followProject,
+    subscribeNewsletter,
+    agreeErpa,
+    activeStep,
+  ]);
 
   return (
     <div className={retiring ? '' : 'hidden'}>

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Retirement.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Retirement.tsx
@@ -41,7 +41,7 @@ type Props = { retiring: boolean };
 export const Retirement = ({ retiring }: Props) => {
   const { _ } = useLingui();
   const ctx = useFormContext<AgreePurchaseFormSchemaType>();
-  const { register, formState, control, getValues } = ctx;
+  const { register, formState, control } = ctx;
   const { errors } = formState;
   const {
     data,
@@ -49,29 +49,32 @@ export const Retirement = ({ retiring }: Props) => {
     activeStep,
   } = useMultiStep<BuyCreditsSchemaTypes>();
 
-  // const anonymousPurchase = useWatch({
-  //   control: control,
-  //   name: 'anonymousPurchase',
-  // });
-  const country = useWatch({
-    control: control,
-    name: 'country',
-  });
-  const stateProvince = useWatch({
-    control: control,
-    name: 'stateProvince',
-  });
-  const retirementReason = useWatch({
-    control: control,
-    name: 'retirementReason',
-  });
-  const postalCode = useWatch({
-    control: control,
-    name: 'postalCode',
+  const fieldNames: (keyof AgreePurchaseFormSchemaType)[] = [
+    'country',
+    'stateProvince',
+    'retirementReason',
+    'postalCode',
+    'followProject',
+    'subscribeNewsletter',
+    'agreeErpa',
+    // 'anonymousPurchase',
+  ];
+
+  const watchedFields = useWatch({
+    control,
+    name: fieldNames,
   });
 
-  const { anonymousPurchase, followProject, subscribeNewsletter, agreeErpa } =
-    getValues();
+  const [
+    country,
+    stateProvince,
+    retirementReason,
+    postalCode,
+    followProject,
+    subscribeNewsletter,
+    agreeErpa,
+    // anonymousPurchase
+  ] = watchedFields;
 
   useEffect(() => {
     debounce(() => {
@@ -95,7 +98,7 @@ export const Retirement = ({ retiring }: Props) => {
         ...data,
         country,
         stateProvince,
-        anonymousPurchase,
+        // anonymousPurchase,
         followProject,
         subscribeNewsletter,
         agreeErpa,
@@ -108,11 +111,11 @@ export const Retirement = ({ retiring }: Props) => {
   }, [
     country,
     stateProvince,
-    anonymousPurchase,
+    // anonymousPurchase
+    activeStep,
     followProject,
     subscribeNewsletter,
     agreeErpa,
-    activeStep,
   ]);
 
   return (
@@ -181,7 +184,7 @@ export const Retirement = ({ retiring }: Props) => {
                 exclude
                 error={!!errors['country']}
                 helperText={errors['country']?.message}
-                value={country}
+                value={country as string | undefined}
                 {...register('country')}
               />
             </Suspense>
@@ -203,7 +206,7 @@ export const Retirement = ({ retiring }: Props) => {
                 country={country as string}
                 error={!!errors['stateProvince']}
                 helperText={errors['stateProvince']?.message}
-                value={stateProvince}
+                value={stateProvince as string | undefined}
                 {...register('stateProvince')}
               />
             </Suspense>

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
@@ -93,6 +93,13 @@ export const AgreePurchaseForm = ({
     setCardDetailsMissing,
   ]);
 
+  // reset cardDetailsMissing on unmount
+  useEffect(() => {
+    return () => {
+      setCardDetailsMissing(true);
+    };
+  }, [setCardDetailsMissing]);
+
   return (
     <Form
       form={form}
@@ -150,7 +157,6 @@ export const AgreePurchaseForm = ({
           saveDisabled={!isValid || isSubmitting}
           saveText={_(msg`purchase now`)}
           onPrev={handleBack}
-          onSave={() => setCardDetailsMissing(null)}
         />
       </div>
     </Form>

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
@@ -93,13 +93,6 @@ export const AgreePurchaseForm = ({
     setCardDetailsMissing,
   ]);
 
-  // reset cardDetailsMissing on unmount
-  useEffect(() => {
-    return () => {
-      setCardDetailsMissing(true);
-    };
-  }, [setCardDetailsMissing]);
-
   return (
     <Form
       form={form}
@@ -157,6 +150,7 @@ export const AgreePurchaseForm = ({
           saveDisabled={!isValid || isSubmitting}
           saveText={_(msg`purchase now`)}
           onPrev={handleBack}
+          onSave={() => setCardDetailsMissing(null)}
         />
       </div>
     </Form>

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseFormFiat.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseFormFiat.tsx
@@ -7,5 +7,12 @@ export const AgreePurchaseFormFiat = (props: Props) => {
   const stripe = useStripe();
   const elements = useElements();
 
-  return <AgreePurchaseForm {...props} stripe={stripe} elements={elements} />;
+  return (
+    <AgreePurchaseForm
+      {...props}
+      stripe={stripe}
+      elements={elements}
+      isCardPayment
+    />
+  );
 };

--- a/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.CryptoOptions.tsx
+++ b/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.CryptoOptions.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from 'react';
 import { Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { cryptoOptions } from 'web-marketplace/src/components/molecules/CreditsAmount/CreditsAmount.constants';
@@ -12,7 +13,7 @@ export function CryptoOptions({
   tradableDisabled = false,
 }: {
   retiring: boolean;
-  handleCryptoPurchaseOptions: () => void;
+  handleCryptoPurchaseOptions: (event: ChangeEvent<HTMLInputElement>) => void;
   tradableDisabled?: boolean;
 }) {
   const { _ } = useLingui();

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.CardInfo.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.CardInfo.tsx
@@ -7,6 +7,8 @@ import CheckboxLabel from 'web-components/src/components/inputs/new/CheckboxLabe
 import { Body } from 'web-components/src/components/typography';
 import { UseStateSetter } from 'web-components/src/types/react/useState';
 
+import { useMultiStep } from 'components/templates/MultiStepTemplate';
+
 import { paymentElementOptions } from './PaymentInfoForm.constants';
 import { PaymentInfoFormSchemaType } from './PaymentInfoForm.schema';
 
@@ -22,6 +24,7 @@ export const CardInfo = ({
 }: CardInfoProps) => {
   const ctx = useFormContext<PaymentInfoFormSchemaType>();
   const { register, control, setValue } = ctx;
+  const { handleSave: updateMultiStepData, activeStep, data } = useMultiStep();
 
   const createAccount = useWatch({
     control: control,
@@ -35,6 +38,19 @@ export const CardInfo = ({
   useEffect(() => {
     setValue('savePaymentMethod', createAccount);
   }, [createAccount, setValue]);
+
+  useEffect(() => {
+    updateMultiStepData(
+      {
+        ...data,
+        savePaymentMethod,
+      },
+      activeStep,
+    );
+    // Intentionally omit `updateMultiStepData` and `data` from the dependency array
+    // because including them trigger unnecessary renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savePaymentMethod, activeStep]);
 
   return (
     <div className={className}>

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.PaymentInfo.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.PaymentInfo.tsx
@@ -9,6 +9,8 @@ import { Radio } from 'web-components/src/components/inputs/new/Radio/Radio';
 import { Title } from 'web-components/src/components/typography';
 import { UseStateSetter } from 'web-components/src/types/react/useState';
 
+import { useMultiStep } from 'components/templates/MultiStepTemplate';
+
 import { CardInfo } from './PaymentInfoForm.CardInfo';
 import { PaymentInfoFormSchemaType } from './PaymentInfoForm.schema';
 
@@ -25,7 +27,7 @@ export const PaymentInfo = ({
   const { _ } = useLingui();
   const ctx = useFormContext<PaymentInfoFormSchemaType>();
   const { register, control, setValue } = ctx;
-
+  const { handleSave: updateMultiStepData, activeStep, data } = useMultiStep();
   const createAccount = useWatch({
     control: control,
     name: 'createAccount',
@@ -37,7 +39,18 @@ export const PaymentInfo = ({
 
   useEffect(() => {
     setValue('savePaymentMethod', createAccount);
-  }, [createAccount, setValue]);
+    updateMultiStepData(
+      {
+        ...data,
+        savePaymentMethod: createAccount,
+        createAccount,
+      },
+      activeStep,
+    );
+    // Intentionally omit `updateMultiStepData` and `data` from the dependency array
+    // because including them trigger unnecessary renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeStep, createAccount, setValue]);
 
   return (
     <Card className="py-30 px-20 sm:py-50 sm:px-40 border-grey-300">

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.PaymentInfo.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.PaymentInfo.tsx
@@ -60,7 +60,7 @@ export const PaymentInfo = ({
       {paymentMethods && paymentMethods.length > 0 ? (
         <>
           {paymentMethods.map(paymentMethod => (
-            <div className="mb-20">
+            <div className="mb-20" key={paymentMethod.id}>
               <Radio
                 label={_(
                   msg`Use my credit card on file ending in ${paymentMethod.card?.last4}`,

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { DefaultValues, useFormState, useWatch } from 'react-hook-form';
 import { useLingui } from '@lingui/react';
 import { Stripe, StripeElements } from '@stripe/stripe-js';
+import { useSetAtom } from 'jotai';
 
 import { PrevNextButtons } from 'web-components/src/components/molecules/PrevNextButtons/PrevNextButtons';
 import { UseStateSetter } from 'web-components/src/types/react/useState';
 
+import { cardDetailsMissingAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { NEXT, PAYMENT_OPTIONS } from 'pages/BuyCredits/BuyCredits.constants';
 import {
   CardDetails,
@@ -62,7 +64,7 @@ export const PaymentInfoForm = ({
     data,
   } = useMultiStep();
   const [paymentInfoValid, setPaymentInfoValid] = useState(false);
-
+  const setCardDetailsMissing = useSetAtom(cardDetailsMissingAtom);
   const form = useZodForm({
     schema: paymentInfoFormSchema(paymentOption),
     defaultValues: {
@@ -110,6 +112,7 @@ export const PaymentInfoForm = ({
     <Form
       form={form}
       onSubmit={async (values: PaymentInfoFormSchemaType) => {
+        setCardDetailsMissing(false);
         const card = paymentOption === PAYMENT_OPTIONS.CARD;
         if (card && !stripe) {
           return;

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
@@ -55,7 +55,12 @@ export const PaymentInfoForm = ({
   setCardDetails,
 }: PaymentInfoFormProps) => {
   const { _ } = useLingui();
-  const { handleBack } = useMultiStep();
+  const {
+    handleBack,
+    handleSave: updateMultiStepData,
+    activeStep,
+    data,
+  } = useMultiStep();
   const [paymentInfoValid, setPaymentInfoValid] = useState(false);
 
   const form = useZodForm({
@@ -89,6 +94,18 @@ export const PaymentInfoForm = ({
     () => paymentOption === PAYMENT_OPTIONS.CARD,
     [paymentOption],
   );
+
+  const handleOnBlur = () => {
+    updateMultiStepData(
+      {
+        ...data,
+        name: form.watch('name'),
+        email: form.watch('email'),
+      },
+      activeStep,
+    );
+  };
+
   return (
     <Form
       form={form}
@@ -142,6 +159,7 @@ export const PaymentInfoForm = ({
         }
         onSubmit(values);
       }}
+      onBlur={handleOnBlur}
     >
       <div className="flex flex-col gap-10 sm:gap-20 max-w-[560px]">
         <CustomerInfo

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
@@ -99,8 +99,8 @@ export const PaymentInfoForm = ({
     updateMultiStepData(
       {
         ...data,
-        name: form.watch('name'),
-        email: form.watch('email'),
+        name: form.getValues('name'),
+        email: form.getValues('email'),
       },
       activeStep,
     );

--- a/web-marketplace/src/components/templates/MultiStepTemplate/MultiStepTemplate.tsx
+++ b/web-marketplace/src/components/templates/MultiStepTemplate/MultiStepTemplate.tsx
@@ -5,6 +5,7 @@ import { StepperSection } from './StepperSection';
 
 type MultiStepProps<T extends object> = ProviderProps<T> & {
   children: JSX.Element;
+  forceStep?: number;
 } & Pick<OnBoardingSectionProps, 'classes'>;
 
 export function MultiStepTemplate<T extends object>({
@@ -14,6 +15,7 @@ export function MultiStepTemplate<T extends object>({
   children,
   withLocalStorage,
   classes,
+  forceStep,
 }: MultiStepProps<T>): JSX.Element {
   return (
     <MultiStepProvider
@@ -21,6 +23,7 @@ export function MultiStepTemplate<T extends object>({
       steps={steps}
       initialValues={initialValues}
       withLocalStorage={withLocalStorage}
+      forceStep={forceStep}
     >
       <StepperSection classes={classes}>{children}</StepperSection>
     </MultiStepProvider>

--- a/web-marketplace/src/hooks/useStorage.ts
+++ b/web-marketplace/src/hooks/useStorage.ts
@@ -6,6 +6,7 @@ interface StorageApi<T> {
   data: T | undefined;
   saveData: React.Dispatch<T>;
   removeData: () => void;
+  isLoading: boolean;
 }
 
 export default function useStorage<T>(
@@ -13,6 +14,7 @@ export default function useStorage<T>(
   withLocalStorage: boolean,
   initialValue?: T,
 ): StorageApi<T> {
+  const [isLoading, setIsLoading] = useState(true);
   const [data, saveData] = useState<T | undefined>(() => {
     // this way, as a fn, this initialization happens just once
     if (withLocalStorage) {
@@ -26,6 +28,7 @@ export default function useStorage<T>(
   });
 
   useEffect(() => {
+    setIsLoading(false);
     if (withLocalStorage && data) {
       const storedValue = localStorage.getItem(key);
       const currentValue = storedValue ? JSON.parse(storedValue) : {};
@@ -52,5 +55,5 @@ export default function useStorage<T>(
     }
   };
 
-  return { data, saveData, removeData };
+  return { data, saveData, removeData, isLoading };
 }

--- a/web-marketplace/src/hooks/useStorage.ts
+++ b/web-marketplace/src/hooks/useStorage.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import _ from 'lodash';
 
 // type Params<T> = [T, React.Dispatch<T>];
 interface StorageApi<T> {
@@ -26,12 +27,15 @@ export default function useStorage<T>(
 
   useEffect(() => {
     if (withLocalStorage && data) {
-      // TODO: if (_.isEqual(data, initialValues)) return;
-      try {
-        localStorage.setItem(key, JSON.stringify(data));
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.log(err);
+      const storedValue = localStorage.getItem(key);
+      const currentValue = storedValue ? JSON.parse(storedValue) : {};
+      if (!_.isEqual(data, currentValue)) {
+        try {
+          localStorage.setItem(key, JSON.stringify(data));
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.log(err);
+        }
       }
     }
   }, [data, key, withLocalStorage]);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
@@ -187,7 +187,7 @@ export const BuyCreditsForm = ({
       typeof data?.retiring === 'undefined' ? prev : data?.retiring,
     );
     setPaymentOption(prev => data?.paymentOption || prev);
-  }, [data, setPaymentOption, setRetiring]);
+  }, [data.retiring, data?.paymentOption, setPaymentOption, setRetiring]);
 
   useEffect(() => {
     if (

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
@@ -5,7 +5,7 @@ import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe, Stripe, StripeElements } from '@stripe/stripe-js';
 import { useQuery } from '@tanstack/react-query';
 import { USD_DENOM } from 'config/allowedBaseDenoms';
-import { useAtom, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 
 import { UseStateSetter } from 'web-components/src/types/react/useState';
 
@@ -61,6 +61,7 @@ import { PaymentInfoFormFiat } from 'components/organisms/PaymentInfoForm/Paymen
 import { useMultiStep } from 'components/templates/MultiStepTemplate';
 
 import {
+  cardDetailsMissingAtom,
   paymentOptionAtom,
   paymentOptionCryptoClickedAtom,
 } from './BuyCredits.atoms';
@@ -122,6 +123,7 @@ export const BuyCreditsForm = ({
   const { wallet, isConnected, activeWalletAddr, loaded } = useWallet();
   const { activeAccount, privActiveAccount } = useAuth();
   const [paymentOption, setPaymentOption] = useAtom(paymentOptionAtom);
+  const cardDetailsMissing = useAtomValue(cardDetailsMissingAtom);
   const {
     isModalOpen,
     modalState,
@@ -194,6 +196,22 @@ export const BuyCreditsForm = ({
     );
     setPaymentOption(prev => data?.paymentOption || prev);
   }, [data, setPaymentOption, setRetiring]);
+
+  useEffect(() => {
+    if (
+      paymentOption === PAYMENT_OPTIONS.CARD &&
+      cardDetailsMissing &&
+      activeStep === 2
+    ) {
+      handleActiveStep(1);
+    }
+  }, [
+    handleActiveStep,
+    cardDetails,
+    paymentOption,
+    activeStep,
+    cardDetailsMissing,
+  ]);
 
   useEffect(() => {
     if (
@@ -473,7 +491,7 @@ export const BuyCreditsForm = ({
                 setCardDetails={setCardDetails}
               />
             )}
-            {activeStep === 2 && (
+            {activeStep === 2 && !cardDetailsMissing && (
               <AgreePurchaseFormFiat
                 email={data?.email}
                 retiring={retiring}
@@ -481,6 +499,16 @@ export const BuyCreditsForm = ({
                 goToChooseCredits={() => handleActiveStep(0)}
                 imgSrc="/svg/info-with-hand.svg"
                 country={cardDetails?.country || 'US'}
+                initialValues={{
+                  country: data?.country || cardDetails?.country || 'US',
+                  stateProvince: data?.stateProvince || '',
+                  postalCode: data?.postalCode || '',
+                  retirementReason: data?.retirementReason || '',
+                  anonymousPurchase: data?.anonymousPurchase || false,
+                  followProject: data?.followProject || false,
+                  subscribeNewsletter: data?.subscribeNewsletter || false,
+                  agreeErpa: data?.agreeErpa || false,
+                }}
               />
             )}
           </Elements>
@@ -516,6 +544,16 @@ export const BuyCreditsForm = ({
                 goToChooseCredits={() => handleActiveStep(0)}
                 imgSrc="/svg/info-with-hand.svg"
                 country={cardDetails?.country || 'US'}
+                initialValues={{
+                  country: data?.country || 'US',
+                  stateProvince: data?.stateProvince || '',
+                  postalCode: data?.postalCode || '',
+                  retirementReason: data?.retirementReason || '',
+                  anonymousPurchase: data?.anonymousPurchase || false,
+                  followProject: data?.followProject || false,
+                  subscribeNewsletter: data?.subscribeNewsletter || false,
+                  agreeErpa: data?.agreeErpa || false,
+                }}
                 isNewsletterSubscribed={subscribersStatusData?.subscribed}
               />
             )}

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
@@ -191,22 +191,6 @@ export const BuyCreditsForm = ({
 
   useEffect(() => {
     if (
-      paymentOption === PAYMENT_OPTIONS.CARD &&
-      cardDetailsMissing &&
-      activeStep === 2
-    ) {
-      handleActiveStep(1);
-    }
-  }, [
-    handleActiveStep,
-    cardDetails,
-    paymentOption,
-    activeStep,
-    cardDetailsMissing,
-  ]);
-
-  useEffect(() => {
-    if (
       !loadingSanityProject &&
       !loadingBuySellOrders &&
       cardSellOrders.length === 0 &&

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
@@ -135,6 +135,7 @@ export const BuyCreditsForm = ({
   const { _ } = useLingui();
   const warningModalContent = useRef<BuyWarningModalContent | undefined>();
   const setErrorBannerTextAtom = useSetAtom(errorBannerTextAtom);
+
   const setWarningBannerTextAtom = useSetAtom(warningBannerTextAtom);
   const setConnectWalletModal = useSetAtom(connectWalletModalAtom);
   const setSwitchWalletModalAtom = useSetAtom(switchWalletModalAtom);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.Form.tsx
@@ -398,14 +398,22 @@ export const BuyCreditsForm = ({
     ],
   );
 
-  const stripeAmount =
-    data?.[CURRENCY_AMOUNT] ||
-    getCurrencyAmount({
-      currentCreditsAmount: 1,
-      card: paymentOption === PAYMENT_OPTIONS.CARD,
-      orderedSellOrders: cardSellOrders,
-      creditTypePrecision: creditTypeData?.creditType?.precision,
-    }).currencyAmount;
+  const stripeAmount = useMemo(() => {
+    return (
+      data?.[CURRENCY_AMOUNT] ||
+      getCurrencyAmount({
+        currentCreditsAmount: 1,
+        card: paymentOption === PAYMENT_OPTIONS.CARD,
+        orderedSellOrders: cardSellOrders,
+        creditTypePrecision: creditTypeData?.creditType?.precision,
+      }).currencyAmount
+    );
+  }, [
+    data,
+    paymentOption,
+    cardSellOrders,
+    creditTypeData?.creditType?.precision,
+  ]);
 
   const stripeOptions = useMemo(
     () => ({

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
@@ -9,4 +9,4 @@ export const spendingCapAtom = atom<number | null>(null);
 export const paymentOptionAtom = atom<PaymentOptionsType>(
   PAYMENT_OPTIONS.CRYPTO,
 );
-export const cardDetailsMissingAtom = atom(true);
+export const cardDetailsMissingAtom = atom(null);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
@@ -9,4 +9,4 @@ export const spendingCapAtom = atom<number | null>(null);
 export const paymentOptionAtom = atom<PaymentOptionsType>(
   PAYMENT_OPTIONS.CRYPTO,
 );
-export const cardDetailsMissingAtom = atom<boolean | null>(null);
+export const cardDetailsMissingAtom = atom(true);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
@@ -9,3 +9,4 @@ export const spendingCapAtom = atom<number | null>(null);
 export const paymentOptionAtom = atom<PaymentOptionsType>(
   PAYMENT_OPTIONS.CRYPTO,
 );
+export const cardDetailsMissingAtom = atom(true);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
@@ -9,4 +9,4 @@ export const spendingCapAtom = atom<number | null>(null);
 export const paymentOptionAtom = atom<PaymentOptionsType>(
   PAYMENT_OPTIONS.CRYPTO,
 );
-export const cardDetailsMissingAtom = atom(null);
+export const cardDetailsMissingAtom = atom<boolean | null>(null);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -85,7 +85,9 @@ export const BuyCredits = () => {
           initialValues={{}}
           classes={{ formWrap: 'max-w-[942px]' }}
           forceStep={
-            paymentOption === PAYMENT_OPTIONS.CARD && cardDetailsMissing
+            paymentOption === PAYMENT_OPTIONS.CARD &&
+            cardDetailsMissing &&
+            cardDetailsMissing !== null
               ? 1
               : undefined
           }

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -50,7 +50,10 @@ export const BuyCredits = () => {
     projectId: onChainProjectId ?? offChainProject?.id,
   });
 
-  // update payment option from local storage data
+  // On form load, update `paymentOption` and `maxAllowedStep` from localStorage to prevent a visual
+  // jump between step 1 (Payment info) and step 2  (Retirement) when resuming the form left at step 2.
+  // These values are needed to calculate the `forceStep` prop in `MultiStepTemplate`, which redirects,
+  // if necessary, the user to step 1 to re-enter payment details.
   useEffect(() => {
     const localStorageData = localStorage.getItem(formModel.formId);
     if (localStorageData) {

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useAtom, useAtomValue } from 'jotai';
-
-import { useWallet } from 'lib/wallet/wallet';
 
 import NotFoundPage from 'pages/NotFound';
 import WithLoader from 'components/atoms/WithLoader';
@@ -19,7 +17,6 @@ import { useSummarizePayment } from './hooks/useSummarizePayment';
 
 export const BuyCredits = () => {
   const { projectId } = useParams();
-  const navigate = useNavigate();
 
   const {
     loadingSanityProject,
@@ -40,28 +37,6 @@ export const BuyCredits = () => {
   const [paymentOption, setPaymentOption] = useAtom(paymentOptionAtom);
   const cardDetailsMissing = useAtomValue(cardDetailsMissingAtom);
   const [maxAllowedStep, setMaxAllowedStep] = useState(0);
-  const { wallet, loaded } = useWallet();
-
-  useEffect(() => {
-    if (
-      !loadingSanityProject &&
-      !loadingBuySellOrders &&
-      cardSellOrders.length === 0 &&
-      ((loaded && !wallet?.address) || isBuyFlowDisabled)
-    )
-      // Else if there's no connected wallet address or buy disabled, redirect to project page
-      navigate(`/project/${projectId}`, { replace: true });
-  }, [
-    loadingSanityProject,
-    loadingBuySellOrders,
-    loaded,
-    wallet?.address,
-    navigate,
-    projectId,
-    cardSellOrders.length,
-    isBuyFlowDisabled,
-  ]);
-
   const [retiring, setRetiring] = useState<boolean>(true);
   const [confirmationTokenId, setConfirmationTokenId] = useState<
     string | undefined

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
@@ -33,7 +33,7 @@ import {
   PAYMENT_OPTIONS,
   RETIREMENT,
 } from './BuyCredits.constants';
-import { PaymentOptionsType } from './BuyCredits.types';
+import { BuyCreditsSchemaTypes, PaymentOptionsType } from './BuyCredits.types';
 
 type GetFormModelParams = {
   paymentOption: PaymentOptionsType;

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
@@ -33,7 +33,7 @@ import {
   PAYMENT_OPTIONS,
   RETIREMENT,
 } from './BuyCredits.constants';
-import { BuyCreditsSchemaTypes, PaymentOptionsType } from './BuyCredits.types';
+import { PaymentOptionsType } from './BuyCredits.types';
 
 type GetFormModelParams = {
   paymentOption: PaymentOptionsType;
@@ -225,32 +225,6 @@ export const getFormModel = ({
     ],
   };
 };
-
-/*
- * Uses `handleSave` to update `useMultiStep`'s `data.currency` and `data.paymentOption`,
- * ensuring consistent access to the selected currency and payment option in `BuyCredits.Form`.
- * This enables `BuyCredits.Form` to fetch and pass the correct `userBalance` to `ChooseCredits.Form`
- * and `OrderSummary.Card` and to keep data.paymentOption sync.
- *
- * This approach is necessary because we currently don’t have access to the updated `useMultiStep`'s `data`
- * until users reach step 2 of the buy credits flow.
- */
-export function updateMultiStepCurrencyAndPaymentOption(
-  handleSave: HandleSaveType<BuyCreditsSchemaTypes>,
-  data: BuyCreditsSchemaTypes,
-  currency: { askDenom: string; askBaseDenom: string },
-  activeStep: number,
-  option: string,
-) {
-  handleSave(
-    {
-      ...data,
-      paymentOption: option,
-      currency,
-    },
-    activeStep,
-  );
-}
 
 export function getCryptoCurrencies(cryptoSellOrders: UISellOrderInfo[]) {
   return cryptoSellOrders

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
@@ -1,27 +1,28 @@
+import { UseFormSetValue } from 'react-hook-form';
 import { i18n } from '@lingui/core';
 import { msg, plural, Trans } from '@lingui/macro';
-// import { Box } from '@mui/material';
 import { QueryAllowedDenomsResponse } from '@regen-network/api/lib/generated/regen/ecocredit/marketplace/v1/query';
 import { USD_DENOM } from 'config/allowedBaseDenoms';
 
-// import { quantityFormatNumberOptions } from 'config/decimals';
-import {
-  // formatNumber,
-  getFormattedNumber,
-} from 'web-components/src/utils/format';
+import { getFormattedNumber } from 'web-components/src/utils/format';
 
-// import { microToDenom } from 'lib/denom.utils';
 import { TranslatorType } from 'lib/i18n/i18n.types';
 import { NormalizeProject } from 'lib/normalizers/projects/normalizeProjectsWithMetadata';
 
 import { UISellOrderInfo } from 'pages/Projects/AllProjects/AllProjects.types';
 import { AmountWithCurrency } from 'components/molecules/AmountWithCurrency/AmountWithCurrency';
+import {
+  CREDITS_AMOUNT,
+  CURRENCY_AMOUNT,
+  MIN_USD_CURRENCY_AMOUNT,
+  SELL_ORDERS,
+} from 'components/molecules/CreditsAmount/CreditsAmount.constants';
 import { Currency } from 'components/molecules/CreditsAmount/CreditsAmount.types';
+import { getCurrencyAmount } from 'components/molecules/CreditsAmount/CreditsAmount.utils';
 import { findDisplayDenom } from 'components/molecules/DenomLabel/DenomLabel.utils';
 import { KEPLR_LOGIN_REQUIRED } from 'components/organisms/BuyWarningModal/BuyWarningModal.constants';
 import { BuyWarningModalContent } from 'components/organisms/BuyWarningModal/BuyWarningModal.types';
 import { CardSellOrder } from 'components/organisms/ChooseCreditsForm/ChooseCreditsForm.types';
-import { HandleSaveType } from 'components/templates/MultiStepTemplate/MultiStep.context';
 import { SellOrderInfoExtented } from 'hooks/useQuerySellOrders';
 
 import {
@@ -299,3 +300,65 @@ export const getCreditsAvailableBannerText = (
     other: `Credit amount adjusted: Only ${formattedCreditsAvailable} credits available in ${displayDenom}`,
   });
 };
+
+/**
+ * Resets the sell orders and the currency and credits amounts in both
+ * the buy credits form and the multiStep localStorage based on the provided data.
+ *
+ * @param paymentOption - The current selected payment option.
+ * @param orderedSellOrders - The list of sell orders.
+ * @param creditTypePrecision - The precision of the credit type.
+ * @param setValue - Function to set form values in react hook form.
+ * @param updateMultiStepData  - Function to update multiStep localStorage data (multiStep handleSave function).
+ * @param data - The multiStep data.
+ * @param activeStep - The current multiStep active step.
+ * @param currentCreditsAmount - The current amount of credits (optional).
+ */
+export function resetCurrencyAndCredits(
+  paymentOption: string,
+  orderedSellOrders: UISellOrderInfo[],
+  creditTypePrecision: number | null | undefined,
+  setValue: UseFormSetValue<any>,
+  updateMultiStepData: (
+    formValues: {} | BuyCreditsSchemaTypes,
+    nextStep: number,
+    dataDisplay?: any,
+  ) => void,
+  data: BuyCreditsSchemaTypes,
+  activeStep: number,
+  currentCreditsAmount: number = 1,
+) {
+  const { currencyAmount, sellOrders } = getCurrencyAmount({
+    currentCreditsAmount,
+    card: paymentOption === PAYMENT_OPTIONS.CARD,
+    orderedSellOrders,
+    creditTypePrecision,
+  });
+
+  let newCreditsAmount = currentCreditsAmount;
+  let newCurrencyAmount = currencyAmount;
+
+  if (
+    newCurrencyAmount < MIN_USD_CURRENCY_AMOUNT &&
+    paymentOption === PAYMENT_OPTIONS.CARD
+  ) {
+    newCreditsAmount = MIN_USD_CURRENCY_AMOUNT / currencyAmount;
+    newCurrencyAmount = MIN_USD_CURRENCY_AMOUNT;
+  }
+
+  setValue(CURRENCY_AMOUNT, newCurrencyAmount, {
+    shouldValidate: true,
+  });
+  setValue(CREDITS_AMOUNT, newCreditsAmount, { shouldValidate: true });
+  setValue(SELL_ORDERS, sellOrders);
+
+  updateMultiStepData(
+    {
+      ...data,
+      creditsAmount: newCreditsAmount,
+      currencyAmount: newCurrencyAmount,
+      sellOrders,
+    },
+    activeStep,
+  );
+}


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-410

Now when users interact with the forms the information should be stored in the localstorage automatically even when the next button hasn't been clicked yet, and therefore, on navigating away and back to the same page, users should be in the same step and see the same form data as before navigating away.  

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. https://deploy-preview-2574--regen-marketplace.netlify.app/project/mai-ndombe-4/buy
2. Edit the form and navigate away then come back to the same page and verify the step and the form data is the same as before navigating away. 

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
