### PR TITLE
chore: APP-575 move NCT to footer

### DIFF
--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Footer.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Footer.tsx
@@ -37,6 +37,10 @@ const RegistryLayoutFooter: React.FC<React.PropsWithChildren<unknown>> = () => {
           title: _(msg`Storefront`),
           href: `/storefront`,
         },
+        {
+          title: 'NCT',
+          href: '/baskets/eco.uC.NCT',
+        },
       ],
     },
     {

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.config.tsx
@@ -34,10 +34,6 @@ import { Link } from 'components/atoms';
 
 export const getMenuItems = (pathname: string, _: TranslatorType): Item[] => [
   {
-    title: 'NCT',
-    href: '/baskets/eco.uC.NCT',
-  },
-  {
     title: _(msg`Projects`),
     dropdownItems: [
       {


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-575
Only moved NCT header nav item to footer, the other items mentioned in the task description had already been done.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2601--regen-marketplace.netlify.app/
Check NCT header nav item has been moved to the footer under "Trade"

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
