### PR TITLE
fix: APP-896 keplr wallet image size in ConnectWalletModal

### DIFF
--- a/web-marketplace/src/components/layout/Layout.ConnectWalletModal.tsx
+++ b/web-marketplace/src/components/layout/Layout.ConnectWalletModal.tsx
@@ -72,7 +72,9 @@ export const LayoutConnectWalletModal = (): JSX.Element => {
               <Image
                 src={keplrWalletExtension}
                 alt="keplr"
-                className="w-[21px] mr-[8px]"
+                width={21}
+                height={21}
+                className="mr-[8px]"
               />
             ),
           }}

--- a/web-marketplace/src/components/layout/Layout.ConnectWalletModal.tsx
+++ b/web-marketplace/src/components/layout/Layout.ConnectWalletModal.tsx
@@ -74,7 +74,6 @@ export const LayoutConnectWalletModal = (): JSX.Element => {
                 alt="keplr"
                 width={21}
                 height={21}
-                className="mr-[8px]"
               />
             ),
           }}


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-896

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

1. Log in with a web2 account
2. Go a project buy page that has some fiat credits available, eg /project/jaguar-stewardship-in-the-pantanal-conservation-network-2/buy
3. Click on the "Buy with crypto" button to see the modal "You must connect a Keplr wallet address to your existing account in order to view this content." and verify the size of the Keplr logo in the "connect wallet" button is right

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
