### PR TITLE
fix: resolve failing tests in ChooseCreditsForm

### DIFF
--- a/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.test.tsx
+++ b/web-marketplace/src/components/organisms/ChooseCreditsForm/ChooseCreditsForm.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   allowedDenoms,
   cardSellOrders,
@@ -16,6 +17,8 @@ vi.mock('react-router-dom', () => ({
     state: { from: '/project/test/buy' },
   })),
 }));
+
+const queryClient = new QueryClient();
 
 describe('ChooseCreditsForm', () => {
   const props = {
@@ -37,17 +40,27 @@ describe('ChooseCreditsForm', () => {
     isUserBalanceLoading: false,
   };
   it('renders without crashing', async () => {
-    render(<ChooseCreditsForm {...props} />, {
-      jotaiDefaultValues: [[paymentOptionAtom, 'card']],
-    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChooseCreditsForm {...props} />
+      </QueryClientProvider>,
+      {
+        jotaiDefaultValues: [[paymentOptionAtom, 'card']],
+      },
+    );
     const form = await screen.queryByTestId('choose-credits-form');
     expect(form).toBeInTheDocument();
   });
 
   it('selects card payment option', () => {
-    render(<ChooseCreditsForm {...props} />, {
-      jotaiDefaultValues: [[paymentOptionAtom, 'card']],
-    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ChooseCreditsForm {...props} />
+      </QueryClientProvider>,
+      {
+        jotaiDefaultValues: [[paymentOptionAtom, 'card']],
+      },
+    );
 
     const cardOption = screen.getByTestId('choose-credit-card');
     if (cardOption) {


### PR DESCRIPTION
## Description

This pull request provides a fix for failing tests in `ChooseCreditsForm.test.tsx` that block [release-v2.10.0](https://github.com/regen-network/regen-web/pull/2690). The tests were failing because a missing `QueryClientProvider`. This has been resolved by wrapping the components in the necessary provider within the test environment.

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
