### PR TITLE
fix: AP-617 network errors handling

### DIFF
--- a/web-marketplace/package.json
+++ b/web-marketplace/package.json
@@ -58,6 +58,7 @@
     "history": "^5.3.0",
     "immer": "^9.0.19",
     "install": "^0.13.0",
+    "is-network-error": "^1.1.0",
     "jotai": "^2.0.1",
     "jotai-immer": "^0.2.0",
     "jsonld": "5.2.0",

--- a/web-marketplace/src/clients/Clients.constants.tsx
+++ b/web-marketplace/src/clients/Clients.constants.tsx
@@ -1,9 +1,12 @@
-import { lazy, ReactNode } from 'react';
+import { ReactNode } from 'react';
+import { safeLazy } from 'utils/safeLazy';
 
 import { CLIENT_CONFIG, MARKETPLACE_CLIENT_TYPE } from './Clients.types';
 
-const RegenProvider = lazy(() => import('./regen/Regen.Providers'));
-const TerrasosProvider = lazy(() => import('./terrasos/Terrasos.Providers'));
+const RegenProvider = safeLazy(() => import('./regen/Regen.Providers'));
+const TerrasosProvider = safeLazy(
+  () => import('./terrasos/Terrasos.Providers'),
+);
 
 export const PROVIDERS_MAPPING: Record<MARKETPLACE_CLIENT_TYPE, ReactNode> = {
   regen: <RegenProvider />,

--- a/web-marketplace/src/clients/regen/Regen.Routes.tsx
+++ b/web-marketplace/src/clients/regen/Regen.Routes.tsx
@@ -11,6 +11,7 @@ import {
 import { Router } from '@remix-run/router';
 import * as Sentry from '@sentry/react';
 import { QueryClient } from '@tanstack/react-query';
+import { safeLazy } from 'utils/safeLazy';
 
 import { Maybe } from 'generated/graphql';
 import { ApolloClientFactory } from 'lib/clients/apolloClientFactory';
@@ -46,52 +47,63 @@ import { projectDetailsLoader } from 'components/templates/ProjectDetails/Projec
 import { KeplrRoute } from '../../components/atoms';
 import { ProjectMetadata } from '../../pages/ProjectMetadata/ProjectMetadata';
 
-const Additionality = lazy(() => import('../../pages/Additionality'));
-const AllProjects = lazy(() => import('../../pages/Projects/AllProjects'));
-const BasicInfo = lazy(() => import('../../pages/BasicInfo'));
-const BatchDetails = lazy(() => import('../../pages/BatchDetails'));
-const BasketDetails = lazy(() => import('../../pages/BasketDetails'));
-const BuyCredits = lazy(() => import('../../pages/BuyCredits'));
-const ChooseCreditClassPage = lazy(
+const Additionality = safeLazy(() => import('../../pages/Additionality'));
+const AllProjects = safeLazy(() => import('../../pages/Projects/AllProjects'));
+const BasicInfo = safeLazy(() => import('../../pages/BasicInfo'));
+const BatchDetails = safeLazy(() => import('../../pages/BatchDetails'));
+const BasketDetails = safeLazy(() => import('../../pages/BasketDetails'));
+const BuyCredits = safeLazy(() => import('../../pages/BuyCredits'));
+const ChooseCreditClassPage = safeLazy(
   () => import('../../pages/ChooseCreditClass'),
 );
-const CreateCreditClassInfo = lazy(
+const CreateCreditClassInfo = safeLazy(
   () => import('../../pages/CreateCreditClassInfo'),
 );
-const CreateCreditClass = lazy(() => import('../../pages/CreateCreditClass'));
-const CreditClassDetails = lazy(() => import('../../pages/CreditClassDetails'));
-const Dashboard = lazy(() => import('../../pages/Dashboard'));
-const Description = lazy(() => import('../../pages/Description'));
-const EcocreditBatches = lazy(() => import('../../pages/EcocreditBatches'));
-const EcocreditsByAccount = lazy(
+const CreateCreditClass = safeLazy(
+  () => import('../../pages/CreateCreditClass'),
+);
+const CreditClassDetails = safeLazy(
+  () => import('../../pages/CreditClassDetails'),
+);
+const Dashboard = safeLazy(() => import('../../pages/Dashboard'));
+const Description = safeLazy(() => import('../../pages/Description'));
+const EcocreditBatches = safeLazy(() => import('../../pages/EcocreditBatches'));
+const EcocreditsByAccount = safeLazy(
   () => import('../../pages/EcocreditsByAccount'),
 );
+
+// ErrorPage cannot use safeLazy because it could create a circular dependency
+// since safeLazy itself uses ErrorPage as its fallback component when imports fail.
 const ErrorPage = lazy(() => import('../../pages/ErrorPage'));
-const Home = lazy(() => import('../../pages/Home'));
-const LandStewards = lazy(() => import('../../pages/LandStewards'));
-const LoginPage = lazy(() => import('../../pages/Login'));
-const Media = lazy(() => import('../../pages/Media'));
-const MethodologyDetails = lazy(() => import('../../pages/MethodologyDetails'));
-const NotFoundPage = lazy(() => import('../../pages/NotFound'));
-const Post = lazy(() => import('../../pages/Post'));
-const PrefinanceProjects = lazy(
+const Home = safeLazy(() => import('../../pages/Home'));
+const LandStewards = safeLazy(() => import('../../pages/LandStewards'));
+const LoginPage = safeLazy(() => import('../../pages/Login'));
+const Media = safeLazy(() => import('../../pages/Media'));
+const MethodologyDetails = safeLazy(
+  () => import('../../pages/MethodologyDetails'),
+);
+const NotFoundPage = safeLazy(() => import('../../pages/NotFound'));
+const Post = safeLazy(() => import('../../pages/Post'));
+const PrefinanceProjects = safeLazy(
   () => import('../../pages/Projects/PrefinanceProjects'),
 );
-const Project = lazy(() => import('../../pages/Project'));
-const Projects = lazy(() => import('../../pages/Projects'));
-const ProjectCreate = lazy(() => import('../../pages/ProjectCreate'));
-const ProjectFinished = lazy(() => import('../../pages/ProjectFinished'));
-const ProjectLocation = lazy(() => import('../../pages/ProjectLocation'));
-const ProjectReview = lazy(() => import('../../pages/ProjectReview'));
-const Roles = lazy(() => import('../../pages/Roles'));
-const VerifyEmail = lazy(() => import('../../pages/VerifyEmail'));
-const ProjectEdit = lazy(() => import('../../pages/ProjectEdit'));
-const Activity = lazy(() => import('../../pages/Activity'));
-const CreateBatch = lazy(() => import('../../pages/CreateBatch'));
-const Storefront = lazy(() => import('../../pages/Marketplace/Storefront'));
-const ConnectWalletPage = lazy(() => import('../../pages/ConnectWalletPage'));
-const ProfileEdit = lazy(() => import('../../pages/ProfileEdit'));
-const Orders = lazy(() => import('../../pages/Orders'));
+const Project = safeLazy(() => import('../../pages/Project'));
+const Projects = safeLazy(() => import('../../pages/Projects'));
+const ProjectCreate = safeLazy(() => import('../../pages/ProjectCreate'));
+const ProjectFinished = safeLazy(() => import('../../pages/ProjectFinished'));
+const ProjectLocation = safeLazy(() => import('../../pages/ProjectLocation'));
+const ProjectReview = safeLazy(() => import('../../pages/ProjectReview'));
+const Roles = safeLazy(() => import('../../pages/Roles'));
+const VerifyEmail = safeLazy(() => import('../../pages/VerifyEmail'));
+const ProjectEdit = safeLazy(() => import('../../pages/ProjectEdit'));
+const Activity = safeLazy(() => import('../../pages/Activity'));
+const CreateBatch = safeLazy(() => import('../../pages/CreateBatch'));
+const Storefront = safeLazy(() => import('../../pages/Marketplace/Storefront'));
+const ConnectWalletPage = safeLazy(
+  () => import('../../pages/ConnectWalletPage'),
+);
+const ProfileEdit = safeLazy(() => import('../../pages/ProfileEdit'));
+const Orders = safeLazy(() => import('../../pages/Orders'));
 
 type RouterProps = {
   reactQueryClient: QueryClient;

--- a/web-marketplace/src/clients/terrasos/Terrasos.Routes.tsx
+++ b/web-marketplace/src/clients/terrasos/Terrasos.Routes.tsx
@@ -12,6 +12,7 @@ import {
 import { Router } from '@remix-run/router';
 import * as Sentry from '@sentry/react';
 import { QueryClient } from '@tanstack/react-query';
+import { safeLazy } from 'utils/safeLazy';
 
 import { ApolloClientFactory } from 'lib/clients/apolloClientFactory';
 
@@ -20,10 +21,10 @@ import PageLoader from 'components/atoms/PageLoader';
 import { RegistryLayout } from 'components/organisms/RegistryLayout/RegistryLayout';
 import { projectDetailsLoader } from 'components/templates/ProjectDetails/ProjectDetails.loader';
 
-const AllProjects = lazy(() => import('../../pages/Projects/AllProjects'));
+const AllProjects = safeLazy(() => import('../../pages/Projects/AllProjects'));
 const ErrorPage = lazy(() => import('../../pages/ErrorPage'));
-const Project = lazy(() => import('../../pages/Project'));
-const Projects = lazy(() => import('../../pages/Projects'));
+const Project = safeLazy(() => import('../../pages/Project'));
+const Projects = safeLazy(() => import('../../pages/Projects'));
 
 type RouterProps = {
   reactQueryClient: QueryClient;

--- a/web-marketplace/src/pages/ErrorPage/ErrorPage.tsx
+++ b/web-marketplace/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import { useRouteError } from 'react-router-dom';
 import { useLingui } from '@lingui/react';
+import isNetworkError from 'is-network-error';
 
 import { SadBeeIcon } from 'web-components/src/components/icons/SadBeeIcon';
 import ErrorView from 'web-components/src/components/views/ErrorView';
@@ -9,24 +10,31 @@ import {
   ERROR_TITLE,
   HOMEPAGE_BUTTON_TEXT,
 } from './ErrorPage.contants';
+import { normalizeError } from './ErrorPage.utils';
 
 import UnhappyBee from 'assets/unhappy-bee.png';
 
 type ErrorPageProps = {
-  importError?: Error;
+  importError?: Error | string;
 };
 
 const ErrorPage = ({ importError }: ErrorPageProps): JSX.Element => {
   const routeError = useRouteError() as Error;
   const { _ } = useLingui();
 
-  const displayedError = importError || routeError;
+  const error = normalizeError(importError || routeError);
 
   return (
     <ErrorView
-      img={importError ? <SadBeeIcon /> : <img alt="error" src={UnhappyBee} />}
+      img={
+        isNetworkError(error) ? (
+          <SadBeeIcon />
+        ) : (
+          <img alt="error" src={UnhappyBee} />
+        )
+      }
       home={import.meta.env.VITE_WEBSITE_URL}
-      msg={displayedError?.message || JSON.stringify(displayedError)}
+      msg={error.message}
       title={_(ERROR_TITLE)}
       bodyText={_(ERROR_HELP_TEXT)}
       buttonText={_(HOMEPAGE_BUTTON_TEXT)}

--- a/web-marketplace/src/pages/ErrorPage/ErrorPage.tsx
+++ b/web-marketplace/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import { useRouteError } from 'react-router-dom';
 import { useLingui } from '@lingui/react';
 
+import { SadBeeIcon } from 'web-components/src/components/icons/SadBeeIcon';
 import ErrorView from 'web-components/src/components/views/ErrorView';
 
 import {
@@ -11,15 +12,21 @@ import {
 
 import UnhappyBee from 'assets/unhappy-bee.png';
 
-const ErrorPage = (): JSX.Element => {
-  const error = useRouteError() as Error;
+type ErrorPageProps = {
+  importError?: Error;
+};
+
+const ErrorPage = ({ importError }: ErrorPageProps): JSX.Element => {
+  const routeError = useRouteError() as Error;
   const { _ } = useLingui();
+
+  const displayedError = importError || routeError;
 
   return (
     <ErrorView
-      img={<img alt="error" src={UnhappyBee} />}
+      img={importError ? <SadBeeIcon /> : <img alt="error" src={UnhappyBee} />}
       home={import.meta.env.VITE_WEBSITE_URL}
-      msg={error.message || JSON.stringify(error)}
+      msg={displayedError?.message || JSON.stringify(displayedError)}
       title={_(ERROR_TITLE)}
       bodyText={_(ERROR_HELP_TEXT)}
       buttonText={_(HOMEPAGE_BUTTON_TEXT)}

--- a/web-marketplace/src/pages/ErrorPage/ErrorPage.utils.ts
+++ b/web-marketplace/src/pages/ErrorPage/ErrorPage.utils.ts
@@ -1,0 +1,12 @@
+// Normalize the error to an Error object when possible
+export const normalizeError = (err: unknown): Error => {
+  if (err instanceof Error) {
+    return err;
+  } else if (typeof err === 'string') {
+    return new Error(err);
+  } else if (err !== null && err !== undefined) {
+    return new Error(JSON.stringify(err));
+  }
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  return new Error('Unknown error');
+};

--- a/web-marketplace/src/utils/safeLazy.tsx
+++ b/web-marketplace/src/utils/safeLazy.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, lazy } from 'react';
+import { ComponentType, lazy, ReactNode } from 'react';
 
 import ErrorPage from 'pages/ErrorPage';
 
@@ -6,6 +6,7 @@ type SafeLazyOptions = {
   retries?: number;
   retryDelay?: number;
   onError?: (error: Error) => void;
+  fallback?: ReactNode;
 };
 
 /**
@@ -24,6 +25,7 @@ export function safeLazy<T extends ComponentType<any>>(
   const {
     retries = 2,
     retryDelay = 1000,
+    fallback,
     // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
     onError = error => console.error('Lazy import failed:', error),
   } = options;
@@ -48,7 +50,8 @@ export function safeLazy<T extends ComponentType<any>>(
     return {
       // React's lazy() function expects the Promise to resolve to an object
       // with a 'default' property that contains the component.
-      default: () => <ErrorPage importError={lastError} />,
+      default: () =>
+        fallback ? fallback : <ErrorPage importError={lastError} />,
     };
   });
 }

--- a/web-marketplace/src/utils/safeLazy.tsx
+++ b/web-marketplace/src/utils/safeLazy.tsx
@@ -1,0 +1,54 @@
+import { ComponentType, lazy } from 'react';
+
+import ErrorPage from 'pages/ErrorPage';
+
+type SafeLazyOptions = {
+  retries?: number;
+  retryDelay?: number;
+  onError?: (error: Error) => void;
+};
+
+/**
+ * Wraps React.lazy() to catch errors in dynamically imported modules.
+ * If an error occurs, it retries the import before returning a fallback component.
+ *
+ * @template T The component type being lazily loaded
+ * @param factory A function that imports the component
+ * @param options Configuration options for error handling and retries
+ * @returns A lazy-loaded component with error handling
+ */
+export function safeLazy<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+  options: SafeLazyOptions = {},
+) {
+  const {
+    retries = 2,
+    retryDelay = 1000,
+    // eslint-disable-next-line no-console, lingui/no-unlocalized-strings
+    onError = error => console.error('Lazy import failed:', error),
+  } = options;
+
+  return lazy(async (): Promise<{ default: T | ComponentType<any> }> => {
+    let lastError: Error;
+
+    for (let attempt = 0; attempt < retries; attempt++) {
+      try {
+        return await factory();
+      } catch (error) {
+        lastError = error as Error;
+
+        if (attempt < retries) {
+          // Create a delay before retrying the import agasin
+          await new Promise(resolve => setTimeout(resolve, retryDelay));
+        }
+      }
+    }
+
+    onError(lastError!);
+    return {
+      // React's lazy() function expects the Promise to resolve to an object
+      // with a 'default' property that contains the component.
+      default: () => <ErrorPage importError={lastError} />,
+    };
+  });
+}


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-617

This PR implements an error catching mechanism for when dynamic imports fail:

- Replace `lazy()` with the new `safeLazy()` utility in all routes.
- Improve the `ErrorPage` to normalise errors, handle network errors and display assets.
- Adds a small (4.54 kB) dependency to help identify network errors in the `ErrorPage` (see package.json).
- By default, safeLazy() uses `ErrorPage`, but it accepts a fallback `ReactNode`. We might consider using this in the future for lazy loaded components too not just routes.


### Author Checklist

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

1. One way of testing this is to go to the deploy previw https://deploy-preview-2630--regen-marketplace.netlify.app/
2. Open the dev tools
3.  Go to the Network tab select **Offline** mode in the select drop down that says: No throttling. 
4. Using the main navigation go to Projects > All Projects
5. Confirm the error page is displayed instead of the "Unexpected Application Error!" page.

![image](https://github.com/user-attachments/assets/b582ed5a-74e7-4775-8eeb-9b095e6cc510)


### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
