### PR TITLE
fix: APP-721 disable create sell order button if no tradable credits available

### DIFF
--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.CreateButton.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.CreateButton.tsx
@@ -1,0 +1,24 @@
+import { Trans } from '@lingui/macro';
+
+import ContainedButton from 'web-components/src/components/buttons/ContainedButton';
+
+import { UseStateSetter } from 'types/react/use-state';
+
+type Props = {
+  setIsSellFlowStarted: UseStateSetter<boolean>;
+  hasTradableCredits: boolean;
+};
+export const CreateButton = ({
+  setIsSellFlowStarted,
+  hasTradableCredits,
+}: Props) => (
+  <div className="flex-none flex items-center">
+    {/* TODO:  If the member is an Editor or Viewer, this button should be hidden */}
+    <ContainedButton
+      disabled={!hasTradableCredits}
+      onClick={() => setIsSellFlowStarted(true)}
+    >
+      + <Trans>Create Sell Order</Trans>
+    </ContainedButton>
+  </div>
+);

--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
@@ -31,7 +31,7 @@ export const UserSellOrdersToolbar = ({
   const tradableCredits =
     credits?.filter(credit => Number(credit.balance?.tradableAmount) > 0) || [];
   const hasTradableCredits = tradableCredits.length > 0;
-  console.log(hasTradableCredits);
+
   return (
     <>
       <div

--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
@@ -3,6 +3,7 @@ import { msg, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
 import ContainedButton from 'web-components/src/components/buttons/ContainedButton';
+import InfoTooltip from 'web-components/src/components/tooltip/InfoTooltip';
 import { Subtitle } from 'web-components/src/components/typography';
 import { cn } from 'web-components/src/utils/styles/cn';
 
@@ -30,6 +31,18 @@ export const UserSellOrdersToolbar = ({
     credits?.filter(credit => Number(credit.balance?.tradableAmount) > 0) || [];
   const hasTradableCredits = tradableCredits.length > 0;
 
+  const createButton = (
+    <div className="flex-none flex items-center">
+      {/* TODO:  If the member is an Editor or Viewer, this button should be hidden */}
+      <ContainedButton
+        disabled={!hasTradableCredits}
+        onClick={() => setIsSellFlowStarted(true)}
+      >
+        + <Trans>Create Sell Order</Trans>
+      </ContainedButton>
+    </div>
+  );
+
   return (
     <>
       <div
@@ -41,15 +54,17 @@ export const UserSellOrdersToolbar = ({
         <Subtitle size="xl" className="text-base sm:text-[22px]">
           <Trans>Sell orders</Trans>
         </Subtitle>
-        <div className="flex-none flex items-center">
-          {/* TODO:  If the member is an Editor or Viewer, this button should be hidden */}
-          <ContainedButton
-            disabled={!hasTradableCredits}
-            onClick={() => setIsSellFlowStarted(true)}
+        {hasTradableCredits ? (
+          createButton
+        ) : (
+          <InfoTooltip
+            arrow
+            placement="top"
+            title={_(msg`You have no tradable credits that can be sold.`)}
           >
-            + <Trans>Create Sell Order</Trans>
-          </ContainedButton>
-        </div>
+            {createButton}
+          </InfoTooltip>
+        )}
       </div>
       {hasTradableCredits && isSellFlowStarted && (
         <Suspense fallback={null}>

--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
@@ -29,7 +29,7 @@ export const UserSellOrdersToolbar = ({
   const { credits } = useFetchEcocredits({ isPaginatedQuery: false });
   const tradableCredits =
     credits?.filter(credit => Number(credit.balance?.tradableAmount) > 0) || [];
-  const hasTradeableCredits = tradableCredits.length > 0;
+  const hasTradableCredits = tradableCredits.length > 0;
 
   return (
     <>
@@ -45,14 +45,14 @@ export const UserSellOrdersToolbar = ({
         <div className="flex-none flex items-center">
           {/* TODO:  If the member is an Editor or Viewer, this button should be hidden */}
           <ContainedButton
-            disabled={!hasTradeableCredits}
+            disabled={!hasTradableCredits}
             onClick={() => setIsSellFlowStarted(true)}
           >
             + <Trans>Create Sell Order</Trans>
           </ContainedButton>
         </div>
       </div>
-      {hasTradeableCredits && isSellFlowStarted && (
+      {hasTradableCredits && isSellFlowStarted && (
         <Suspense fallback={null}>
           <CreateSellOrderFlow
             isFlowStarted={isSellFlowStarted}

--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
@@ -2,12 +2,13 @@ import { lazy, Suspense, useState } from 'react';
 import { msg, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
-import ContainedButton from 'web-components/src/components/buttons/ContainedButton';
 import InfoTooltip from 'web-components/src/components/tooltip/InfoTooltip';
 import { Subtitle } from 'web-components/src/components/typography';
 import { cn } from 'web-components/src/utils/styles/cn';
 
 import { useFetchEcocredits } from 'pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits';
+
+import { CreateButton } from './UserSellOrders.CreateButton';
 
 const CreateSellOrderFlow = lazy(async () => ({
   default: (
@@ -30,19 +31,7 @@ export const UserSellOrdersToolbar = ({
   const tradableCredits =
     credits?.filter(credit => Number(credit.balance?.tradableAmount) > 0) || [];
   const hasTradableCredits = tradableCredits.length > 0;
-
-  const createButton = (
-    <div className="flex-none flex items-center">
-      {/* TODO:  If the member is an Editor or Viewer, this button should be hidden */}
-      <ContainedButton
-        disabled={!hasTradableCredits}
-        onClick={() => setIsSellFlowStarted(true)}
-      >
-        + <Trans>Create Sell Order</Trans>
-      </ContainedButton>
-    </div>
-  );
-
+  console.log(hasTradableCredits);
   return (
     <>
       <div
@@ -55,14 +44,22 @@ export const UserSellOrdersToolbar = ({
           <Trans>Sell orders</Trans>
         </Subtitle>
         {hasTradableCredits ? (
-          createButton
+          <CreateButton
+            hasTradableCredits={hasTradableCredits}
+            setIsSellFlowStarted={setIsSellFlowStarted}
+          />
         ) : (
           <InfoTooltip
             arrow
             placement="top"
             title={_(msg`You have no tradable credits that can be sold.`)}
           >
-            {createButton}
+            <div>
+              <CreateButton
+                hasTradableCredits={hasTradableCredits}
+                setIsSellFlowStarted={setIsSellFlowStarted}
+              />
+            </div>
           </InfoTooltip>
         )}
       </div>

--- a/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
+++ b/web-marketplace/src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx
@@ -6,7 +6,6 @@ import ContainedButton from 'web-components/src/components/buttons/ContainedButt
 import { Subtitle } from 'web-components/src/components/typography';
 import { cn } from 'web-components/src/utils/styles/cn';
 
-// import { CreateSellOrderFlow } from 'features/marketplace/CreateSellOrderFlow/CreateSellOrderFlow';
 import { useFetchEcocredits } from 'pages/Dashboard/MyEcocredits/hooks/useFetchEcocredits';
 
 const CreateSellOrderFlow = lazy(async () => ({

--- a/web-marketplace/src/ledger.tsx
+++ b/web-marketplace/src/ledger.tsx
@@ -3,13 +3,13 @@ import { OfflineSigner, Registry } from '@cosmjs/proto-signing';
 import { AminoTypes, SigningStargateClient } from '@cosmjs/stargate';
 import {
   cosmosAminoConverters,
-  // cosmosProtoRegistry,
-  // ibc,
-  // ibcAminoConverters,
-  // ibcProtoRegistry,
-  // regen,
-  // regenAminoConverters,
-  // regenProtoRegistry,
+  cosmosProtoRegistry,
+  ibc,
+  ibcAminoConverters,
+  ibcProtoRegistry,
+  regen,
+  regenAminoConverters,
+  regenProtoRegistry,
 } from '@regen-network/api';
 import { chains } from 'chain-registry';
 

--- a/web-marketplace/src/ledger.tsx
+++ b/web-marketplace/src/ledger.tsx
@@ -3,13 +3,13 @@ import { OfflineSigner, Registry } from '@cosmjs/proto-signing';
 import { AminoTypes, SigningStargateClient } from '@cosmjs/stargate';
 import {
   cosmosAminoConverters,
-  cosmosProtoRegistry,
-  ibc,
-  ibcAminoConverters,
-  ibcProtoRegistry,
-  regen,
-  regenAminoConverters,
-  regenProtoRegistry,
+  // cosmosProtoRegistry,
+  // ibc,
+  // ibcAminoConverters,
+  // ibcProtoRegistry,
+  // regen,
+  // regenAminoConverters,
+  // regenProtoRegistry,
 } from '@regen-network/api';
 import { chains } from 'chain-registry';
 

--- a/web-marketplace/src/lib/i18n/locales/en.po
+++ b/web-marketplace/src/lib/i18n/locales/en.po
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Choose basket"
 msgstr ""
 
-#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:49
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:75
 msgid "Choose batch"
 msgstr ""
 
@@ -3895,7 +3895,7 @@ msgid "sell order id:"
 msgstr ""
 
 #: src/components/organisms/SellOrdersTable/SellOrdersTable.tsx:60
-#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:36
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:55
 #: src/pages/Marketplace/Storefront/Storefront.tsx:154
 msgid "Sell orders"
 msgstr ""
@@ -5073,6 +5073,10 @@ msgstr ""
 
 #: src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Tradable.tsx:25
 msgid "You have chosen to purchase tradable credits, so you will not receive a retirement certificate."
+msgstr ""
+
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:63
+msgid "You have no tradable credits that can be sold."
 msgstr ""
 
 #: src/pages/Dashboard/MyCreditBatches/MyCreditBatches.constants.ts:3

--- a/web-marketplace/src/lib/i18n/locales/es.po
+++ b/web-marketplace/src/lib/i18n/locales/es.po
@@ -774,7 +774,6 @@ msgstr "Tabla de ecocréditos puenteables"
 #: src/components/organisms/BridgableEcocreditsTable/BridgableEcocreditsTable.constants.ts:3
 #: src/features/ecocredit/BridgeFlow/BridgeFlow.constants.ts:4
 #: src/pages/Dashboard/Dashboard.constants.tsx:36
-#: src/pages/Dashboard/Dashboard.constants.tsx:36
 msgid "Bridge"
 msgstr "Puente"
 
@@ -1012,7 +1011,7 @@ msgstr "Elige los ecocréditos que sean elegibles para esta cesta.<0>Más inform
 msgid "Choose basket"
 msgstr "Elija la cesta"
 
-#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:49
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:75
 msgid "Choose batch"
 msgstr "Seleccione lote"
 
@@ -3899,7 +3898,7 @@ msgid "sell order id:"
 msgstr "ID de orden de venta:"
 
 #: src/components/organisms/SellOrdersTable/SellOrdersTable.tsx:60
-#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:36
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:55
 #: src/pages/Marketplace/Storefront/Storefront.tsx:154
 msgid "Sell orders"
 msgstr "Órdenes de venta"
@@ -5078,6 +5077,10 @@ msgstr "Usted ingresó:"
 #: src/components/organisms/AgreePurchaseForm/AgreePurchaseForm.Tradable.tsx:25
 msgid "You have chosen to purchase tradable credits, so you will not receive a retirement certificate."
 msgstr "Ha elegido comprar créditos negociables, por lo que no recibirá un certificado de retirada."
+
+#: src/components/organisms/UserSellOrders/UserSellOrders.Toolbar.tsx:63
+msgid "You have no tradable credits that can be sold."
+msgstr "No tienes créditos negociables que se puedan vender."
 
 #: src/pages/Dashboard/MyCreditBatches/MyCreditBatches.constants.ts:3
 msgid "You have not issued any credit batches yet"


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-721

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] provided a link to the relevant issue or specification
- [x] provided instructions on how to test
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

https://deploy-preview-2677--regen-marketplace.netlify.app/dashboard/admin/sell
1. check that create sell order button is disabled when logged in with an account that doesn't have any tradable credits
2. check that it's enabled when logged in with an account that does have tradable credits

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
