### PR TITLE
fix: APP-540 add support for commas in editable input

### DIFF
--- a/web-components/src/components/SupCurrencyAndAmount/SupCurrencyAndAmount.tsx
+++ b/web-components/src/components/SupCurrencyAndAmount/SupCurrencyAndAmount.tsx
@@ -1,5 +1,7 @@
 import { USD_DENOM } from 'web-marketplace/src/config/allowedBaseDenoms';
 
+import { localizeNumber } from '../inputs/new/EditableInput/EditableInput.utils';
+
 export function SupCurrencyAndAmount({
   price,
   currencyCode,
@@ -12,9 +14,11 @@ export function SupCurrencyAndAmount({
   return currencyCode && currencyCode === USD_DENOM ? (
     <span>
       <span className="align-top text-[11px] leading-normal">$</span>
-      <span className={className}>{Number(price).toFixed(2)}</span>
+      <span className={className}>
+        {localizeNumber(+Number(price).toFixed(2))}
+      </span>
     </span>
   ) : (
-    <span className={className}>{price}</span>
+    <span className={className}>{localizeNumber(+price)}</span>
   );
 }

--- a/web-components/src/components/inputs/new/EditableInput/EditableInput.tsx
+++ b/web-components/src/components/inputs/new/EditableInput/EditableInput.tsx
@@ -43,15 +43,12 @@ export const EditableInput = ({
   const [currentValue, setCurrentValue] = useState(value);
   const [decimalSeparator, setDecimalSeparator] = useState('.');
   const wrapperRef = useRef(null);
+  const formattedValue = +currentValue.replace('.', ',');
 
-  const amountValid =
-    +currentValue.replace(/,/g, '.') <= maxValue &&
-    +currentValue.replace(/,/g, '.') > 0;
+  const amountValid = formattedValue <= maxValue && formattedValue > 0;
 
   const isUpdateDisabled =
-    !amountValid ||
-    error?.hasError ||
-    +initialValue === +currentValue.replace(/,/g, '.');
+    !amountValid || error?.hasError || +initialValue === formattedValue;
 
   useEffect(() => {
     setInitialValue(value);
@@ -112,7 +109,7 @@ export const EditableInput = ({
 
   const handleOnUpdate = () => {
     if (isUpdateDisabled) return;
-    onChange(+currentValue.replace(/,/g, '.'));
+    onChange(formattedValue);
     toggleEditable();
   };
 

--- a/web-components/src/components/inputs/new/EditableInput/EditableInput.utils.ts
+++ b/web-components/src/components/inputs/new/EditableInput/EditableInput.utils.ts
@@ -1,19 +1,71 @@
+/*
+ * Sanitizes a string to ensure it represents a valid numeric format.
+ *
+ * @example
+ * sanitizeValue('.5')    // returns '0.5'
+ * sanitizeValue('01.23') // returns '1.23'
+ * sanitizeValue('1,23') // returns '1,23'
+ * sanitizeValue('abc')   // returns ''
+ * sanitizeValue('00')   // returns '0'
+ */
+
 export const sanitizeValue = (value: string): string => {
+  // Convert a leading '.' or ',' to '0.' or '0,'
   if (value.startsWith('.')) {
     return '0.';
   }
-  if (value === '0' || value.startsWith('0.')) {
-    // Disallow 0.[a-z]
-    if (/^0\.[a-zA-Z]/.test(value)) {
-      return '0.';
-    }
-    return value.replace(/(\..*?)\..*/g, '$1');
+  if (value.startsWith(',')) {
+    return '0,';
   }
-  // Strip leading zeros, non digits and multiple dots
-  const sanitized = value
-    .replace(/[^0-9.]/g, '')
-    .replace(/^0+/, '')
-    .replace(/(\..*?)\..*/g, '$1');
+
+  // Remove any character that is not a digit, comma, or period.
+  let sanitized = value.replace(/[^0-9.,]/g, '');
+
+  // Avoid having both a comma and a period at the same time
+  // If both comma and period exist, decide which one to keep by checking which comes first.
+  const commaIndex = sanitized.indexOf(',');
+  const periodIndex = sanitized.indexOf('.');
+  if (commaIndex !== -1 && periodIndex !== -1) {
+    if (commaIndex < periodIndex) {
+      // A comma appears first: remove all periods.
+      sanitized = sanitized.replace(/\./g, '');
+    } else {
+      // A period appears first: remove all commas.
+      sanitized = sanitized.replace(/,/g, '');
+    }
+  }
+
+  // Ensure only one instance of the remaining decimal separator is present.
+  if (sanitized.includes('.')) {
+    sanitized = sanitized.replace(/(\..*?)\..*/g, '$1');
+  }
+  if (sanitized.includes(',')) {
+    sanitized = sanitized.replace(/(,.*?),(.*)/g, '$1');
+  }
+
+  // Remove leading zeros, unless the number starts with '0.' or '0,'
+  if (!(sanitized.startsWith('0.') || sanitized.startsWith('0,'))) {
+    // If the entire string is zeros (e.g. "00"), return "0"
+    if (/^0+$/.test(sanitized)) {
+      sanitized = '0';
+    } else {
+      // If zeros are followed by other digits (e.g. "01"), remove the leading zeros.
+      sanitized = sanitized.replace(/^0+/, '');
+    }
+  }
 
   return sanitized ? sanitized : '';
+};
+
+export const localizeNumber = (
+  input: number,
+  locale = navigator.language || 'en-US',
+) => {
+  const number = Number(input);
+
+  // Format the number for the given locale
+  return new Intl.NumberFormat(locale, {
+    useGrouping: true,
+    minimumFractionDigits: 2,
+  }).format(number);
 };

--- a/web-components/src/utils/format.ts
+++ b/web-components/src/utils/format.ts
@@ -22,7 +22,9 @@ export function getFormattedNumber(
   number: number,
   options?: Intl.NumberFormatOptions | undefined,
 ): string {
-  return new Intl.NumberFormat('en-US', options).format(number);
+  return new Intl.NumberFormat(navigator.language || 'en-US', options).format(
+    number,
+  );
 }
 
 export function getFormattedPeriod(start: string, end: string | Date): string {

--- a/web-marketplace/src/components/molecules/OrderSummaryCard/OrderSummaryCard.test.tsx
+++ b/web-marketplace/src/components/molecules/OrderSummaryCard/OrderSummaryCard.test.tsx
@@ -47,7 +47,7 @@ describe('OrderSummaryCard', () => {
   it('displays the number of credits', () => {
     render(<OrderSummaryCard {...orderSummary} />);
 
-    const numberOfCredits = screen.getByText('5');
+    const numberOfCredits = screen.getByText('5.00');
     expect(numberOfCredits).toBeInTheDocument();
   });
 

--- a/web-marketplace/src/components/organisms/Order/Order.test.tsx
+++ b/web-marketplace/src/components/organisms/Order/Order.test.tsx
@@ -194,7 +194,7 @@ describe('Order Component', () => {
       />,
     );
     expect(screen.getByText(/2000/i)).toBeInTheDocument();
-    expect(screen.getByText(/400000/i)).toBeInTheDocument();
+    expect(screen.getByText(/400,000.00/i)).toBeInTheDocument();
     expect(screen.getAllByText(/usd/i)).toHaveLength(2);
   });
 


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-540

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. Verify that the decimal and thousands separators reflect the user's location in:
- Order summary card in the editable input and the prices => buy Credits flow step 2
- In the credits and currency inputs => buy Credits flow step 1
- Buy Credits flow  success modal
- My Orders page
- ... maybe we should standardise this and use the right numbers format based on location all across the marketplace, wdyt?

While working on this I've been changing the browser's language (in Chrome in Settings > Language > Preferred languages) and putting different languages on top makes the numbers format change. I haven't been able to see this settings update work on the buy credits flow step 1, although I think @blushi can see the French local format (commas) in step 1, is that right? 

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
