### PR TITLE
fix: APP-594 clear localStorage items related to buy credits on logout

### DIFF
--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
@@ -9,7 +9,10 @@ import CheckboxLabel from 'web-components/src/components/inputs/new/CheckboxLabe
 import { PrevNextButtons } from 'web-components/src/components/molecules/PrevNextButtons/PrevNextButtons';
 import { Body } from 'web-components/src/components/typography/Body';
 
-import { cardDetailsMissingAtom } from 'pages/BuyCredits/BuyCredits.atoms';
+import {
+  cardDetailsMissingAtom,
+  resetBuyCreditsFormAtom,
+} from 'pages/BuyCredits/BuyCredits.atoms';
 import AgreeErpaCheckbox from 'components/atoms/AgreeErpaCheckboxNew';
 import Form from 'components/molecules/Form/Form';
 import { useZodForm } from 'components/molecules/Form/hook/useZodForm';
@@ -52,16 +55,24 @@ export const AgreePurchaseForm = ({
   isCardPayment,
 }: AgreePurchaseFormProps) => {
   const { _ } = useLingui();
-  const { handleBack, handleActiveStep } = useMultiStep();
+  const {
+    handleBack,
+    handleActiveStep,
+    handleResetData: removeMultiStepFormData,
+  } = useMultiStep();
   const [cardDetailsMissing, setCardDetailsMissing] = useAtom(
     cardDetailsMissingAtom,
   );
+  const [shouldResetForm, setShouldResetForm] = useAtom(
+    resetBuyCreditsFormAtom,
+  );
+
   const form = useZodForm({
     schema: agreePurchaseFormSchema(retiring),
     defaultValues: initialValues,
     mode: 'onBlur',
   });
-  const { errors, isValid, isSubmitting } = useFormState({
+  const { isValid, isSubmitting } = useFormState({
     control: form.control,
   });
 
@@ -99,6 +110,17 @@ export const AgreePurchaseForm = ({
       setCardDetailsMissing(true);
     };
   }, [setCardDetailsMissing]);
+
+  // Reset form on log out
+  useEffect(() => {
+    if (shouldResetForm) {
+      setShouldResetForm(false);
+      // On form reset, remove multi-step form data,
+      // and reset the current form fields
+      removeMultiStepFormData();
+      form.reset();
+    }
+  }, [shouldResetForm, form, removeMultiStepFormData, setShouldResetForm]);
 
   return (
     <Form

--- a/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
+++ b/web-marketplace/src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.tsx
@@ -119,8 +119,15 @@ export const AgreePurchaseForm = ({
       // and reset the current form fields
       removeMultiStepFormData();
       form.reset();
+      handleActiveStep(0);
     }
-  }, [shouldResetForm, form, removeMultiStepFormData, setShouldResetForm]);
+  }, [
+    shouldResetForm,
+    form,
+    removeMultiStepFormData,
+    setShouldResetForm,
+    handleActiveStep,
+  ]);
 
   return (
     <Form

--- a/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.tsx
+++ b/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.tsx
@@ -125,6 +125,7 @@ export const ChooseCreditsForm = React.memo(
       handleSave: updateMultiStepData,
       activeStep,
       handleResetData: removeMultiStepFormData,
+      handleActiveStep,
     } = useMultiStep<BuyCreditsSchemaTypes>();
     const [paymentOption, setPaymentOption] = useAtom(paymentOptionAtom);
     const [shouldResetForm, setShouldResetForm] = useAtom(
@@ -305,8 +306,16 @@ export const ChooseCreditsForm = React.memo(
         // and reset the current form fields
         removeMultiStepFormData();
         form.reset();
+
+        handleActiveStep(0);
       }
-    }, [shouldResetForm, form, removeMultiStepFormData, setShouldResetForm]);
+    }, [
+      shouldResetForm,
+      form,
+      removeMultiStepFormData,
+      setShouldResetForm,
+      handleActiveStep,
+    ]);
 
     // Advanced settings not enabled for MVP
     // const [advanceSettingsOpen, setAdvanceSettingsOpen] = useState(false);

