### PR TITLE
fix: APP-901 discrepancy between prices on /projects and project page

### DIFF
--- a/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
+++ b/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
@@ -168,7 +168,11 @@ export const SellOrdersActionsBar = ({
                       />
                     )}
                   </Box>
-                  <Subtitle>{avgPricePerTonLabel ?? prefinancePrice}</Subtitle>
+                  <Subtitle>
+                    {isPrefinanceProject
+                      ? prefinancePrice
+                      : avgPricePerTonLabel}
+                  </Subtitle>
                 </Box>
               )}
             {(!isCommunityCredit ||

--- a/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
+++ b/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
@@ -143,7 +143,7 @@ export const SellOrdersActionsBar = ({
         ) : (
           <>
             {((!isPrefinanceProject && !isBuyButtonDisabled) || !isSoldOut) &&
-              (prefinancePrice ||
+              ((isPrefinanceProject && prefinancePrice) ||
                 (avgPricePerTonLabel && !!onChainProjectId)) && (
                 <Box
                   sx={{

--- a/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
+++ b/web-marketplace/src/components/organisms/SellOrdersActionsBar/SellOrdersActionsBar.tsx
@@ -168,7 +168,7 @@ export const SellOrdersActionsBar = ({
                       />
                     )}
                   </Box>
-                  <Subtitle>{prefinancePrice ?? avgPricePerTonLabel}</Subtitle>
+                  <Subtitle>{avgPricePerTonLabel ?? prefinancePrice}</Subtitle>
                 </Box>
               )}
             {(!isCommunityCredit ||


### PR DESCRIPTION
## Description

https://regennetwork.atlassian.net/browse/APP-901

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] provided a link to the relevant issue or specification
- [ ] provided instructions on how to test
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### How to test

<!-- This should include steps on how to test the fixes or features within the marketplace app and/or the website.
If applicable, this should also include links to the created/updated components on storybook. -->

We were incorrectly showing old prefinance price on the project page when it was still stored in sanity, while on the projects page, we are correctly showing the correct on chain credit price
I replicated this for https://dev.app.regen.network/project/jaguar-stewardship-in-the-pantanal-conservation-network-2 (prefinance price set to $2 on sanity: https://regen.sanity.studio/staging/structure/shared;projects;english;c2df0317-d469-48ae-b85d-f25b4bb7fd6c%2Ctemplate%3Dproject-en)
Double check that on chain credit price $1 now appears correctly on https://deploy-preview-2825--regen-marketplace.netlify.app/project/jaguar-stewardship-in-the-pantanal-conservation-network-2
as on https://deploy-preview-2825--regen-marketplace.netlify.app/projects/1

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please **add
your handle next to the items reviewed if you only reviewed selected items**._

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed code correctness and readability
- [ ] verified React components follow DRY principles
- [ ] reviewed documentation is accurate
- [ ] reviewed tests
- [ ] manually tested (if applicable)
