### PR TITLE
fix: APP-641 make orders page only accessible when logged in or connected to keplr

### DIFF
--- a/web-marketplace/src/clients/regen/Regen.Routes.tsx
+++ b/web-marketplace/src/clients/regen/Regen.Routes.tsx
@@ -377,7 +377,10 @@ export const getRegenRoutes = ({
             path="settings"
             element={<AuthRoute component={ProfileEditSettings} />}
           />
-          <Route path="my-orders" element={<Orders />} />
+          <Route
+            path="my-orders"
+            element={<KeplrOrAuthRoute component={Orders} />}
+          />
         </Route>
       </Route>
       <Route path="connect-wallet" element={<ConnectWalletPage />} />


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-641

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

From https://deploy-preview-2648--regen-marketplace.netlify.app/dashboard/admin/my-orders, check this page is only accessible if logged in or connected with wallet connect.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
