### PR TITLE
fix: APP-536 show regen address instead of account id in user profile

### DIFF
--- a/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
+++ b/web-marketplace/src/pages/EcocreditsByAccount/EcocreditsByAccount.tsx
@@ -137,9 +137,9 @@ export const EcocreditsByAccount = (): JSX.Element => {
               infos={{
                 addressLink: {
                   href: address
-                    ? getAccountUrl(accountAddressOrId, true)
+                    ? getAccountUrl(address, true)
                     : `/profiles/${accountAddressOrId}/portfolio`,
-                  text: address ? truncate(accountAddressOrId) : '',
+                  text: address ? truncate(address) : '',
                 },
                 description: account?.description?.trimEnd() ?? '',
                 socialsLinks,


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-536

I have noticed that when clicking on the link to 'mintscan.io' it doesn't work with the [account id](https://www.mintscan.io/regen/address/29533874-7476-11ef-a949-0afffa81c869) but it does with the [regen address](https://www.mintscan.io/regen/address/regen16dk9z6pegzjfmu8v4xam04pfglvd4rwzpjruyj), so I have changed it, review this too please. 

The same thing doesn't work either in dev, is this known? In dev it points to 'https://redwood.regen.aneka.io/accounts/' instead of mintscan.io.

### Author Checklist

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. https://deploy-preview-2585--regen-marketplace.netlify.app/
2. Check the profile page of organization accounts show the regen address instead of the account id
3. Check that when clicking on the regen address the link works and mintscan.io loads as expected.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
