### PR TITLE
fix: APP-822 hide org dashboard controls from user dashboard when user type is org

### DIFF
--- a/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.tsx
+++ b/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.tsx
@@ -22,6 +22,7 @@ import { DashboardNavigationProps } from './DashboardNavigation.types';
 import { getDashboardNavigationSections } from './DashboardNavigation.utils';
 
 export const DashboardNavigation = ({
+  isOrganizationDashboard,
   header: { activeAccount, accounts, onAccountSelect, onViewProfileClick },
   currentPath,
   onNavItemClick,
@@ -46,6 +47,7 @@ export const DashboardNavigation = ({
   unfinalizedOrgName,
   onFinishOrgCreation,
 }: DashboardNavigationProps & {
+  isOrganizationDashboard?: boolean;
   mobileMenuOpen?: boolean;
   hasWalletAddress?: boolean;
   wallet?: String;
@@ -81,7 +83,6 @@ export const DashboardNavigation = ({
     () =>
       getDashboardNavigationSections(
         _,
-        activeAccount.type,
         loginDisabled || false,
         collapsed,
         isIssuer || false,
@@ -91,6 +92,7 @@ export const DashboardNavigation = ({
         hasOrders ?? false,
         hasCreditBatches ?? false,
         canEditOrg ?? true,
+        isOrganizationDashboard,
       ),
     [
       _,

--- a/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.utils.tsx
+++ b/web-marketplace/src/components/organisms/DashboardNavigation/DashboardNavigation.utils.tsx
@@ -166,7 +166,6 @@ const getOrdersSection = (
 
 export function getDashboardNavigationSections(
   _: TranslatorType,
-  accountType: 'user' | 'org',
   loginDisabled: boolean,
   collapsed = false,
   isIssuer = false,
@@ -176,6 +175,7 @@ export function getDashboardNavigationSections(
   hasOrders = false,
   hasCreditBatches = false,
   canEditOrg = true,
+  isOrganizationDashboard?: boolean,
 ): DashboardNavigationSection[] {
   const sections = [];
   if (hasWalletAddress) {
@@ -197,7 +197,7 @@ export function getDashboardNavigationSections(
     sections.push(getOrdersSection(_, collapsed));
   }
 
-  if (accountType === 'user') {
+  if (!isOrganizationDashboard) {
     sections.push(...getUserSections(_, loginDisabled));
   } else {
     sections.push(getOrgSection(_, collapsed, canEditOrg));

--- a/web-marketplace/src/legacy-pages/Dashboard/Dashboard.tsx
+++ b/web-marketplace/src/legacy-pages/Dashboard/Dashboard.tsx
@@ -456,6 +456,7 @@ export const Dashboard = () => {
           {/* Left sidebar navigation */}
           <div className="md:sticky md:top-0 md:h-screen">
             <DashboardNavigation
+              isOrganizationDashboard={isOrganizationDashboard}
               collapsed={collapsed}
               onToggleCollapse={setCollapsed}
               currentPath={section ?? ''}


### PR DESCRIPTION

## Description

https://regennetwork.atlassian.net/browse/APP-822

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

Log in with a user of type "organization" (if needed, please contact @blushi to make your account of type organization since this is not available anymore from "edit profile") and double check that organization related sections ("manage organization") do not appear on your user dashboard, "Profile" section should appear instead. Double check that they appear on organization dashboard.

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
