### PR TITLE
fix: APP-624 use getHashUrl for blockchain record link

### DIFF
--- a/web-marketplace/src/components/organisms/ConfirmationModal.tsx
+++ b/web-marketplace/src/components/organisms/ConfirmationModal.tsx
@@ -8,6 +8,8 @@ import Card from 'web-components/src/components/cards/Card';
 import Modal, { RegenModalProps } from 'web-components/src/components/modal';
 import { Body, Label, Title } from 'web-components/src/components/typography';
 
+import { getHashUrl } from 'lib/block-explorer';
+
 import CowIllustration from '../../assets/cow-illustration.png';
 import CarbonCreditFruit from '../../assets/svgs/carbon-credit-fruit.svg';
 
@@ -134,9 +136,7 @@ const ConfirmationModal: React.FC<React.PropsWithChildren<Props>> = ({
             <Link
               color="secondary.main"
               fontWeight={700}
-              href={`${
-                import.meta.env.VITE_BLOCK_EXPLORER
-              }/txs/${transactionHash}`}
+              href={getHashUrl(transactionHash)}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/web-marketplace/src/components/organisms/Order/Order.Summary.tsx
+++ b/web-marketplace/src/components/organisms/Order/Order.Summary.tsx
@@ -8,6 +8,8 @@ import CreditsIcon from 'web-components/src/components/icons/CreditsIcon';
 import { PaymentInfoIcon } from 'web-components/src/components/icons/PaymentInfoIcon';
 import QuestionMarkTooltip from 'web-components/src/components/tooltip/QuestionMarkTooltip';
 
+import { getHashUrl } from 'lib/block-explorer';
+
 import { Link } from 'components/atoms';
 import { AmountWithCurrency } from 'components/molecules/AmountWithCurrency/AmountWithCurrency';
 import { DenomIconWithCurrency } from 'components/molecules/DenomIconWithCurrency/DenomIconWithCurrency';
@@ -190,9 +192,7 @@ export const OrderSummary = ({
             }
             value={
               <Link
-                href={`${
-                  import.meta.env.VITE_BLOCK_EXPLORER
-                }/txs/${blockchainRecord}`}
+                href={getHashUrl(blockchainRecord)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-grey-700 inline-block text-ellipsis w-[100px] overflow-hidden border-0 border-b-[1px] border-solid leading-5"


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-624

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

This is hardly testable on staging since we do not have a working block explorer for redwood.
But now using `getHashUrl` allows to adjust the tx URL based on the environment and explorer since different block explorers may use different paths. In particular, on mintscan, we were missing some `regen/` in the URL 

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