--- a/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.tsx
+++ b/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.tsx
@@ -30,6 +30,7 @@ import { warningBannerTextAtom } from 'lib/atoms/banner.atoms';
 
 import {
   paymentOptionAtom,
+  resetBuyCreditsFormAtom,
   spendingCapAtom,
 } from 'pages/BuyCredits/BuyCredits.atoms';
 import {
@@ -123,9 +124,12 @@ export const ChooseCreditsForm = React.memo(
       data,
       handleSave: updateMultiStepData,
       activeStep,
+      handleResetData: removeMultiStepFormData,
     } = useMultiStep<BuyCreditsSchemaTypes>();
     const [paymentOption, setPaymentOption] = useAtom(paymentOptionAtom);
-
+    const [shouldResetForm, setShouldResetForm] = useAtom(
+      resetBuyCreditsFormAtom,
+    );
     const cryptoCurrencies = useMemo(
       () => getCryptoCurrencies(cryptoSellOrders),
       [cryptoSellOrders],
@@ -292,6 +296,17 @@ export const ChooseCreditsForm = React.memo(
         form.trigger();
       }
     }, [form, form.trigger, creditsAvailable, spendingCap]);
+
+    // Reset form on log out
+    useEffect(() => {
+      if (shouldResetForm) {
+        setShouldResetForm(false);
+        // On form reset, remove multi-step form data,
+        // and reset the current form fields
+        removeMultiStepFormData();
+        form.reset();
+      }
+    }, [shouldResetForm, form, removeMultiStepFormData, setShouldResetForm]);
 
     // Advanced settings not enabled for MVP
     // const [advanceSettingsOpen, setAdvanceSettingsOpen] = useState(false);

