### PR TITLE
fix: get sanity project using slug if any in useGetProject

### DIFF
--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
@@ -99,12 +99,6 @@ export const useGetProject = () => {
 
   const anchoredMetadata = data as AnchoredProjectMetadataLD | undefined;
 
-  const { isBuyFlowDisabled, projectsWithOrderData, loadingBuySellOrders } =
-    useBuySellOrderData({
-      projectId: onChainProjectId,
-      isOffChainProject: !onChainProjectId,
-    });
-
   const offChainProjectById = offchainProjectByIdData?.data.projectById;
   const publishedOffchainProjectById = offChainProjectById?.published
     ? offChainProjectById
@@ -130,15 +124,22 @@ export const useGetProject = () => {
     }),
   );
 
-  const sellOrders = projectsWithOrderData?.[0]?.filteredSellOrders || [];
-  const cardSellOrders = projectsWithOrderData?.[0]?.cardSellOrders || [];
-
   const slug =
     offchainProjectByIdData?.data?.projectById?.slug ||
     projectByOnChainId?.data?.projectByOnChainId?.slug ||
     projectBySlug?.data.projectBySlug?.slug;
 
   const slugOrId = slug || onChainProjectId || offChainProject?.id;
+
+  const { isBuyFlowDisabled, projectsWithOrderData, loadingBuySellOrders } =
+    useBuySellOrderData({
+      projectId: onChainProjectId,
+      projectSlugOrId: slugOrId,
+      isOffChainProject: !onChainProjectId,
+    });
+
+  const sellOrders = projectsWithOrderData?.[0]?.filteredSellOrders || [];
+  const cardSellOrders = projectsWithOrderData?.[0]?.cardSellOrders || [];
 
   const { data: sanityProjectData, isInitialLoading: loadingSanityProject } =
     useQuery(

--- a/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
+++ b/web-marketplace/src/components/templates/ProjectDetails/hooks/useGetProject.ts
@@ -31,17 +31,6 @@ export const useGetProject = () => {
   const isOnChainId = getIsOnChainId(projectId);
   const isOffChainUuid = getIsUuid(projectId);
 
-  const { data: sanityProjectData, isInitialLoading: loadingSanityProject } =
-    useQuery(
-      getProjectByIdQuery({
-        id: projectId as string,
-        sanityClient,
-        enabled: !!sanityClient && !!projectId,
-        languageCode: selectedLanguage,
-      }),
-    );
-  const sanityProject = sanityProjectData?.allProject?.[0];
-
   // if projectId is slug, query project by slug
   const { data: projectBySlug, isInitialLoading: loadingProjectBySlug } =
     useQuery(
@@ -148,6 +137,19 @@ export const useGetProject = () => {
     offchainProjectByIdData?.data?.projectById?.slug ||
     projectByOnChainId?.data?.projectByOnChainId?.slug ||
     projectBySlug?.data.projectBySlug?.slug;
+
+  const slugOrId = slug || onChainProjectId || offChainProject?.id;
+
+  const { data: sanityProjectData, isInitialLoading: loadingSanityProject } =
+    useQuery(
+      getProjectByIdQuery({
+        id: slugOrId as string,
+        sanityClient,
+        enabled: !!sanityClient && !!slugOrId,
+        languageCode: selectedLanguage,
+      }),
+    );
+  const sanityProject = sanityProjectData?.allProject?.[0];
 
   const loadingDb =
     loadingProjectByOnChainId ||

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -252,8 +252,7 @@ export function useProjectsWithOrders({
         );
         const sanityProject = sanityProjectsData?.allProject?.find(
           sanityProject =>
-            sanityProject.projectId === project?.id ||
-            sanityProject.projectId === offChainProject?.slug,
+            sanityProject.projectId === (offChainProject?.slug ?? project?.id),
         );
 
         const allCardSellOrders = getCardSellOrders(

--- a/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
+++ b/web-marketplace/src/hooks/projects/useProjectsWithOrders.ts
@@ -63,6 +63,7 @@ export interface ProjectsWithOrdersProps {
   marketTypeFilter?: Record<string, boolean>;
   buyingOptionsFilters?: Record<string, boolean>;
   isOffChainProject?: boolean;
+  projectSlugOrId?: string;
 }
 
 /**
@@ -88,6 +89,9 @@ export function useProjectsWithOrders({
   marketTypeFilter = { COMPLIANCE_MARKET: true, VOLUNTARY_MARKET: true },
   buyingOptionsFilters = {},
   isOffChainProject = false,
+  // projectSlugOrId is provided from useGetProject which already fetches the individual off-chain project,
+  // so we don't have to fetch all off chain projects to find the project slug in this hook
+  projectSlugOrId,
 }: ProjectsWithOrdersProps): ProjectsSellOrders {
   const { ecocreditClient, marketplaceClient, dataClient } = useLedger();
   const graphqlClient = useApolloClient();
@@ -424,7 +428,7 @@ export function useProjectsWithOrders({
   // Sanity projects
   const sanityProjectsResults = useQueries({
     queries: sortedProjects?.map(project => {
-      const id = project?.slug || project?.id;
+      const id = projectSlugOrId || project?.slug || project?.id;
       return getProjectByIdQuery({
         id: id as string,
         sanityClient,

--- a/web-marketplace/src/hooks/useBuySellOrderData.tsx
+++ b/web-marketplace/src/hooks/useBuySellOrderData.tsx
@@ -6,6 +6,7 @@ type Props = {
   projectId?: string;
   classId?: string;
   isOffChainProject?: boolean;
+  projectSlugOrId?: string;
 };
 
 type ResponseType = {
@@ -18,14 +19,16 @@ export const useBuySellOrderData = ({
   projectId,
   classId,
   isOffChainProject = false,
+  projectSlugOrId,
 }: Props): ResponseType => {
   const { projectsWithOrderData, loading: loadingProjects } =
     useProjectsWithOrders({
       projectId,
       classId,
-      enableOffchainProjectsQuery: false,
+      enableOffchainProjectsQuery: projectSlugOrId ? false : true,
       showCommunityProjects: true,
       isOffChainProject,
+      projectSlugOrId,
     });
 
   const isBuyFlowDisabled =

--- a/web-marketplace/src/hooks/useBuySellOrderData.tsx
+++ b/web-marketplace/src/hooks/useBuySellOrderData.tsx
@@ -25,7 +25,7 @@ export const useBuySellOrderData = ({
     useProjectsWithOrders({
       projectId,
       classId,
-      enableOffchainProjectsQuery: projectSlugOrId ? false : true,
+      enableOffchainProjectsQuery: !projectSlugOrId,
       showCommunityProjects: true,
       isOffChainProject,
       projectSlugOrId,


### PR DESCRIPTION
## Description

Did not create a task but small fix to get into the release

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

When accessing a project buy page that has a slug, check that the fiat credits should be based on the sanity project data identified with this slug, ie for the C01-001 on chain project that has a slug mai-ndombe-4 on staging, it should fetch data from https://regen.sanity.studio/staging/structure/shared;projects;english;63de6010-79cd-4bf3-a89c-916d8337e1ba, not https://regen.sanity.studio/staging/structure/shared;projects;english;c57f9531-2711-44ca-90b3-2f5931579690 

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
