### PR TITLE
fix: APP-834 hide "issued credit batches" on web2 user dashboard

### DIFF
--- a/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.utils.tsx
+++ b/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.utils.tsx
@@ -184,7 +184,6 @@ export function getDashboardNavigationSections(
   if (!loginDisabled || hasProjects) {
     sections.push(getProjectsSection(_, collapsed));
   }
-
   if (isIssuer || showCreditClasses || hasCreditBatches) {
     const issuance = getCreditIssuanceSection(_, collapsed);
     issuance.items = issuance.items.filter(item => {

--- a/web-marketplace/src/hooks/batches/useFetchPaginatedBatches.ts
+++ b/web-marketplace/src/hooks/batches/useFetchPaginatedBatches.ts
@@ -46,6 +46,11 @@ type Props = {
    * Address can be fetched asynchronously (based on some account/organization uuid),
    */
   isAddressLoading?: boolean;
+  /**
+   * Forces the address filter to be applied even if the address is not provided.
+   * This can be useful to disable fetching batches when the address is not available.
+   */
+  forceAddress?: boolean;
 };
 
 export const useFetchPaginatedBatches = ({
@@ -54,6 +59,7 @@ export const useFetchPaginatedBatches = ({
   creditClassId,
   withAllData = true,
   isAddressLoading = false,
+  forceAddress = false,
 }: Props): {
   batchesWithSupply: BatchInfoWithSupply[] | undefined;
   setPaginationParams: UseStateSetter<TablePaginationParams>;
@@ -102,7 +108,8 @@ export const useFetchPaginatedBatches = ({
         !!queryClient &&
         !projectId &&
         !address &&
-        !creditClassId,
+        !creditClassId &&
+        !forceAddress,
     }),
   );
 

--- a/web-marketplace/src/legacy-pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/legacy-pages/Dashboard/Dashboard.tsx
@@ -277,7 +277,11 @@ export const Dashboard = () => {
 
   const { batchesWithSupply } = useFetchPaginatedBatches({
     address: dashboardAccountAddress ?? wallet?.address,
+    // useFetchPaginatedBatches is quite generic so it fetches all batches if no address is provided
+    // so in case the current user account has not wallet address, we need to disable the fetch
+    forceAddress: true,
   });
+
   const hasCreditBatches = batchesWithSupply && batchesWithSupply.length > 0;
 
   const onAccountSelect = (id: string) => {

--- a/web-marketplace/src/legacy-pages/Profile/Profile.tsx
+++ b/web-marketplace/src/legacy-pages/Profile/Profile.tsx
@@ -92,6 +92,7 @@ export const Profile = (): JSX.Element => {
   const { batchesWithSupply } = useFetchPaginatedBatches({
     address,
     isAddressLoading: isLoading,
+    forceAddress: true,
   });
   const hasCreditBatches = batchesWithSupply && batchesWithSupply.length > 0;
 


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-834

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Log in with a web2 user account and access your dashboard, "issued credit batches" shouldn't available there anymore.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