--- a/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
+++ b/web-marketplace/src/components/organisms/PaymentInfoForm/PaymentInfoForm.tsx
@@ -66,6 +66,7 @@ export const PaymentInfoForm = ({
     activeStep,
     data,
     handleResetData: removeMultiStepFormData,
+    handleActiveStep,
   } = useMultiStep();
   const [paymentInfoValid, setPaymentInfoValid] = useState(false);
   const setCardDetailsMissing = useSetAtom(cardDetailsMissingAtom);
@@ -113,6 +114,8 @@ export const PaymentInfoForm = ({
 
       // force Stripe Elements to re-render
       setPaymentElementKey(prev => prev + 1);
+
+      handleActiveStep(0);
     }
   }, [
     shouldResetForm,
@@ -122,6 +125,7 @@ export const PaymentInfoForm = ({
     accountName,
     paymentMethods,
     setShouldResetForm,
+    handleActiveStep,
   ]);
 
   const paymentMethodId = useWatch({

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -15,6 +15,7 @@ import { useAuth } from 'lib/auth/auth';
 import { getPaymentMethodsQuery } from 'lib/queries/react-query/registry-server/getPaymentMethodsQuery/getPaymentMethodsQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
+import { BUY_CREDITS_FORM_PREFIX } from 'pages/BuyCredits/BuyCredits.constants';
 import { getWalletAddress } from 'pages/Dashboard/Dashboard.utils';
 import { useProfileItems } from 'pages/Dashboard/hooks/useProfileItems';
 import { getDefaultAvatar } from 'pages/ProfileEdit/ProfileEdit.utils';
@@ -113,6 +114,15 @@ const RegistryLayoutHeader: React.FC = () => {
     ? headerColors[pathname]
     : theme.palette.primary.light;
 
+  const onLogOut = () => {
+    disconnect && disconnect();
+
+    // Remove all localStorage items related with the buy credits flow
+    Object.keys(localStorage)
+      .filter(key => key.startsWith(BUY_CREDITS_FORM_PREFIX))
+      .forEach(key => localStorage.removeItem(key));
+  };
+
   return (
     <>
       <Header
@@ -148,7 +158,7 @@ const RegistryLayoutHeader: React.FC = () => {
                 avatar={
                   activeAccount?.image ? activeAccount?.image : defaultAvatar
                 }
-                disconnect={disconnect}
+                disconnect={onLogOut}
                 pathname={pathname}
                 linkComponent={RegistryNavLink}
                 userMenuItems={userMenuItems}

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -15,7 +15,6 @@ import { useAuth } from 'lib/auth/auth';
 import { getPaymentMethodsQuery } from 'lib/queries/react-query/registry-server/getPaymentMethodsQuery/getPaymentMethodsQuery';
 import { useWallet } from 'lib/wallet/wallet';
 
-import { BUY_CREDITS_FORM_PREFIX } from 'pages/BuyCredits/BuyCredits.constants';
 import { getWalletAddress } from 'pages/Dashboard/Dashboard.utils';
 import { useProfileItems } from 'pages/Dashboard/hooks/useProfileItems';
 import { getDefaultAvatar } from 'pages/ProfileEdit/ProfileEdit.utils';
@@ -114,15 +113,6 @@ const RegistryLayoutHeader: React.FC = () => {
     ? headerColors[pathname]
     : theme.palette.primary.light;
 
-  const onLogOut = async () => {
-    await disconnect();
-
-    // Remove all localStorage items related with the buy credits flow
-    Object.keys(localStorage)
-      .filter(key => key.startsWith(BUY_CREDITS_FORM_PREFIX))
-      .forEach(key => localStorage.removeItem(key));
-  };
-
   return (
     <>
       <Header
@@ -158,7 +148,7 @@ const RegistryLayoutHeader: React.FC = () => {
                 avatar={
                   activeAccount?.image ? activeAccount?.image : defaultAvatar
                 }
-                disconnect={onLogOut}
+                disconnect={disconnect}
                 pathname={pathname}
                 linkComponent={RegistryNavLink}
                 userMenuItems={userMenuItems}

--- a/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
+++ b/web-marketplace/src/components/organisms/RegistryLayout/RegistryLayout.Header.tsx
@@ -114,8 +114,8 @@ const RegistryLayoutHeader: React.FC = () => {
     ? headerColors[pathname]
     : theme.palette.primary.light;
 
-  const onLogOut = () => {
-    disconnect && disconnect();
+  const onLogOut = async () => {
+    await disconnect();
 
     // Remove all localStorage items related with the buy credits flow
     Object.keys(localStorage)
@@ -146,7 +146,7 @@ const RegistryLayoutHeader: React.FC = () => {
                 isHome && 'text-sc-button-text-icon-light',
               )}
             /> */}
-            {chainId && accountOrWallet && disconnect && (
+            {chainId && accountOrWallet && (
               <UserMenuItems
                 nameOrAddress={
                   activeAccount?.name ||

--- a/web-marketplace/src/components/templates/MultiStepTemplate/MultiStep.context.tsx
+++ b/web-marketplace/src/components/templates/MultiStepTemplate/MultiStep.context.tsx
@@ -43,6 +43,7 @@ type ContextProps<T extends object> = {
   handleResetReview: () => void;
   handleSuccess: () => void;
   handleError: () => void;
+  handleResetData: () => void;
   resultStatus: ResultStatus;
 };
 
@@ -65,6 +66,7 @@ const initialValues = {
   handleResetReview: () => {},
   handleSuccess: () => {},
   handleError: () => {},
+  handleResetData: () => {},
 };
 
 const MultiStepContext = React.createContext<ContextProps<{}>>(initialValues);
@@ -195,6 +197,7 @@ export function MultiStepProvider<T extends object>({
     handleResetReview,
     handleSuccess,
     handleError,
+    handleResetData,
     resultStatus,
   };
 

--- a/web-marketplace/src/lib/wallet/hooks/useDisconnect.tsx
+++ b/web-marketplace/src/lib/wallet/hooks/useDisconnect.tsx
@@ -3,6 +3,8 @@ import { useWallet } from '@cosmos-kit/react-lite';
 
 import { UseStateSetter } from 'types/react/use-state';
 
+import { BUY_CREDITS_FORM_PREFIX } from 'pages/BuyCredits/BuyCredits.constants';
+
 import { Wallet } from '../wallet';
 import {
   AUTO_CONNECT_WALLET_KEY,
@@ -44,6 +46,11 @@ export const useDisconnect = ({
     walletConfigRef.current = undefined;
     localStorage.removeItem(AUTO_CONNECT_WALLET_KEY);
     localStorage.removeItem(WALLET_CONNECT_KEY);
+
+    // Remove all localStorage items related with the buy credits flow
+    Object.keys(localStorage)
+      .filter(key => key.startsWith(BUY_CREDITS_FORM_PREFIX))
+      .forEach(key => localStorage.removeItem(key));
 
     // signArbitrary (used in login) not yet supported by @keplr-wallet/wc-client
     // https://github.com/chainapsis/keplr-wallet/issues/664

--- a/web-marketplace/src/lib/wallet/hooks/useDisconnect.tsx
+++ b/web-marketplace/src/lib/wallet/hooks/useDisconnect.tsx
@@ -1,8 +1,10 @@
 import { MutableRefObject, useCallback } from 'react';
 import { useWallet } from '@cosmos-kit/react-lite';
+import { useSetAtom } from 'jotai';
 
 import { UseStateSetter } from 'types/react/use-state';
 
+import { resetBuyCreditsFormAtom } from 'pages/BuyCredits/BuyCredits.atoms';
 import { BUY_CREDITS_FORM_PREFIX } from 'pages/BuyCredits/BuyCredits.constants';
 
 import { Wallet } from '../wallet';
@@ -34,6 +36,7 @@ export const useDisconnect = ({
   setWalletConnect,
 }: Props): DisconnectType => {
   const { mainWallet } = useWallet(KEPLR_MOBILE);
+  const setShouldResetBuyCreditsForm = useSetAtom(resetBuyCreditsFormAtom);
 
   const disconnect = useCallback(async (): Promise<void> => {
     if (walletConnect && mainWallet) {
@@ -46,6 +49,8 @@ export const useDisconnect = ({
     walletConfigRef.current = undefined;
     localStorage.removeItem(AUTO_CONNECT_WALLET_KEY);
     localStorage.removeItem(WALLET_CONNECT_KEY);
+
+    setShouldResetBuyCreditsForm(true);
 
     // Remove all localStorage items related with the buy credits flow
     Object.keys(localStorage)
@@ -61,6 +66,7 @@ export const useDisconnect = ({
     setWallet,
     setConnectionType,
     walletConfigRef,
+    setShouldResetBuyCreditsForm,
     logout,
     setWalletConnect,
   ]);

--- a/web-marketplace/src/lib/wallet/wallet.tsx
+++ b/web-marketplace/src/lib/wallet/wallet.tsx
@@ -73,7 +73,7 @@ export type WalletContextType = {
   loaded: boolean;
   connect?: (params: ConnectParams) => Promise<void>;
   connectWallet?: ConnectWalletType;
-  disconnect?: () => void;
+  disconnect: () => Promise<void>;
   handleAddAddress?: () => Promise<void>;
   connectionType?: string;
   error?: unknown;
@@ -90,6 +90,7 @@ const WalletContext = createContext<WalletContextType>({
   accountChanging: false,
   isKeplrMobileWeb: false,
   loginDisabled: false,
+  disconnect: async () => {},
 });
 
 export const WalletProvider: React.FC<React.PropsWithChildren<unknown>> = ({

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.atoms.ts
@@ -10,3 +10,5 @@ export const paymentOptionAtom = atom<PaymentOptionsType>(
   PAYMENT_OPTIONS.CRYPTO,
 );
 export const cardDetailsMissingAtom = atom(true);
+
+export const resetBuyCreditsFormAtom = atom(false);

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.constants.ts
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.constants.ts
@@ -17,3 +17,4 @@ export const RETIREMENT = msg`Retirement`;
 export const AGREE_PURCHASE = `Agree & purchase`;
 export const COMPLETE = msg`Complete`;
 export const EMAIL_RECEIPT = msg`We have emailed you a receipt to`;
+export const BUY_CREDITS_FORM_PREFIX = 'buy-credits-';

--- a/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
+++ b/web-marketplace/src/pages/BuyCredits/BuyCredits.utils.tsx
@@ -39,6 +39,7 @@ import { CardSellOrder } from 'components/organisms/ChooseCreditsForm/ChooseCred
 
 import {
   AGREE_PURCHASE,
+  BUY_CREDITS_FORM_PREFIX,
   CHOOSE_CREDITS,
   COMPLETE,
   CUSTOMER_INFO,
@@ -216,7 +217,7 @@ export const getFormModel = ({
     : undefined;
 
   return {
-    formId: `buy-credits-${projectId}`,
+    formId: `${BUY_CREDITS_FORM_PREFIX}${projectId}`,
     steps: [
       {
         id: 'choose-credits',


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-594

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. Navigate to the buy credits flow step 1 of a project: https://deploy-preview-2615--regen-marketplace.netlify.app/project/C01-007/buy
2. Log in
3. Open developer tools (right click > inspect)
4. Go to the tab `Application` and on the left sidebar go to `Storage` and open `Local Storage`
5. Find the item starting with `https://deploy-preview-2615--regen-marketplace.netlify.app/` and click on it
6. On the right panel you'll see a table with a heading called `key` and inside items with different names.
7. Find the ones starting with `buy-credits-`
8. Log out
9. All the items stariting with `buy-credits-` should be deleted.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
