### PR TITLE
Fix multiple retirements in tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/regen-network/regen-web/compare/v2.10.1...v2.11.0) (2025-08-04)
+
+### Bug Fixes
+
+- APP-708 get compliance credits from shared sanity projects ([#2679](https://github.com/regen-network/regen-web/issues/2679)) ([6812c16](https://github.com/regen-network/regen-web/commit/6812c16f48e4ec0de25b9d724c796f3012346413))
+
+### Features
+
+- APP-673 add member card UI ([#2693](https://github.com/regen-network/regen-web/issues/2693)) ([ae97761](https://github.com/regen-network/regen-web/commit/ae97761aa0c3ea0b4667809394b451f6db07af06))
+- APP-706 Allow account with Stripe integration to create USD sell orders ([#2676](https://github.com/regen-network/regen-web/issues/2676)) ([72a2c97](https://github.com/regen-network/regen-web/commit/72a2c97420ba56bc8676c29cb5abfff503aa11cc))
+
 ## [2.10.1](https://github.com/regen-network/regen-web/compare/v2.10.0...v2.10.1) (2025-07-29)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.1",
+  "version": "2.11.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": ["web-marketplace", "web-components", "web-storybook", "web-www"]

--- a/web-components/CHANGELOG.md
+++ b/web-components/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/regen-network/regen-web/compare/v2.10.1...v2.11.0) (2025-08-04)
+
+### Features
+
+- APP-673 add member card UI ([#2693](https://github.com/regen-network/regen-web/issues/2693)) ([ae97761](https://github.com/regen-network/regen-web/commit/ae97761aa0c3ea0b4667809394b451f6db07af06))
+- APP-706 Allow account with Stripe integration to create USD sell orders ([#2676](https://github.com/regen-network/regen-web/issues/2676)) ([72a2c97](https://github.com/regen-network/regen-web/commit/72a2c97420ba56bc8676c29cb5abfff503aa11cc))
+
 # [2.10.0](https://github.com/regen-network/regen-web/compare/v2.9.5...v2.10.0) (2025-07-22)
 
 ### Features

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-components",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "private": true,
   "main": "build/index.js",
   "type": "module",

--- a/web-marketplace/CHANGELOG.md
+++ b/web-marketplace/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/regen-network/regen-web/compare/v2.10.1...v2.11.0) (2025-08-04)
+
+### Bug Fixes
+
+- APP-708 get compliance credits from shared sanity projects ([#2679](https://github.com/regen-network/regen-web/issues/2679)) ([6812c16](https://github.com/regen-network/regen-web/commit/6812c16f48e4ec0de25b9d724c796f3012346413))
+
+### Features
+
+- APP-706 Allow account with Stripe integration to create USD sell orders ([#2676](https://github.com/regen-network/regen-web/issues/2676)) ([72a2c97](https://github.com/regen-network/regen-web/commit/72a2c97420ba56bc8676c29cb5abfff503aa11cc))
+
 ## [2.10.1](https://github.com/regen-network/regen-web/compare/v2.10.0...v2.10.1) (2025-07-29)
 
 ### Bug Fixes

--- a/web-marketplace/indexer-graphql.schema.json
+++ b/web-marketplace/indexer-graphql.schema.json
@@ -5741,45 +5741,6 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "DeleteRetirementByTxHashInput",
-        "description": "All input for the `deleteRetirementByTxHash` mutation.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "clientMutationId",
-            "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "txHash",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
         "name": "DeleteRetirementInput",
         "description": "All input for the `deleteRetirement` mutation.",
         "fields": null,
@@ -12417,35 +12378,6 @@
             "deprecationReason": null
           },
           {
-            "name": "updateRetirementByTxHash",
-            "description": "Updates a single `Retirement` using a unique key and a patch.",
-            "args": [
-              {
-                "name": "input",
-                "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "UpdateRetirementByTxHashInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "UpdateRetirementPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "updateTx",
             "description": "Updates a single `Tx` using its globally unique id and a patch.",
             "args": [
@@ -13212,35 +13144,6 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "DeleteRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "DeleteRetirementPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleteRetirementByTxHash",
-            "description": "Deletes a single `Retirement` using a unique key.",
-            "args": [
-              {
-                "name": "input",
-                "description": "The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "DeleteRetirementByTxHashInput",
                     "ofType": null
                   }
                 },
@@ -18772,35 +18675,6 @@
             "deprecationReason": null
           },
           {
-            "name": "retirementByTxHash",
-            "description": null,
-            "args": [
-              {
-                "name": "txHash",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Retirement",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "txByChainNumAndBlockHeightAndTxIdx",
             "description": null,
             "args": [
@@ -23616,61 +23490,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "UpdateRetirementByTxHashInput",
-        "description": "All input for the `updateRetirementByTxHash` mutation.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "clientMutationId",
-            "description": "An arbitrary string value with no semantic meaning. Will be included in the\npayload verbatim. May be used to track mutations by the client.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "retirementPatch",
-            "description": "An object where the defined keys will be set on the `Retirement` being updated.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "RetirementPatch",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "txHash",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },

--- a/web-marketplace/package.json
+++ b/web-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-marketplace",
-  "version": "2.10.1",
+  "version": "2.11.0",
   "private": true,
   "dependencies": {
     "@analytics/amplitude": "^0.1.3",

--- a/web-marketplace/src/generated/indexer-graphql.tsx
+++ b/web-marketplace/src/generated/indexer-graphql.tsx
@@ -1190,16 +1190,6 @@ export type DeleteRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxInput = {
   msgIdx: Scalars['Int'];
 };
 
-/** All input for the `deleteRetirementByTxHash` mutation. */
-export type DeleteRetirementByTxHashInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  txHash: Scalars['String'];
-};
-
 /** All input for the `deleteRetirement` mutation. */
 export type DeleteRetirementInput = {
   /**
@@ -2161,8 +2151,6 @@ export type Mutation = {
   updateRetirement?: Maybe<UpdateRetirementPayload>;
   /** Updates a single `Retirement` using a unique key and a patch. */
   updateRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdx?: Maybe<UpdateRetirementPayload>;
-  /** Updates a single `Retirement` using a unique key and a patch. */
-  updateRetirementByTxHash?: Maybe<UpdateRetirementPayload>;
   /** Updates a single `Tx` using its globally unique id and a patch. */
   updateTx?: Maybe<UpdateTxPayload>;
   /** Updates a single `Tx` using a unique key and a patch. */
@@ -2217,8 +2205,6 @@ export type Mutation = {
   deleteRetirement?: Maybe<DeleteRetirementPayload>;
   /** Deletes a single `Retirement` using a unique key. */
   deleteRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdx?: Maybe<DeleteRetirementPayload>;
-  /** Deletes a single `Retirement` using a unique key. */
-  deleteRetirementByTxHash?: Maybe<DeleteRetirementPayload>;
   /** Deletes a single `Tx` using its globally unique id. */
   deleteTx?: Maybe<DeleteTxPayload>;
   /** Deletes a single `Tx` using a unique key. */
@@ -2433,12 +2419,6 @@ export type MutationUpdateRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxArg
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateRetirementByTxHashArgs = {
-  input: UpdateRetirementByTxHashInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateTxArgs = {
   input: UpdateTxInput;
 };
@@ -2597,12 +2577,6 @@ export type MutationDeleteRetirementArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxArgs = {
   input: DeleteRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteRetirementByTxHashArgs = {
-  input: DeleteRetirementByTxHashInput;
 };
 
 
@@ -3050,7 +3024,6 @@ export type Query = Node & {
   orderByChainNumAndBlockHeightAndTxIdxAndMsgIdxAndProjectIdAndAskDenom?: Maybe<Order>;
   proposalByChainNumAndBlockHeightAndTxIdxAndMsgIdx?: Maybe<Proposal>;
   retirementByChainNumAndBlockHeightAndTxIdxAndMsgIdx?: Maybe<Retirement>;
-  retirementByTxHash?: Maybe<Retirement>;
   txByChainNumAndBlockHeightAndTxIdx?: Maybe<Tx>;
   txByHash?: Maybe<Tx>;
   voteByChainNumAndBlockHeightAndTxIdxAndMsgIdx?: Maybe<Vote>;
@@ -3363,12 +3336,6 @@ export type QueryRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxArgs = {
   blockHeight: Scalars['BigInt'];
   txIdx: Scalars['Int'];
   msgIdx: Scalars['Int'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryRetirementByTxHashArgs = {
-  txHash: Scalars['String'];
 };
 
 
@@ -4213,18 +4180,6 @@ export type UpdateRetirementByChainNumAndBlockHeightAndTxIdxAndMsgIdxInput = {
   msgIdx: Scalars['Int'];
 };
 
-/** All input for the `updateRetirementByTxHash` mutation. */
-export type UpdateRetirementByTxHashInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `Retirement` being updated. */
-  retirementPatch: RetirementPatch;
-  txHash: Scalars['String'];
-};
-
 /** All input for the `updateRetirement` mutation. */
 export type UpdateRetirementInput = {
   /**
@@ -4646,9 +4601,12 @@ export type IndexerRetirementByTxHashQueryVariables = Exact<{
 
 export type IndexerRetirementByTxHashQuery = (
   { __typename?: 'Query' }
-  & { retirementByTxHash?: Maybe<(
-    { __typename?: 'Retirement' }
-    & RetirementFieldsFragment
+  & { allRetirements?: Maybe<(
+    { __typename?: 'RetirementsConnection' }
+    & { nodes: Array<Maybe<(
+      { __typename?: 'Retirement' }
+      & RetirementFieldsFragment
+    )>> }
   )> }
 );
 
@@ -4953,8 +4911,10 @@ export type IndexerRetirementByNodeIdLazyQueryHookResult = ReturnType<typeof use
 export type IndexerRetirementByNodeIdQueryResult = Apollo.QueryResult<IndexerRetirementByNodeIdQuery, IndexerRetirementByNodeIdQueryVariables>;
 export const IndexerRetirementByTxHashDocument = gql`
     query IndexerRetirementByTxHash($txHash: String!) {
-  retirementByTxHash(txHash: $txHash) {
-    ...retirementFields
+  allRetirements(condition: {txHash: $txHash}, orderBy: TIMESTAMP_DESC) {
+    nodes {
+      ...retirementFields
+    }
   }
 }
     ${RetirementFieldsFragmentDoc}`;

--- a/web-marketplace/src/graphql/indexer/RetirementByTxHash.graphql
+++ b/web-marketplace/src/graphql/indexer/RetirementByTxHash.graphql
@@ -1,5 +1,7 @@
 query IndexerRetirementByTxHash($txHash: String!) {
-  retirementByTxHash(txHash: $txHash) {
-    ...retirementFields
+  allRetirements(condition: { txHash: $txHash }, orderBy: TIMESTAMP_DESC) {
+    nodes {
+      ...retirementFields
+    }
   }
 }

--- a/web-marketplace/src/pages/BuyCredits/hooks/useFetchRetirementForPurchase.ts
+++ b/web-marketplace/src/pages/BuyCredits/hooks/useFetchRetirementForPurchase.ts
@@ -99,7 +99,7 @@ export const useFetchRetirementForPurchase = ({
       txHash: _txHash as string,
     }),
   );
-  const retirement = data?.data?.retirementByTxHash;
+  const retirement = data?.data?.allRetirements?.nodes?.[0];
 
   const onPending = useCallback(() => {
     if (

--- a/web-marketplace/src/pages/Certificate/hooks/useFetchRetirement.ts
+++ b/web-marketplace/src/pages/Certificate/hooks/useFetchRetirement.ts
@@ -79,7 +79,7 @@ export const useFetchRetirement = ({ id }: Params) => {
   );
 
   const retirement = isValidPaymentIntentId
-    ? retirementByTxHashData?.data.retirementByTxHash
+    ? retirementByTxHashData?.data?.allRetirements?.nodes?.[0]
     : data?.data.retirement;
 
   // Extract data from batch denom id

--- a/web-marketplace/src/pages/Orders/hooks/useOrders.tsx
+++ b/web-marketplace/src/pages/Orders/hooks/useOrders.tsx
@@ -206,7 +206,8 @@ export const useOrders = () => {
         );
         const askBaseDenom =
           (denomTrace ? denomTrace.baseDenom : order?.askDenom) ?? '';
-        const retirement = retirementResults[i]?.data?.data?.retirementByTxHash;
+        const retirement =
+          retirementResults[i]?.data?.data?.allRetirements?.nodes?.[0];
         const formattedDate = i18n.date(order?.timestamp, {
           year: 'numeric',
           month: 'short',

--- a/web-storybook/CHANGELOG.md
+++ b/web-storybook/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/regen-network/regen-web/compare/v2.10.1...v2.11.0) (2025-08-04)
+
+### Features
+
+- APP-673 add member card UI ([#2693](https://github.com/regen-network/regen-web/issues/2693)) ([ae97761](https://github.com/regen-network/regen-web/commit/ae97761aa0c3ea0b4667809394b451f6db07af06))
+
 # [2.9.0](https://github.com/regen-network/regen-web/compare/v2.8.1...v2.9.0) (2025-05-19)
 
 **Note:** Version bump only for package web-storybook

--- a/web-storybook/package.json
+++ b/web-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-storybook",
-  "version": "2.9.0",
+  "version": "2.11.0",
   "private": true,
   "scripts": {
     "build-storybook": "storybook build -s public",

--- a/web-www/CHANGELOG.md
+++ b/web-www/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.11.0](https://github.com/regen-network/regen-web/compare/v2.10.1...v2.11.0) (2025-08-04)
+
+**Note:** Version bump only for package web-www
+
 # [2.10.0](https://github.com/regen-network/regen-web/compare/v2.9.5...v2.10.0) (2025-07-22)
 
 **Note:** Version bump only for package web-www

--- a/web-www/package-lock.json
+++ b/web-www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-www",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-www",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "dependencies": {
         "@types/node": "18.15.11",
         "@types/react": "18.0.33",

--- a/web-www/package.json
+++ b/web-www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-www",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Description

As part of https://www.mintscan.io/regen/tx/9B00C0556DC6F7CF2D2D6C8F602DA57B6CD453B90BFA4B3F28CB7574A8ADCE39?sector=message multiple retirements were made as part of a single tx. This caused some issue on the indexer side where we had a unique constraint on `retirements.tx_hash`, which I removed. This is the related front-end fix.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
