### PR TITLE
fix: APP-598 filters 'apply' and 'close' buttons position on mobile

### DIFF
--- a/web-components/src/components/organisms/ProjectFilters/ProjectFilters.tsx
+++ b/web-components/src/components/organisms/ProjectFilters/ProjectFilters.tsx
@@ -35,13 +35,13 @@ export default function ProjectFilters({
   onFilterReset,
   labels,
   showResetButton = true,
-  classNames,
+  className,
 }: {
   filters: Filter[];
   onFilterReset: () => void;
   labels: ProjectFilterLabels;
   showResetButton?: boolean;
-  classNames?: string;
+  className?: string;
 }) {
   const [isExpanded, setIsExpanded] = useState<Record<number, boolean>>({});
   const handleExpand = (index: number) => {
@@ -51,7 +51,7 @@ export default function ProjectFilters({
   const filtersLength = displayedFilters.length;
 
   return (
-    <div className={classNames}>
+    <div className={className}>
       <div className="justify-between items-baseline flex">
         <div className="text-[18px] font-bold">{labels.title}</div>
         {showResetButton && (

--- a/web-components/src/components/organisms/ProjectFilters/ProjectFilters.tsx
+++ b/web-components/src/components/organisms/ProjectFilters/ProjectFilters.tsx
@@ -35,11 +35,13 @@ export default function ProjectFilters({
   onFilterReset,
   labels,
   showResetButton = true,
+  classNames,
 }: {
   filters: Filter[];
   onFilterReset: () => void;
   labels: ProjectFilterLabels;
   showResetButton?: boolean;
+  classNames?: string;
 }) {
   const [isExpanded, setIsExpanded] = useState<Record<number, boolean>>({});
   const handleExpand = (index: number) => {
@@ -49,7 +51,7 @@ export default function ProjectFilters({
   const filtersLength = displayedFilters.length;
 
   return (
-    <>
+    <div className={classNames}>
       <div className="justify-between items-baseline flex">
         <div className="text-[18px] font-bold">{labels.title}</div>
         {showResetButton && (
@@ -127,6 +129,6 @@ export default function ProjectFilters({
           </Box>
         );
       })}
-    </>
+    </div>
   );
 }

--- a/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterBody.tsx
+++ b/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterBody.tsx
@@ -40,7 +40,7 @@ type Props = {
   buyingOptionsFilterOptions: FilterOption[];
   mobile?: boolean;
   onCloseFilterModal?: () => void;
-  classNames?: string;
+  className?: string;
 };
 
 const ProjectFilterBody = ({
@@ -52,7 +52,7 @@ const ProjectFilterBody = ({
   buyingOptionsFilterOptions,
   mobile, // on mobile, filters are only applied after clicking "apply filters" button
   onCloseFilterModal,
-  classNames,
+  className,
 }: Props) => {
   const { _ } = useLingui();
 
@@ -123,7 +123,7 @@ const ProjectFilterBody = ({
   return (
     <>
       <ProjectFilters
-        classNames={classNames}
+        className={className}
         filters={[
           {
             selectedFilters: prefinance

--- a/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterBody.tsx
+++ b/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterBody.tsx
@@ -40,6 +40,7 @@ type Props = {
   buyingOptionsFilterOptions: FilterOption[];
   mobile?: boolean;
   onCloseFilterModal?: () => void;
+  classNames?: string;
 };
 
 const ProjectFilterBody = ({
@@ -51,6 +52,7 @@ const ProjectFilterBody = ({
   buyingOptionsFilterOptions,
   mobile, // on mobile, filters are only applied after clicking "apply filters" button
   onCloseFilterModal,
+  classNames,
 }: Props) => {
   const { _ } = useLingui();
 
@@ -121,6 +123,7 @@ const ProjectFilterBody = ({
   return (
     <>
       <ProjectFilters
+        classNames={classNames}
         filters={[
           {
             selectedFilters: prefinance
@@ -187,7 +190,7 @@ const ProjectFilterBody = ({
         }}
       />
       {mobile && (
-        <div className="shadow-[0_-4px_10px_0_rgba(0,0,0,0.10)] fixed bottom-0 left-0 w-full border-0 border-solid border-t border-sc-surface-stroke flex justify-end h-[62px] py-10 px-20 bg-sc-surface-page-background-light">
+        <div className="shadow-[0_-4px_10px_0_rgba(0,0,0,0.10)] sticky bottom-0 left-0 w-full border-0 border-solid border-t border-sc-surface-stroke flex justify-end h-[62px] py-10 px-20 bg-sc-surface-page-background-light">
           <ContainedButton
             onClick={() => {
               setClientFilters();

--- a/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterMobile.tsx
+++ b/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterMobile.tsx
@@ -68,7 +68,11 @@ const ProjectFilterMobile = ({
           : _(ADD_FILTERS_MODAL_BUTTON)}
         {numberOfSelectedFilters ? ` (${numberOfSelectedFilters})` : ''}
       </OutlinedButton>
-      <Modal open={isOpen} onClose={onClose} className="h-full">
+      <Modal
+        open={isOpen}
+        onClose={onClose}
+        className="!pb-0 !pl-0 !pr-0 flex flex-col h-full"
+      >
         <ProjectFilterBody
           allProjects={allProjects}
           creditClassFilterOptions={creditClassFilterOptions}
@@ -78,6 +82,7 @@ const ProjectFilterMobile = ({
           buyingOptionsFilterOptions={buyingOptionsFilterOptions}
           onCloseFilterModal={onClose}
           mobile
+          classNames="pl-[43px] pr-[43px] overflow-auto h-full"
         />
       </Modal>
     </>

--- a/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterMobile.tsx
+++ b/web-marketplace/src/pages/Projects/AllProjects/AllProjects.ProjectFilterMobile.tsx
@@ -82,7 +82,7 @@ const ProjectFilterMobile = ({
           buyingOptionsFilterOptions={buyingOptionsFilterOptions}
           onCloseFilterModal={onClose}
           mobile
-          classNames="pl-[43px] pr-[43px] overflow-auto h-full"
+          className="pl-20 pr-20 overflow-auto h-full"
         />
       </Modal>
     </>


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-598

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. Go to the projects page and resize the screen to between 640px and 1024px wide: https://deploy-preview-2622--regen-marketplace.netlify.app/projects/1
2. Open the filters and click on 'see more' under Credit class filters so the scrollbar appears.
3. Scroll to the bottom of the filter and verify that the button to apply the filters stays at the bottom of the modal and the X close button stays at the top and always visible.
4. Verify that this is the case for screens below 640px as well.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
